### PR TITLE
Skip BEGIN FW ENTRIES in the FW table

### DIFF
--- a/src/ckb/kbfirmware.cpp
+++ b/src/ckb/kbfirmware.cpp
@@ -113,8 +113,8 @@ void KbFirmware::processDownload(QNetworkReply* reply){
         if(!scan){
             if(line == "!BEGIN FW ENTRIES")
                 scan = true;
-            else
-                continue;
+
+            continue;
         }
         if(line == "!END FW ENTRIES")
             break;


### PR DESCRIPTION
Minor edit to prevent the GUI from throwing a warning when reading the firmware table.
