### PR TITLE
Replace magic protocol numbers with defines

### DIFF
--- a/src/daemon/CMakeLists.txt
+++ b/src/daemon/CMakeLists.txt
@@ -95,6 +95,7 @@ if (MACOS OR LINUX)
               notify.h
               os.h
               profile.h
+              protocol.h
               structures.h
               usb.h)
 endif ()

--- a/src/daemon/device_keyboard.c
+++ b/src/daemon/device_keyboard.c
@@ -30,13 +30,13 @@ int setactive_kb(usbdevice* kb, int active){
     pthread_mutex_unlock(imutex(kb));
 
     uchar msg[3][MSG_SIZE] = {
-        { 0x07, 0x04, 0 },                  // Disables or enables HW control for top row
-        { 0x07, 0x40, 0 },                  // Selects key input
-        { 0x07, 0x05, 2, 0, 0x03, 0x00 }    // Commits key input selection
+        { CMD_SET, FIELD_SPECIAL, 0 },                // Disables or enables HW control for top row
+        { CMD_SET, FIELD_KEYINPUT, 0 },               // Selects key input
+        { CMD_SET, FIELD_LIGHTING, 2, 0, 0x03, 0x00 } // Commits key input selection
     };
     if(active){
         // Put the M-keys (K95) as well as the Brightness/Lock keys into software-controlled mode.
-        msg[0][2] = 2;
+        msg[0][2] = MODE_SOFTWARE;
         if(!usbsend(kb, msg[0], 1))
             return -1;
         DELAY_MEDIUM(kb);
@@ -64,7 +64,7 @@ int setactive_kb(usbdevice* kb, int active){
         DELAY_MEDIUM(kb);
     } else {
         // Set the M-keys back into hardware mode, restore hardware RGB profile. It has to be sent twice for some reason.
-        msg[0][2] = 1;
+        msg[0][2] = MODE_HARDWARE;
         if(!usbsend(kb, msg[0], 1))
             return -1;
         DELAY_MEDIUM(kb);

--- a/src/daemon/device_mouse.c
+++ b/src/daemon/device_mouse.c
@@ -11,15 +11,15 @@ int setactive_mouse(usbdevice* kb, int active){
         return 0;
     const int keycount = 20;
     uchar msg[2][MSG_SIZE] = {
-        { 0x07, 0x04, 0 },                  // Disables or enables HW control for DPI and Sniper button
-        { 0x07, 0x40, keycount, 0 },        // Select button input (simlilar to the packet sent to keyboards, but lacks a commit packet)
+        { CMD_SET, FIELD_SPECIAL, 0 },            // Disables or enables HW control for DPI and Sniper button
+        { CMD_SET, FIELD_KEYINPUT, keycount, 0 }, // Select button input (simlilar to the packet sent to keyboards, but lacks a commit packet)
     };
     if(active)
         // Put the mouse into SW mode
-        msg[0][2] = 2;
+        msg[0][2] = MODE_SOFTWARE;
     else
         // Restore HW mode
-        msg[0][2] = 1;
+        msg[0][2] = MODE_HARDWARE;
     pthread_mutex_lock(imutex(kb));
     kb->active = !!active;
     kb->profile->lastlight.forceupdate = 1;
@@ -65,7 +65,7 @@ int cmd_pollrate(usbdevice* kb, usbmode* dummy1, int dummy2, int rate, const cha
     (void)dummy3;
 
     uchar msg[MSG_SIZE] = {
-        0x07, 0x0a, 0, 0, (uchar)rate
+        CMD_SET, FIELD_POLLRATE, 0, 0, (uchar)rate
     };
     if(!usbsend(kb, msg, 1))
         return -1;

--- a/src/daemon/dpi.c
+++ b/src/daemon/dpi.c
@@ -131,7 +131,7 @@ int updatedpi(usbdevice* kb, int force){
                 // requested flags after switching stages.
                 newenabled = lastdpi->enabled | 1 << newdpi->current;
             }
-            uchar data_pkt[MSG_SIZE] = { 0x07, 0x13, 0x05, 0, newenabled };
+            uchar data_pkt[MSG_SIZE] = { CMD_SET, FIELD_MOUSE, MOUSE_DPIMASK, 0, newenabled };
             if(!usbsend(kb, data_pkt, 1))
                 return -2;
             // Cache the flags we wrote.
@@ -140,7 +140,7 @@ int updatedpi(usbdevice* kb, int force){
         // Set the DPI for the new stage if necessary.
         if (newdpi->x[newdpi->current] != lastdpi->x[newdpi->current] ||
             newdpi->y[newdpi->current] != lastdpi->y[newdpi->current]) {
-            uchar data_pkt[MSG_SIZE] = { 0x07, 0x13, 0xd0, 0 };
+            uchar data_pkt[MSG_SIZE] = { CMD_SET, FIELD_MOUSE, MOUSE_DPIPROF, 0 };
             data_pkt[2] |= newdpi->current;
             data_pkt[5] = newdpi->x[newdpi->current] & 0xFF;
             data_pkt[6] = (newdpi->x[newdpi->current] >> 8) & 0xFF;
@@ -153,7 +153,7 @@ int updatedpi(usbdevice* kb, int force){
             lastdpi->y[newdpi->current] = newdpi->y[newdpi->current];
         }
         // Set current DPI stage.
-        uchar data_pkt[MSG_SIZE] = { 0x07, 0x13, 0x02, 0, newdpi->current };
+        uchar data_pkt[MSG_SIZE] = { CMD_SET, FIELD_MOUSE, MOUSE_DPI, 0, newdpi->current };
         if(!usbsend(kb, data_pkt, 1))
             return -2;
     }
@@ -163,7 +163,7 @@ int updatedpi(usbdevice* kb, int force){
     for(int i = 0; i < DPI_COUNT; i++){
         if (newdpi->x[i] == lastdpi->x[i] && newdpi->y[i] == lastdpi->y[i])
             continue;
-        uchar data_pkt[MSG_SIZE] = { 0x07, 0x13, 0xd0, 0 };
+        uchar data_pkt[MSG_SIZE] = { CMD_SET, FIELD_MOUSE, MOUSE_DPIPROF, 0 };
         data_pkt[2] |= i;
         data_pkt[5] = newdpi->x[i] & 0xFF;
         data_pkt[6] = (newdpi->x[i] >> 8) & 0xFF;
@@ -175,17 +175,17 @@ int updatedpi(usbdevice* kb, int force){
 
     // Send settings
     if (newdpi->enabled != lastdpi->enabled) {
-        uchar data_pkt[MSG_SIZE] = { 0x07, 0x13, 0x05, 0, newdpi->enabled };
+        uchar data_pkt[MSG_SIZE] = { CMD_SET, FIELD_MOUSE, MOUSE_DPIMASK, 0, newdpi->enabled };
         if(!usbsend(kb, data_pkt, 1))
             return -2;
     }
     if (newdpi->lift != lastdpi->lift) {
-        uchar data_pkt[MSG_SIZE] = { 0x07, 0x13, 0x03, 0, newdpi->lift };
+        uchar data_pkt[MSG_SIZE] = { CMD_SET, FIELD_MOUSE, MOUSE_LIFT, 0, newdpi->lift };
         if(!usbsend(kb, data_pkt, 1))
             return -2;
     }
     if (newdpi->snap != lastdpi->snap) {
-        uchar data_pkt[MSG_SIZE] = { 0x07, 0x13, 0x04, 0, newdpi->snap, 0x05 };
+        uchar data_pkt[MSG_SIZE] = { CMD_SET, FIELD_MOUSE, MOUSE_SNAP, 0, newdpi->snap, 0x05 };
         if(!usbsend(kb, data_pkt, 1))
             return -2;
     }
@@ -198,7 +198,7 @@ int updatedpi(usbdevice* kb, int force){
 int savedpi(usbdevice* kb, dpiset* dpi, lighting* light){
     // Send X/Y DPIs
     for(int i = 0; i < DPI_COUNT; i++){
-        uchar data_pkt[MSG_SIZE] = { 0x07, 0x13, 0xd0, 1 };
+        uchar data_pkt[MSG_SIZE] = { CMD_SET, FIELD_MOUSE, MOUSE_DPIPROF, 1 };
         data_pkt[2] |= i;
         data_pkt[5] = dpi->x[i] & 0xFF;
         data_pkt[6] = (dpi->x[i] >> 8) & 0xFF;
@@ -214,10 +214,10 @@ int savedpi(usbdevice* kb, dpiset* dpi, lighting* light){
 
     // Send settings
     uchar data_pkt[4][MSG_SIZE] = {
-        { 0x07, 0x13, 0x05, 1, dpi->enabled },
-        { 0x07, 0x13, 0x02, 1, dpi->current },
-        { 0x07, 0x13, 0x03, 1, dpi->lift },
-        { 0x07, 0x13, 0x04, 1, dpi->snap, 0x05 }
+        { CMD_SET, FIELD_MOUSE, MOUSE_DPIMASK, 1, dpi->enabled },
+        { CMD_SET, FIELD_MOUSE, MOUSE_DPI, 1, dpi->current },
+        { CMD_SET, FIELD_MOUSE, MOUSE_LIFT, 1, dpi->lift },
+        { CMD_SET, FIELD_MOUSE, MOUSE_SNAP, 1, dpi->snap, 0x05 }
     };
     if(!usbsend(kb, data_pkt[0], 4))
         return -2;
@@ -228,10 +228,10 @@ int savedpi(usbdevice* kb, dpiset* dpi, lighting* light){
 int loaddpi(usbdevice* kb, dpiset* dpi, lighting* light){
     // Ask for settings
     uchar data_pkt[4][MSG_SIZE] = {
-        { 0x0e, 0x13, 0x05, 1, },
-        { 0x0e, 0x13, 0x02, 1, },
-        { 0x0e, 0x13, 0x03, 1, },
-        { 0x0e, 0x13, 0x04, 1, }
+        { CMD_GET, FIELD_MOUSE, MOUSE_DPIMASK, 1, },
+        { CMD_GET, FIELD_MOUSE, MOUSE_DPI, 1, },
+        { CMD_GET, FIELD_MOUSE, MOUSE_LIFT, 1, },
+        { CMD_GET, FIELD_MOUSE, MOUSE_SNAP, 1, }
     };
     uchar in_pkt[4][MSG_SIZE];
     for(int i = 0; i < 4; i++){
@@ -255,7 +255,7 @@ int loaddpi(usbdevice* kb, dpiset* dpi, lighting* light){
 
     // Get X/Y DPIs
     for(int i = 0; i < DPI_COUNT; i++){
-        uchar data_pkt[MSG_SIZE] = { 0x0e, 0x13, 0xd0, 1 };
+        uchar data_pkt[MSG_SIZE] = { CMD_GET, FIELD_MOUSE, MOUSE_DPIPROF, 1 };
         uchar in_pkt[MSG_SIZE];
         data_pkt[2] |= i;
         if(!usbrecv(kb, data_pkt, in_pkt))

--- a/src/daemon/led_keyboard.c
+++ b/src/daemon/led_keyboard.c
@@ -108,31 +108,31 @@ int updatergb_kb(usbdevice* kb, int force){
         // Update strafe sidelights if necessary
         if(lastlight->sidelight != newlight->sidelight) {
             uchar data_pkt[2][MSG_SIZE] = {
-                 { 0x07, 0x05, 0x08, 0x00, 0x00 },
-                 { 0x07, 0x05, 0x02, 0, 0x03 }
+                 { CMD_SET, FIELD_LIGHTING, MODE_SIDELIGHT, 0x00, 0x00 },
+                 { CMD_SET, FIELD_LIGHTING, MODE_SOFTWARE, 0, 0x03 }
              };
              if (newlight->sidelight)
-                 data_pkt[0][4]=1;    // turn on
+                 data_pkt[0][4] = 1;    // turn on
              if(!usbsend(kb, data_pkt[0], 2))
                  return -1;
         }
         // 16.8M color lighting works fine on strafe and is the only way it actually works
         uchar data_pkt[12][MSG_SIZE] = {
             // Red
-            { 0x7f, 0x01, 0x3c, 0 },
-            { 0x7f, 0x02, 0x3c, 0 },
-            { 0x7f, 0x03, 0x30, 0 },
-            { 0x07, 0x28, 0x01, 0x03, 0x01, 0},
+            { CMD_WRITE_BULK, 0x01, 0x3c, 0 },
+            { CMD_WRITE_BULK, 0x02, 0x3c, 0 },
+            { CMD_WRITE_BULK, 0x03, 0x30, 0 },
+            { CMD_SET, FIELD_KB_COLOR, COLOR_RED, 0x03, 0x01, 0},
             // Green
-            { 0x7f, 0x01, 0x3c, 0 },
-            { 0x7f, 0x02, 0x3c, 0 },
-            { 0x7f, 0x03, 0x30, 0 },
-            { 0x07, 0x28, 0x02, 0x03, 0x01, 0},
+            { CMD_WRITE_BULK, 0x01, 0x3c, 0 },
+            { CMD_WRITE_BULK, 0x02, 0x3c, 0 },
+            { CMD_WRITE_BULK, 0x03, 0x30, 0 },
+            { CMD_SET, FIELD_KB_COLOR, COLOR_GREEN, 0x03, 0x01, 0},
             // Blue
-            { 0x7f, 0x01, 0x3c, 0 },
-            { 0x7f, 0x02, 0x3c, 0 },
-            { 0x7f, 0x03, 0x30, 0 },
-            { 0x07, 0x28, 0x03, 0x03, 0x02, 0}
+            { CMD_WRITE_BULK, 0x01, 0x3c, 0 },
+            { CMD_WRITE_BULK, 0x02, 0x3c, 0 },
+            { CMD_WRITE_BULK, 0x03, 0x30, 0 },
+            { CMD_SET, FIELD_KB_COLOR, COLOR_BLUE, 0x03, 0x02, 0}
         };
         makergb_full(newlight, data_pkt);
         if(!usbsend(kb, data_pkt[0], 12))
@@ -140,11 +140,11 @@ int updatergb_kb(usbdevice* kb, int force){
     } else {
         // On older keyboards it looks flickery and causes lighting glitches, so we don't use it.
         uchar data_pkt[5][MSG_SIZE] = {
-            { 0x7f, 0x01, 60, 0 },
-            { 0x7f, 0x02, 60, 0 },
-            { 0x7f, 0x03, 60, 0 },
-            { 0x7f, 0x04, 36, 0 },
-            { 0x07, 0x27, 0x00, 0x00, 0xD8 }
+            { CMD_WRITE_BULK, 0x01, 60, 0 },
+            { CMD_WRITE_BULK, 0x02, 60, 0 },
+            { CMD_WRITE_BULK, 0x03, 60, 0 },
+            { CMD_WRITE_BULK, 0x04, 36, 0 },
+            { CMD_SET, FIELD_KB_9BCLR, 0x00, 0x00, 0xD8 }
         };
         makergb_512(newlight, data_pkt, kb->dither ? ordered8to3 : quantize8to3);
         if(!usbsend(kb, data_pkt[0], 5))
@@ -159,36 +159,36 @@ int savergb_kb(usbdevice* kb, lighting* light, int mode){
     if(kb->fwversion >= 0x0120 || IS_V2_OVERRIDE(kb)){
         uchar data_pkt[12][MSG_SIZE] = {
             // Red
-            { 0x7f, 0x01, 60, 0 },
-            { 0x7f, 0x02, 60, 0 },
-            { 0x7f, 0x03, 24, 0 },
-            { 0x07, 0x14, 0x03, 0x01, 0x01, mode + 1, 0x01 },
+            { CMD_WRITE_BULK, 0x01, 60, 0 },
+            { CMD_WRITE_BULK, 0x02, 60, 0 },
+            { CMD_WRITE_BULK, 0x03, 24, 0 },
+            { CMD_SET, FIELD_KB_HWCLR, 0x03, 0x01, 0x01, mode + 1, COLOR_RED},
             // Green
-            { 0x7f, 0x01, 60, 0 },
-            { 0x7f, 0x02, 60, 0 },
-            { 0x7f, 0x03, 24, 0 },
-            { 0x07, 0x14, 0x03, 0x01, 0x01, mode + 1, 0x02 },
+            { CMD_WRITE_BULK, 0x01, 60, 0 },
+            { CMD_WRITE_BULK, 0x02, 60, 0 },
+            { CMD_WRITE_BULK, 0x03, 24, 0 },
+            { CMD_SET, FIELD_KB_HWCLR, 0x03, 0x01, 0x01, mode + 1, COLOR_GREEN },
             // Blue
-            { 0x7f, 0x01, 60, 0 },
-            { 0x7f, 0x02, 60, 0 },
-            { 0x7f, 0x03, 24, 0 },
-            { 0x07, 0x14, 0x03, 0x01, 0x01, mode + 1, 0x03 }
+            { CMD_WRITE_BULK, 0x01, 60, 0 },
+            { CMD_WRITE_BULK, 0x02, 60, 0 },
+            { CMD_WRITE_BULK, 0x03, 24, 0 },
+            { CMD_SET, FIELD_KB_HWCLR, 0x03, 0x01, 0x01, mode + 1, COLOR_BLUE }
         };
         makergb_full(light, data_pkt);
         if(!usbsend(kb, data_pkt[0], 12))
             return -1;
         if (IS_STRAFE(kb)){ // end save
-            uchar save_end_pkt[MSG_SIZE] = { 0x07, 0x14, 0x04, 0x01, 0x01 };
+            uchar save_end_pkt[MSG_SIZE] = { CMD_SET, FIELD_KB_HWCLR, 0x04, 0x01, 0x01 };
             if(!usbsend(kb, save_end_pkt, 1))
                 return -1;
         }
     } else {
         uchar data_pkt[5][MSG_SIZE] = {
-            { 0x7f, 0x01, 60, 0 },
-            { 0x7f, 0x02, 60, 0 },
-            { 0x7f, 0x03, 60, 0 },
-            { 0x7f, 0x04, 36, 0 },
-            { 0x07, 0x14, 0x02, 0x00, 0x01, mode + 1 }
+            { CMD_WRITE_BULK, 0x01, 60, 0 },
+            { CMD_WRITE_BULK, 0x02, 60, 0 },
+            { CMD_WRITE_BULK, 0x03, 60, 0 },
+            { CMD_WRITE_BULK, 0x04, 36, 0 },
+            { CMD_SET, FIELD_KB_HWCLR, 0x02, 0x00, 0x01, mode + 1 }
         };
         makergb_512(light, data_pkt, kb->dither ? ordered8to3 : quantize8to3);
         if(!usbsend(kb, data_pkt[0], 5))
@@ -200,24 +200,24 @@ int savergb_kb(usbdevice* kb, lighting* light, int mode){
 int loadrgb_kb(usbdevice* kb, lighting* light, int mode){
     if(kb->fwversion >= 0x0120 || IS_V2_OVERRIDE(kb)){
         uchar data_pkt[12][MSG_SIZE] = {
-            { 0x0e, 0x14, 0x03, 0x01, 0x01, mode + 1, 0x01 },
-            { 0xff, 0x01, 60, 0 },
-            { 0xff, 0x02, 60, 0 },
-            { 0xff, 0x03, 24, 0 },
-            { 0x0e, 0x14, 0x03, 0x01, 0x01, mode + 1, 0x02 },
-            { 0xff, 0x01, 60, 0 },
-            { 0xff, 0x02, 60, 0 },
-            { 0xff, 0x03, 24, 0 },
-            { 0x0e, 0x14, 0x03, 0x01, 0x01, mode + 1, 0x03 },
-            { 0xff, 0x01, 60, 0 },
-            { 0xff, 0x02, 60, 0 },
-            { 0xff, 0x03, 24, 0 },
+            { CMD_GET, FIELD_KB_HWCLR, 0x03, 0x01, 0x01, mode + 1, COLOR_RED },
+            { CMD_READ_BULK, 0x01, 60, 0 },
+            { CMD_READ_BULK, 0x02, 60, 0 },
+            { CMD_READ_BULK, 0x03, 24, 0 },
+            { CMD_GET, FIELD_KB_HWCLR, 0x03, 0x01, 0x01, mode + 1, COLOR_GREEN },
+            { CMD_READ_BULK, 0x01, 60, 0 },
+            { CMD_READ_BULK, 0x02, 60, 0 },
+            { CMD_READ_BULK, 0x03, 24, 0 },
+            { CMD_GET, FIELD_KB_HWCLR, 0x03, 0x01, 0x01, mode + 1, COLOR_BLUE },
+            { CMD_READ_BULK, 0x01, 60, 0 },
+            { CMD_READ_BULK, 0x02, 60, 0 },
+            { CMD_READ_BULK, 0x03, 24, 0 },
         };
         uchar in_pkt[4][MSG_SIZE] = {
-            { 0x0e, 0x14, 0x03, 0x01 },
-            { 0xff, 0x01, 60, 0 },
-            { 0xff, 0x02, 60, 0 },
-            { 0xff, 0x03, 24, 0 },
+            { CMD_GET, FIELD_KB_HWCLR, 0x03, 0x01 },
+            { CMD_READ_BULK, 0x01, 60, 0 },
+            { CMD_READ_BULK, 0x02, 60, 0 },
+            { CMD_READ_BULK, 0x03, 24, 0 },
         };
 
         /// Since Firmware Version 2.05 for K95RGB the answers for getting the stored color-maps from the hardware
@@ -227,10 +227,10 @@ int loadrgb_kb(usbdevice* kb, lighting* light, int mode){
         /// So we have to determine in the most inner loop the firmware version and type of KB to select the correct compare-table.
 
         uchar cmp_pkt[4][4] = {
-            { 0x0e, 0x14, 0x03, 0x01 },
-            { 0x0e, 0xff, 0x01, 60 },
-            { 0x0e, 0xff, 0x02, 60 },
-            { 0x0e, 0xff, 0x03, 24 },
+            { CMD_GET, FIELD_KB_HWCLR, 0x03, 0x01 },
+            { CMD_GET, CMD_READ_BULK, 0x01, 60 },
+            { CMD_GET, CMD_READ_BULK, 0x02, 60 },
+            { CMD_GET, CMD_READ_BULK, 0x03, 24 },
         };
         /// Read colors
         uchar* colors[3] = { light->r, light->g, light->b };
@@ -269,17 +269,17 @@ int loadrgb_kb(usbdevice* kb, lighting* light, int mode){
         }
     } else {
         uchar data_pkt[5][MSG_SIZE] = {
-            { 0x0e, 0x14, 0x02, 0x01, 0x01, mode + 1, 0 },
-            { 0xff, 0x01, 60, 0 },
-            { 0xff, 0x02, 60, 0 },
-            { 0xff, 0x03, 60, 0 },
-            { 0xff, 0x04, 36, 0 },
+            { CMD_GET, FIELD_KB_HWCLR, 0x02, 0x01, 0x01, mode + 1, 0 },
+            { CMD_READ_BULK, 0x01, 60, 0 },
+            { CMD_READ_BULK, 0x02, 60, 0 },
+            { CMD_READ_BULK, 0x03, 60, 0 },
+            { CMD_READ_BULK, 0x04, 36, 0 },
         };
         uchar in_pkt[4][MSG_SIZE] = {
-            { 0xff, 0x01, 60, 0 },
-            { 0xff, 0x02, 60, 0 },
-            { 0xff, 0x03, 60, 0 },
-            { 0xff, 0x04, 36, 0 },
+            { CMD_READ_BULK, 0x01, 60, 0 },
+            { CMD_READ_BULK, 0x02, 60, 0 },
+            { CMD_READ_BULK, 0x03, 60, 0 },
+            { CMD_READ_BULK, 0x04, 36, 0 },
         };
         // Write initial packet
         if(!usbsend(kb, data_pkt[0], 1))

--- a/src/daemon/led_mouse.c
+++ b/src/daemon/led_mouse.c
@@ -32,8 +32,8 @@ int updatergb_mouse(usbdevice* kb, int force){
     int num_zones = IS_GLAIVE(kb) ? 3 : N_MOUSE_ZONES;
     // Send the RGB values for each zone to the mouse
     uchar data_pkt[2][MSG_SIZE] = {
-        { 0x07, 0x22, num_zones, 0x01, 0 }, // RGB colors
-        { 0x07, 0x05, 0x02, 0 }                 // Lighting on/off
+        { CMD_SET, FIELD_M_COLOR, num_zones, 0x01, 0 }, // RGB colors
+        { CMD_SET, FIELD_LIGHTING, MODE_SOFTWARE, 0 }   // Lighting on/off
     };
     uchar* rgb_data = &data_pkt[0][4];
     for(int i = 0; i < N_MOUSE_ZONES; i++){
@@ -54,7 +54,7 @@ int updatergb_mouse(usbdevice* kb, int force){
             return -1;
     } else if(was_black || force){
         // If the lighting WAS black, or if we're on forced update, send the activation packet
-        data_pkt[1][4] = 1;
+        data_pkt[1][4] = MODE_HARDWARE;
         if(!usbsend(kb, data_pkt[1], 1))
             return -1;
     }
@@ -66,7 +66,7 @@ int updatergb_mouse(usbdevice* kb, int force){
 int savergb_mouse(usbdevice* kb, lighting* light, int mode){
     (void)mode;
 
-    uchar data_pkt[MSG_SIZE] = { 0x07, 0x13, 0x10, 1, 0 };
+    uchar data_pkt[MSG_SIZE] = { CMD_SET, FIELD_MOUSE, MOUSE_HWCOLOR, 1, 0 };
     // Save each RGB zone, minus the DPI light which is sent in the DPI packets
     int zonecount = IS_SCIMITAR(kb) ? 4 : IS_SABRE(kb) ? 3 : 2;
     for(int i = 0; i < zonecount; i++){
@@ -87,7 +87,7 @@ int savergb_mouse(usbdevice* kb, lighting* light, int mode){
 int loadrgb_mouse(usbdevice* kb, lighting* light, int mode){
     (void)mode;
 
-    uchar data_pkt[MSG_SIZE] = { 0x0e, 0x13, 0x10, 1, 0 };
+    uchar data_pkt[MSG_SIZE] = { CMD_GET, FIELD_MOUSE, MOUSE_HWCOLOR, 1, 0 };
     uchar in_pkt[MSG_SIZE] = { 0 };
     // Load each RGB zone
     int zonecount = IS_SCIMITAR(kb) ? 4 : IS_SABRE(kb) ? 3 : 2;

--- a/src/daemon/led_mousepad.c
+++ b/src/daemon/led_mousepad.c
@@ -19,9 +19,9 @@ int updatergb_mousepad(usbdevice* kb, int force){
         return 0;
     lastlight->forceupdate = newlight->forceupdate = 0;
 
-    // Send the RGB values for each zone to the mouse
+    // Send the RGB values for each zone to the mousepad
     uchar data_pkt[MSG_SIZE] = {
-        0x07, 0x22, N_MOUSEPAD_ZONES, 0x00, 0, // RGB colors
+        CMD_SET, FIELD_MP_COLOR, N_MOUSEPAD_ZONES, 0x00, 0, // RGB colors
     };
     uchar* rgb_data = &data_pkt[4];
     for(int i = 0; i < N_MOUSEPAD_ZONES; i++){

--- a/src/daemon/profile_mouse.c
+++ b/src/daemon/profile_mouse.c
@@ -12,8 +12,8 @@ int cmd_hwload_mouse(usbdevice* kb, usbmode* dummy1, int dummy2, int apply, cons
     hwprofile* hw = calloc(1, sizeof(hwprofile));
     // Ask for profile and mode IDs
     uchar data_pkt[2][MSG_SIZE] = {
-        { 0x0e, 0x15, 0x01, 0 },
-        { 0x0e, 0x16, 0x01, 0 }
+        { CMD_GET, FIELD_M_PROFID, 0x01, 0 },
+        { CMD_GET, FIELD_M_PROFNM, 0x01, 0 }
     };
     uchar in_pkt[MSG_SIZE];
     for(int i = 0; i <= 1; i++){
@@ -64,8 +64,8 @@ int cmd_hwsave_mouse(usbdevice* kb, usbmode* dummy1, int dummy2, int dummy3, con
     nativetohw(kb->profile, hw, 1);
     // Save the profile and mode names
     uchar data_pkt[2][MSG_SIZE] = {
-        { 0x07, 0x16, 0x01, 0 },
-        { 0x07, 0x15, 0x01, 0 },
+        { CMD_SET, FIELD_M_PROFNM, 0x01, 0 },
+        { CMD_SET, FIELD_M_PROFID, 0x01, 0 },
     };
     for(int i = 0; i <= 1; i++){
         data_pkt[0][3] = i;

--- a/src/daemon/protocol.h
+++ b/src/daemon/protocol.h
@@ -1,0 +1,53 @@
+// This file is purely macros, so it can be included multiple times without harm.
+// For more detail, please see https://github.com/ckb-next/corsair-protocol.
+
+// Corsair protocol commands.
+#define CMD_SET        0x07 // Write a single field.
+#define CMD_GET        0x0e // Read a single field.
+
+#define CMD_WRITE_BULK 0x7f // Write a stream of up to 5 packets at a time.
+#define CMD_READ_BULK  0xff // Read a stream of up to 5 packets at a time.
+
+#define FIELD_IDENT    0x01 // Firmware identification. Read only.
+#define FIELD_RESET    0x02 // Reset the device. Write only.
+#define FIELD_SPECIAL  0x04 // Special function mode, like G-keys and sniper buttons. Write only.
+#define FIELD_LIGHTING 0x05 // Lighting mode hardware/software. Write only.
+#define FIELD_POLLRATE 0x0a // Change device poll rate. Write only.
+#define FIELD_FW_START 0x0c // Begin firmware update. Write only.
+#define FIELD_FW_DATA  0x0d // Firmware update data. Write only.
+#define FIELD_MOUSE    0x13 // Mouse subcommands. Read and write, subcommand-depending.
+#define FIELD_KB_HWCLR 0x14 // Keyboard hardware colour. Read and write.
+#define FIELD_M_PROFID 0x15 // Mouse profile ID. Read and write.
+#define FIELD_M_PROFNM 0x16 // Mouse profile name. Read and write, UTF-16LE.
+#define FIELD_KB_HWANM 0x17 // Hardware animation commands used by the K95 Platinum. Read and write, subcommand-depending.
+#define FIELD_M_COLOR  0x22 // Mouse software colour change. Write only.
+#define FIELD_MP_COLOR 0x22 // Mousepad software colour change. The command is the same as for mice, but the format is different. Write only.
+#define FIELD_KB_ZNCLR 0x25 // Zoned colour change used by the K55. Write only.
+#define FIELD_KB_9BCLR 0x27 // 9-bit colour change used by !IS_FULLRANGE keyboards. Write only.
+#define FIELD_KB_COLOR 0x28 // 24-bit colour change used by IS_FULLRANGE keyboards. Write only.
+#define FIELD_KEYINPUT 0x40 // Key input mode; whether an event should trigger a HID or Corsair event (or both). Write only.
+
+// Used for FIELD_RESET.
+#define RESET_NORMAL   0x00 // A medium-speed reset.
+#define RESET_FAST     0x01 // A faster reset.
+#define RESET_BLD      0xaa // Reboot to bootloader; mounting as a virtual FAT12 device.
+#define RESET_SLOW     0xf0 // A slow reset sent after firmware update.
+
+// Used for FIELD_SPECIAL and FIELD_LIGHTING.
+#define MODE_HARDWARE  0x01 // This should be hardware controlled and not generate an event.
+#define MODE_SOFTWARE  0x02 // This should be software controlled and generate an event.
+#define MODE_SIDELIGHT 0x08 // Strafe sidelighting control.
+
+// Used for FIELD_MOUSE. All subcommands are read/write.
+#define MOUSE_DPI      0x02 // Mouse DPI mode.
+#define MOUSE_LIFT     0x03 // Mouse lift height.
+#define MOUSE_SNAP     0x04 // Mouse angle snap.
+#define MOUSE_DPIMASK  0x05 // Mouse DPI enabled mask.
+#define MOUSE_HWCOLOR  0x10 // Mouse hardware colour base (0x10-0x15).
+#define MOUSE_DPIPROF  0xd0 // Mouse DPI profile info.
+
+// Used for FIELD_KB_COLOR.
+#define COLOR_RED      0x01 // The red channel of RGB.
+#define COLOR_GREEN    0x02 // The green channel of RGB.
+#define COLOR_BLUE     0x03 // The blue channel of RGB.
+

--- a/src/daemon/usb.h
+++ b/src/daemon/usb.h
@@ -1,9 +1,11 @@
 #ifndef USB_H
 #define USB_H
 
+#include <ckbnextconfig.h>
+
 #include "includes.h"
 #include "keymap.h"
-#include <ckbnextconfig.h>
+#include "protocol.h"
 
 /// \file usb.h
 /// Definitions for using USB interface


### PR DESCRIPTION
Given how much more we know about the protocol compared to this time last year, I felt we should replace the magic numbers with #defines that gave a little more information about what the protocol is doing.