### PR TITLE
Add Dark Core IDs

### DIFF
--- a/src/daemon/led_mouse.c
+++ b/src/daemon/led_mouse.c
@@ -17,6 +17,40 @@ static int isblack(const usbdevice* kb, const lighting* light){
     return !memcmp(light->r + LED_MOUSE, black, sizeof(black)) && !memcmp(light->g + LED_MOUSE, black, sizeof(black)) && !memcmp(light->b + LED_MOUSE, black, sizeof(black));
 }
 
+static int updatergb_darkcore(usbdevice* kb, lighting* lastlight, lighting* newlight){
+    // Dark Core zone bits:
+    // 1: Front
+    // 2: Thumb
+    // 4: Rear
+    // Dark Core commands:
+    // 00: Colour Shift
+    // 01: Colour Pulse
+    // 03: Rainbow
+    // 07: Static Colour
+    // FF: No animation (black)
+    for (int zone = 0; zone < 3; zone++) {
+        uchar data_pkt[MSG_SIZE] = {
+            0x07, 0xaa, 0
+        };
+        data_pkt[4]  = 1 << zone; // This is a bitmask, so we could later check and merge commands.
+        data_pkt[5]  = 7;
+        data_pkt[8]  = 100; // Opacity.
+        data_pkt[9]  = newlight->r[zone];
+        data_pkt[10] = newlight->g[zone];
+        data_pkt[11] = newlight->b[zone];
+        // Colour gets sent twice for some reason.
+        data_pkt[12] = newlight->r[zone];
+        data_pkt[13] = newlight->g[zone];
+        data_pkt[14] = newlight->b[zone];
+        data_pkt[15] = 5; // Terminator byte?
+        if(!usbsend(kb, data_pkt, 1))
+            return -1;
+    }
+
+    memcpy(lastlight, newlight, sizeof(lighting));
+    return 0;
+}
+
 int updatergb_mouse(usbdevice* kb, int force){
     if(!kb->active)
         return 0;
@@ -27,6 +61,10 @@ int updatergb_mouse(usbdevice* kb, int force){
             && !rgbcmp(lastlight, newlight))
         return 0;
     lastlight->forceupdate = newlight->forceupdate = 0;
+
+    // The Dark Core has its own lighting protocol.
+    if(IS_DARK_CORE(kb))
+        return updatergb_darkcore(kb, lastlight, newlight);
 
     // Prevent writing to DPI LEDs or non-existent LED zones for the Glaive.
     int num_zones = IS_GLAIVE(kb) ? 3 : N_MOUSE_ZONES;

--- a/src/daemon/usb.c
+++ b/src/daemon/usb.c
@@ -130,6 +130,8 @@ const char* product_str(short product){
         return "katar";
     if(product == P_POLARIS)
         return "polaris";
+    if(product == P_DARK_CORE || product == P_DARK_CORE_WL)
+        return "darkcore";
     return "";
 }
 

--- a/src/daemon/usb.c
+++ b/src/daemon/usb.c
@@ -46,6 +46,7 @@ ushort models[N_MODELS] = {
     P_KATAR,
     // Mousepads
     P_POLARIS,
+    P_DARK_CORE,
 };
 
 /// brief .

--- a/src/daemon/usb.h
+++ b/src/daemon/usb.h
@@ -114,7 +114,7 @@
 #define P_POLARIS            0x1b3b
 #define IS_POLARIS(kb)       ((kb)->vendor == V_CORSAIR && ((kb)->product == P_POLARIS))
 
-#define N_MODELS 33
+#define N_MODELS 34
 extern ushort models[];
 
 ///

--- a/src/daemon/usb.h
+++ b/src/daemon/usb.h
@@ -105,6 +105,12 @@
 #define P_KATAR              0x1b22
 #define IS_KATAR(kb)         ((kb)->vendor == V_CORSAIR && (kb)->product == P_KATAR)
 
+#define P_DARK_CORE          0x1b35 /* wired */
+#define P_DARK_CORE_STR      "1b35"
+#define P_DARK_CORE_WL       0x1b64 /* wireless */
+#define P_DARK_CORE_WL_STR   "1b64"
+#define IS_DARK_CORE(kb)     ((kb)->vendor == V_CORSAIR && ((kb)->product == P_DARK_CORE || (kb)->product == P_DARK_CORE_WL))
+
 #define P_POLARIS            0x1b3b
 #define IS_POLARIS(kb)       ((kb)->vendor == V_CORSAIR && ((kb)->product == P_POLARIS))
 
@@ -155,7 +161,7 @@ const char* product_str(short product);
 #define IS_FULLRANGE(kb)                (!IS_LEGACY((kb)->vendor, (kb)->product) && (kb)->product != P_K65 && (kb)->product != P_K70 && (kb)->product != P_K95 && (kb)->product != P_STRAFE_NRGB)
 
 /// Mouse vs keyboard test
-#define IS_MOUSE(vendor, product)       ((vendor) == (V_CORSAIR) && ((product) == (P_M65) || (product) == (P_M65_PRO) || (product) == (P_SABRE_O) || (product) == (P_SABRE_L) || (product) == (P_SABRE_N) || (product) == (P_SCIMITAR) || (product) == (P_SCIMITAR_PRO) || (product) == (P_SABRE_O2) || (product) == (P_GLAIVE) || (product) == (P_HARPOON) || (product) == (P_KATAR)))
+#define IS_MOUSE(vendor, product)       ((vendor) == (V_CORSAIR) && ((product) == (P_M65) || (product) == (P_M65_PRO) || (product) == (P_SABRE_O) || (product) == (P_SABRE_L) || (product) == (P_SABRE_N) || (product) == (P_SCIMITAR) || (product) == (P_SCIMITAR_PRO) || (product) == (P_SABRE_O2) || (product) == (P_GLAIVE) || (product) == (P_HARPOON) || (product) == (P_KATAR) || (product) == (P_DARK_CORE) || (product) == (P_DARK_CORE_WL)))
 
 /// For calling with a usbdevice*, vendor and product are extracted and IS_MOUSE() is returned.
 #define IS_MOUSE_DEV(kb)                IS_MOUSE((kb)->vendor, (kb)->product)

--- a/src/daemon/usb.h
+++ b/src/daemon/usb.h
@@ -171,7 +171,7 @@ const char* product_str(short product);
 
 /// Used for new devices that come with V3 firmware endpoint configuration out of the factory, but have fwversion < 0x300.
 /// Note: only the RGB variant of the K68 needs a v3 override.
-#define IS_V3_OVERRIDE(kb)              ((kb)->product == P_K68)
+#define IS_V3_OVERRIDE(kb)              ((kb)->product == P_K68 || IS_DARK_CORE(kb))
 
 /// Used when a device has a firmware with a low version number that uses the new endpoint configuration.
 #define IS_V2_OVERRIDE(kb)              (IS_V3_OVERRIDE(kb) || IS_PLATINUM(kb) || IS_K63(kb) || IS_K68(kb) || IS_HARPOON(kb) || IS_GLAIVE(kb) || IS_KATAR(kb) || (kb)->product == P_STRAFE_NRGB_2 || IS_POLARIS(kb))


### PR DESCRIPTION
These IDs aren't plumbed into usb_*.c, so they won't work until we get a volunteer with the device itself.