### PR TITLE
Use URB Interrupts for all non-HID transfers

### DIFF
--- a/src/ckb-daemon/structures.h
+++ b/src/ckb-daemon/structures.h
@@ -188,6 +188,10 @@ typedef struct {
     int handle;
     // uinput handles
     int uinput_kb, uinput_mouse;
+    // Buffer used to store non-HID interrupt reads from the input thread.
+    uchar* interruptbuf;
+    // Mutex to share data between the input thread and os_usbrecv()
+    pthread_mutex_t interruptmutex;
 #else
     // USB identifier
     uint32_t location_id[IFACE_MAX + 1];

--- a/src/ckb-daemon/usb.h
+++ b/src/ckb-daemon/usb.h
@@ -127,12 +127,16 @@
 #define IS_POLARIS(kb) ((kb)->vendor == V_CORSAIR && ((kb)->product == P_POLARIS))
 
 ///
-/// uncomment to see USB packets sent to the device
+/// Uncomment to see USB packets sent to the device
 // #define DEBUG_USB_SEND
 
 ///
-///uncomment to see USB packets received from the device
+/// Uncomment to see USB packets received from the device through os_usbrecv()
 // #define DEBUG_USB_RECV
+
+///
+/// Uncomment to see USB packets received from the device throug the input thread
+// #define DEBUG_USB_INPUT
 
 ///
 /// \brief vendor_str Vendor/product string representations


### PR DESCRIPTION
Closes #51, which contains a really nice summary of the whole problem.

A mutex and a buffer are added to the usbdevice struct.

When usbsend is called with the is_recv flag, the mutex is locked.
The main thread listens for packets starting with 0x0e, copies them to the buffer and unlocks the mutex.
usbrecv waits for the mutex to be unlocked and then copies the buffer from usbdevice.

The above is all ignored, falling back to the old behaviour, when fwversion is lower than 1.3 which works only with URB Controls.

Ideally, the comments for the functions should be rewritten before merging this.