### PR TITLE
Specify support for the K68 non-RGB version only

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,8 @@ See also:
     * non-RGB
     * LUX RGB
     * RGB RAPIDFIRE
-* K68
+* K68:
+    * non-RGB
 * K70:
     * RGB
     * non-RGB


### PR DESCRIPTION
Corsair has announced the RGB version of the K68.