### PR TITLE
Add IS_V3_OVERRIDE and clean up EP usage 

### DIFF
--- a/src/ckb-daemon/keymap.c
+++ b/src/ckb-daemon/keymap.c
@@ -1,6 +1,7 @@
 #include "device.h"
 #include "includes.h"
 #include "keymap.h"
+#include "usb.h"
 
 const key keymap[N_KEYS_EXTENDED] = {
     // Keyboard keys
@@ -388,9 +389,10 @@ void hid_kb_translate(unsigned char* kbinput, int endpoint, int length, const un
 
 #define BUTTON_HID_COUNT    5
 
-void hid_mouse_translate(unsigned char* kbinput, short* xaxis, short* yaxis, int endpoint, int length, const unsigned char* urbinput, ushort fwversion){
+void hid_mouse_translate(unsigned char* kbinput, short* xaxis, short* yaxis, int endpoint, int length, const unsigned char* urbinput, void* context){
+    usbdevice* kb = context;
     //The HID Input Endpoint on FWv3 is 64 bytes, so we can't check for length.
-    if((endpoint != 2 && endpoint != -2) || (fwversion < 0x300 && length < 10))
+    if((endpoint != 2 && endpoint != -2) || (kb->fwversion < 0x300 && !IS_V3_OVERRIDE(kb) && length < 10))
         return;
     // EP 2: mouse input
     if(urbinput[0] != 1)

--- a/src/ckb-daemon/keymap.h
+++ b/src/ckb-daemon/keymap.h
@@ -64,7 +64,7 @@ extern const key keymap[N_KEYS_EXTENDED];
 // Translates input from HID to a ckb input bitfield.
 // Use positive endpoint for non-RGB keyboards, negative endpoint for RGB
 void hid_kb_translate(unsigned char* kbinput, int endpoint, int length, const unsigned char* urbinput);
-void hid_mouse_translate(unsigned char* kbinput, short* xaxis, short* yaxis, int endpoint, int length, const unsigned char* urbinput, ushort fwversion);
+void hid_mouse_translate(unsigned char* kbinput, short* xaxis, short* yaxis, int endpoint, int length, const unsigned char* urbinput, void* context);
 
 // Copies input from Corsair reports
 void corsair_kbcopy(unsigned char* kbinput, int endpoint, const unsigned char* urbinput);

--- a/src/ckb-daemon/usb.h
+++ b/src/ckb-daemon/usb.h
@@ -112,13 +112,17 @@
 #define P_SCIMITAR_PRO_STR  "1b3e"
 #define IS_SCIMITAR(kb) ((kb)->vendor == V_CORSAIR && ((kb)->product == P_SCIMITAR || (kb)->product == P_SCIMITAR_PRO))
 
-#define P_HARPOON          0x1b3c
-#define P_HARPOON_STR      "1b3c"
+#define P_HARPOON           0x1b3c
+#define P_HARPOON_STR       "1b3c"
 #define IS_HARPOON(kb) ((kb)->vendor == V_CORSAIR && (kb)->product == P_HARPOON)
 
-#define P_GLAIVE          0x1b34
-#define P_GLAIVE_STR      "1b34"
+#define P_GLAIVE            0x1b34
+#define P_GLAIVE_STR        "1b34"
 #define IS_GLAIVE(kb) ((kb)->vendor == V_CORSAIR && (kb)->product == P_GLAIVE)
+
+#define P_POLARIS           0x1b3b
+#define P_POLARIS_STR       "1b3b"
+#define IS_POLARIS(kb) ((kb)->vendor == V_CORSAIR && ((kb)->product == P_POLARIS))
 
 ///
 /// uncomment to see USB packets sent to the device
@@ -168,8 +172,14 @@ const char* product_str(short product);
 /// Used to apply quirks and features to the PLATINUM devices.
 #define IS_PLATINUM(kb)                 ((kb)->vendor == V_CORSAIR && ((kb)->product == P_K95_PLATINUM))
 
-/// Used when a device has a firmware with a low version number that uses the new protocol
-#define IS_V2_OVERRIDE(kb)             (IS_PLATINUM(kb) || IS_K63(kb) || IS_K68(kb) || IS_HARPOON(kb) || IS_GLAIVE(kb) || (kb)->product == P_STRAFE_NRGB_2)
+/// Used for even newer devices that come with V3 firmware out of the factory.
+#define IS_V3_OVERRIDE(kb)              (0)
+
+/// Used when a device has a firmware with a low version number that uses the new endpoint configuration.
+#define IS_V2_OVERRIDE(kb)              (IS_V3_OVERRIDE(kb) || IS_PLATINUM(kb) || IS_K63(kb) || IS_K68(kb) || IS_HARPOON(kb) || IS_GLAIVE(kb) || (kb)->product == P_STRAFE_NRGB_2)
+
+/// Used for devices that have a single IN endpoint, and no HID input
+#define IS_SINGLE_EP(kb)                (IS_POLARIS(kb))
 
 /// USB delays for when the keyboards get picky about timing
 /// That was the original comment, but it is used anytime.

--- a/src/ckb-daemon/usb.h
+++ b/src/ckb-daemon/usb.h
@@ -172,7 +172,7 @@ const char* product_str(short product);
 /// Used to apply quirks and features to the PLATINUM devices.
 #define IS_PLATINUM(kb)                 ((kb)->vendor == V_CORSAIR && ((kb)->product == P_K95_PLATINUM))
 
-/// Used for even newer devices that come with V3 firmware out of the factory.
+/// Used for new devices that come with V3 firmware endpoint configuration out of the factory, but have fwversion < 0x300.
 #define IS_V3_OVERRIDE(kb)              (0)
 
 /// Used when a device has a firmware with a low version number that uses the new endpoint configuration.

--- a/src/ckb-daemon/usb_mac.c
+++ b/src/ckb-daemon/usb_mac.c
@@ -788,7 +788,7 @@ static usbdevice* add_hid(hid_dev_t handle, io_object_t** rm_notify){
     uint16_t idvendor = hidgetlong(handle, CFSTR(kIOHIDVendorIDKey)), idproduct = hidgetlong(handle, CFSTR(kIOHIDProductIDKey));
     int handle_idx;
 
-    // Because a single v3 hack wasn't enough
+    // The usbdevice struct is created later on, however in order to use IS_V3_OVERRIDE we need one with vendor and product, so a temporary one is created
     struct {uint16_t vendor; uint16_t product;} *fakekb;
     fakekb->vendor = idvendor;
     fakekb->product = idproduct;

--- a/src/ckb-daemon/usb_mac.c
+++ b/src/ckb-daemon/usb_mac.c
@@ -120,7 +120,7 @@ int os_usbsend(usbdevice* kb, const uchar* out_msg, int is_recv, const char* fil
     } else {
         // For newer devices, use interrupt transfers
         // macOS sees 4 endpoints (including ep0) for FW 3.XX
-        int ep = (kb->fwversion >= 0x130 && (kb->fwversion < 0x200 || kb->fwversion >= 0x300)) ? 4 : 3;
+        int ep = (kb->fwversion >= 0x130 && (kb->fwversion < 0x200 || kb->fwversion >= 0x300 || IS_V3_OVERRIDE(kb))) ? 4 : 3;
         usb_iface_t h_usb = kb->ifusb[ep - 1];
         hid_dev_t h_hid = kb->ifhid[ep - 1];
         if(h_usb)
@@ -179,14 +179,14 @@ int _nk95cmd(usbdevice* kb, uchar bRequest, ushort wValue, const char* file, int
 void os_sendindicators(usbdevice* kb){
     void *ileds;
     ushort leds;
-    if(kb->fwversion >= 0x300) {
+    if(kb->fwversion >= 0x300 || IS_V3_OVERRIDE(kb)) {
         leds = (kb->ileds << 8) | 0x0001;
         ileds = &leds;
     }
     else {
         ileds = &kb->ileds;
     }
-    IOUSBDevRequestTO rq = { 0x21, 0x09, 0x0200, 0x00, (kb->fwversion >= 0x300 ? 2 : 1), ileds, 0, 500, 500 };
+    IOUSBDevRequestTO rq = { 0x21, 0x09, 0x0200, 0x00, ((kb->fwversion >= 0x300 || IS_V3_OVERRIDE(kb)) ? 2 : 1), ileds, 0, 500, 500 };
     kern_return_t res = (*kb->handle)->DeviceRequestTO(kb->handle, &rq);
     if(res == kIOReturnNotOpen){
         // Handle not open - try to go through the HID system instead
@@ -239,7 +239,7 @@ static void intreport(void* context, IOReturn result, void* sender, IOHIDReportT
         case 8:
         case 10:
         case 11:
-            hid_mouse_translate(kb->input.keys, &kb->input.rel_x, &kb->input.rel_y, -2, length, data, kb->fwversion);
+            hid_mouse_translate(kb->input.keys, &kb->input.rel_x, &kb->input.rel_y, -2, length, data, kb);
             break;
         case MSG_SIZE:
             corsair_mousecopy(kb->input.keys, kb->epcount >= 4 ? -3 : -2, data);
@@ -784,7 +784,14 @@ static usbdevice* add_hid(hid_dev_t handle, io_object_t** rm_notify){
     long output = hidgetlong(handle, CFSTR(kIOHIDMaxOutputReportSizeKey));
     long feature = hidgetlong(handle, CFSTR(kIOHIDMaxFeatureReportSizeKey));
     long fwversion = hidgetlong(handle, CFSTR(kIOHIDVersionNumberKey));
+    // Get the model and serial number
+    uint16_t idvendor = hidgetlong(handle, CFSTR(kIOHIDVendorIDKey)), idproduct = hidgetlong(handle, CFSTR(kIOHIDProductIDKey));
     int handle_idx;
+
+    // Because a single v3 hack wasn't enough
+    struct {uint16_t vendor; uint16_t product;} fakekb;
+    fakekb.vendor = idvendor;
+    fakekb.product = idproduct;
 
     // Handle 3 is for controlling the device (only exists for RGB)
     if(feature == 64)
@@ -800,7 +807,8 @@ static usbdevice* add_hid(hid_dev_t handle, io_object_t** rm_notify){
     else if((output <= 1 && feature <= 1 &&
                 (input == 8 ||                  // Keyboards
                  input == 7)) ||                // Mice
-            (fwversion >= 0x300 &&              // FWv3 hack
+            ((fwversion >= 0x300 ||             // FWv3 hack
+                IS_V3_OVERRIDE(fakekb)) &&
                 input == 64 &&
                 output <= 2 &&
                 feature == 1))
@@ -816,8 +824,6 @@ static usbdevice* add_hid(hid_dev_t handle, io_object_t** rm_notify){
         return 0;
     }
 
-    // Get the model and serial number
-    uint16_t idvendor = hidgetlong(handle, CFSTR(kIOHIDVendorIDKey)), idproduct = hidgetlong(handle, CFSTR(kIOHIDProductIDKey));
     // Use the location ID key to group the handles together
     uint32_t location = hidgetlong(handle, CFSTR(kIOHIDLocationIDKey));
     int index = find_device(idvendor, idproduct, location, handle_idx + 1);

--- a/src/ckb-daemon/usb_mac.c
+++ b/src/ckb-daemon/usb_mac.c
@@ -789,9 +789,9 @@ static usbdevice* add_hid(hid_dev_t handle, io_object_t** rm_notify){
     int handle_idx;
 
     // Because a single v3 hack wasn't enough
-    struct {uint16_t vendor; uint16_t product;} fakekb;
-    fakekb.vendor = idvendor;
-    fakekb.product = idproduct;
+    struct {uint16_t vendor; uint16_t product;} *fakekb;
+    fakekb->vendor = idvendor;
+    fakekb->product = idproduct;
 
     // Handle 3 is for controlling the device (only exists for RGB)
     if(feature == 64)


### PR DESCRIPTION
This PR cleans up EP usage in os_usbsend(), and also introduces IS_V3_OVERRIDE.
Interrupt reads, the K55, the Polaris, and the K68 (as well as probably all new devices) depend on this.

TODO: Add IS_V3(kb) that combines the fwversion check with the override.
Since it is a small enough change, it can be done afterwards, otherwise the above will need to be rebased yet again.