### PR TITLE
Disable Save to Hardware button for unsupported devices

### DIFF
--- a/src/ckb-daemon/devnode.c
+++ b/src/ckb-daemon/devnode.c
@@ -265,6 +265,8 @@ static int _mkdevpath(usbdevice* kb){
                 fputs(" fwversion", ffile);
             if(HAS_FEATURES(kb, FEAT_FWUPDATE))
                 fputs(" fwupdate", ffile);
+            if(HAS_FEATURES(kb, FEAT_HWLOAD))
+                fputs(" hwload", ffile);
             fputc('\n', ffile);
             fclose(ffile);
             chmod(fpath, S_GID_READ);

--- a/src/ckb/kb.cpp
+++ b/src/ckb/kb.cpp
@@ -18,7 +18,7 @@ KeyMap::Layout Kb::_layout = KeyMap::NO_LAYOUT;
 bool Kb::_dither = false, Kb::_mouseAccel = true, Kb::_delay = false;
 
 Kb::Kb(QObject *parent, const QString& path) :
-    QThread(parent), features("N/A"), firmware("N/A"), pollrate("N/A"), monochrome(false),
+    QThread(parent), features("N/A"), firmware("N/A"), pollrate("N/A"), monochrome(false), hwload(false),
     devpath(path), cmdpath(path + "/cmd"), notifyPath(path + "/notify1"), macroPath(path + "/notify2"),
     _currentProfile(0), _currentMode(0), _model(KeyMap::NO_MODEL),
     lastAutoSave(QDateTime::currentMSecsSinceEpoch()),
@@ -50,6 +50,8 @@ Kb::Kb(QObject *parent, const QString& path) :
     }
     if (features.contains("monochrome"))
         monochrome = true;
+    if (features.contains("hwload"))
+        hwload = true;
     if (mpath.open(QIODevice::ReadOnly)){
         usbModel = mpath.read(100);
         usbModel = usbModel.remove("Corsair").remove("Gaming").remove("Keyboard").remove("Mouse").remove("Bootloader").trimmed();

--- a/src/ckb/kb.h
+++ b/src/ckb/kb.h
@@ -18,6 +18,7 @@ public:
     QString features, firmware, pollrate;
     bool monochrome;
     short productID;
+    bool hwload;
 
     // Keyboard model
     inline KeyMap::Model    model() const                       { return _model; }

--- a/src/ckb/kbwidget.cpp
+++ b/src/ckb/kbwidget.cpp
@@ -55,6 +55,11 @@ KbWidget::KbWidget(QWidget *parent, Kb *_device) :
     // Set monochrome mode according to hardware
     if(device->monochrome)
         ui->lightWidget->setMonochrome();
+    // Disable Save to hardware button for unsupported devices
+    if(!device->hwload){
+        ui->hwSaveButton->setDisabled(true);
+        ui->hwSaveButton->setToolTip(QString(tr("Saving to hardware is not supported on this device.")));
+    }
 }
 
 KbWidget::~KbWidget(){


### PR DESCRIPTION
There's no point in letting people try to save to hardware by pressing the button, when it's unsupported either due to lack of interrupts (v3), or because of protocol changes (Platinum).