### PR TITLE
Rename "NRGB" devices to "LEGACY"

### DIFF
--- a/src/daemon/device.h
+++ b/src/daemon/device.h
@@ -32,7 +32,7 @@ extern pthread_cond_t macrovar[DEV_MAX];
 // Sets up device hardware, after software initialization is finished. Also used during resets
 // Should be called only from setupusb/resetusb
 int start_dev(usbdevice* kb, int makeactive);
-int start_kb_nrgb(usbdevice* kb, int makeactive);
+int start_kb_legacy(usbdevice* kb, int makeactive);
 
 // Activates/deactives software control on a keyboard. Return 0 on success
 int setactive_kb(usbdevice* kb, int active);
@@ -54,7 +54,7 @@ int cmd_idle_mouse(usbdevice* kb, usbmode* dummy1, int dummy2, int dummy3, const
 int cmd_pollrate(usbdevice* kb, usbmode* dummy1, int dummy2, int rate, const char* dummy3);
 
 // Sets a device's current mode index. This is only used on the non-RGB K95; the RGB keyboards have no gettable HW index.
-void setmodeindex_nrgb(usbdevice* kb, int index);
+void setmodeindex_legacy(usbdevice* kb, int index);
 
 
 // Per-key input settings for device setup

--- a/src/daemon/device_keyboard.c
+++ b/src/daemon/device_keyboard.c
@@ -6,7 +6,7 @@
 #include "profile.h"
 #include "usb.h"
 
-int start_kb_nrgb(usbdevice* kb, int makeactive){
+int start_kb_legacy(usbdevice* kb, int makeactive){
     (void)makeactive;
 
     // Put the non-RGB K95 into software mode. Nothing else needs to be done hardware wise
@@ -129,7 +129,7 @@ int cmd_idle_kb(usbdevice* kb, usbmode* dummy1, int dummy2, int dummy3, const ch
     return setactive_kb(kb, 0);
 }
 
-void setmodeindex_nrgb(usbdevice *kb, int index){
+void setmodeindex_legacy(usbdevice *kb, int index){
     switch(index % 3){
     case 0:
         nk95cmd(kb, NK95_M1);

--- a/src/daemon/device_vtable.c
+++ b/src/daemon/device_vtable.c
@@ -95,8 +95,8 @@ const devcmd vtable_keyboard = {
     .updatedpi = int1_int_none                  ///< This is for mice only
 };
 
-// Non-RGB keyboard vtable (K70)
-const devcmd vtable_keyboard_nonrgb = {
+// Legacy keyboard vtable (K70)
+const devcmd vtable_keyboard_legacy = {
     .hwload = cmd_io_none,
     .hwsave = cmd_io_none,
     .fwupdate = cmd_io_none,
@@ -132,12 +132,12 @@ const devcmd vtable_keyboard_nonrgb = {
     .get = cmd_get,
     .restart = cmd_restart,
 
-    .start = start_kb_nrgb,
-    .setmodeindex = setmodeindex_nrgb,          ///< this is special for non RGBs
+    .start = start_kb_legacy,
+    .setmodeindex = setmodeindex_legacy,        ///< This is special for legacy keyboards
     .allocprofile = allocprofile,
     .loadprofile = loadprofile_none,
     .freeprofile = freeprofile,
-    .updatergb = int1_int_none,                 ///< non RGB keyboards do not have an rgb update function
+    .updatergb = int1_int_none,                 ///< Legacy keyboards do not have an rgb update function
     .updateindicators = updateindicators_kb,
     .updatedpi = int1_int_none                  ///< This is for mice only
 };

--- a/src/daemon/keymap_patch.c
+++ b/src/daemon/keymap_patch.c
@@ -17,11 +17,11 @@ keypatch k63patch[] = {
 #define K63PATCH_LEN sizeof(k63patch)/sizeof(*k63patch)
 
 keypatches mappatches[] = {
-    { P_K68,      k63patch, K63PATCH_LEN },
-    { P_K68_NRGB, k63patch, K63PATCH_LEN },
-    { P_K65,      k65patch, K65PATCH_LEN },
-    { P_K65_NRGB, k65patch, K65PATCH_LEN },
-    { P_K63_NRGB, k63patch, K63PATCH_LEN },
+    { P_K68,        k63patch, K63PATCH_LEN },
+    { P_K68_NRGB,   k63patch, K63PATCH_LEN },
+    { P_K65,        k65patch, K65PATCH_LEN },
+    { P_K65_LEGACY, k65patch, K65PATCH_LEN },
+    { P_K63_NRGB,   k63patch, K63PATCH_LEN },
 };
 #define KEYPATCHES_LEN sizeof(mappatches)/sizeof(*mappatches)
 

--- a/src/daemon/structures.h
+++ b/src/daemon/structures.h
@@ -150,7 +150,7 @@ typedef struct {
 // Standard feature sets
 #define FEAT_COMMON     (FEAT_BIND | FEAT_NOTIFY | FEAT_FWVERSION | FEAT_MOUSEACCEL | FEAT_HWLOAD)
 #define FEAT_STD_RGB    (FEAT_COMMON | FEAT_RGB | FEAT_POLLRATE | FEAT_FWUPDATE)
-#define FEAT_STD_NRGB   (FEAT_COMMON)
+#define FEAT_STD_LEGACY (FEAT_COMMON)
 #define FEAT_LMASK      (FEAT_ANSI | FEAT_ISO)
 
 // Feature test (usbdevice* kb, int feat)
@@ -177,7 +177,7 @@ typedef struct {
 
 // vtables for keyboards/mice (see command.h)
 extern const union devcmd vtable_keyboard;
-extern const union devcmd vtable_keyboard_nonrgb;
+extern const union devcmd vtable_keyboard_legacy;
 extern const union devcmd vtable_mouse;
 extern const union devcmd vtable_mousepad;
 

--- a/src/daemon/usb.c
+++ b/src/daemon/usb.c
@@ -61,15 +61,15 @@ const char* vendor_str(short vendor){
 /// product_str() needs the \a product \a ID
 ///
 const char* product_str(short product){
-    if(product == P_K95 || product == P_K95_NRGB)
+    if(product == P_K95 || product == P_K95_LEGACY)
         return "k95";
     if(product == P_K95_PLATINUM)
         return "k95p";
-    if(product == P_K70 || product == P_K70_NRGB || product == P_K70_LUX || product == P_K70_LUX_NRGB || product == P_K70_RFIRE || product == P_K70_RFIRE_NRGB)
+    if(product == P_K70 || product == P_K70_LEGACY || product == P_K70_LUX || product == P_K70_LUX_NRGB || product == P_K70_RFIRE || product == P_K70_RFIRE_NRGB)
         return "k70";
     if(product == P_K68 || product == P_K68_NRGB)
         return "k68";
-    if(product == P_K65 || product == P_K65_NRGB || product == P_K65_LUX || product == P_K65_RFIRE)
+    if(product == P_K65 || product == P_K65_LEGACY || product == P_K65_LUX || product == P_K65_RFIRE)
         return "k65";
     if(product == P_K63_NRGB)
         return "k63";
@@ -107,16 +107,16 @@ const char* product_str(short product){
 /// \todo Is the last point really a good decision and always correct?
 ///
 static const devcmd* get_vtable(short vendor, short product){
-    // return IS_MOUSE(vendor, product) ? &vtable_mouse : IS_RGB(vendor, product) ? &vtable_keyboard : &vtable_keyboard_nonrgb;
+    // return IS_MOUSE(vendor, product) ? &vtable_mouse : !IS_LEGACY(vendor, product) ? &vtable_keyboard : &vtable_keyboard_nonrgb;
     if(IS_MOUSE(vendor, product))
         return &vtable_mouse;
     else if(IS_MOUSEPAD(vendor, product))
         return &vtable_mousepad;
     else {
-        if(IS_RGB(vendor, product))
-            return &vtable_keyboard;
+        if(IS_LEGACY(vendor, product))
+            return &vtable_keyboard_legacy;
         else
-            return &vtable_keyboard_nonrgb;
+            return &vtable_keyboard;
     }
 }
 
@@ -245,7 +245,7 @@ static void* _setupusb(void* context){
     // Set standard fields
     short vendor = kb->vendor, product = kb->product;
     const devcmd* vt = kb->vtable = get_vtable(vendor, product);
-    kb->features = (IS_RGB(vendor, product) ? FEAT_STD_RGB : FEAT_STD_NRGB) & features_mask;
+    kb->features = (IS_LEGACY(vendor, product) ? FEAT_STD_LEGACY : FEAT_STD_RGB) & features_mask;
     if(IS_MOUSE(vendor, product)) kb->features |= FEAT_ADJRATE;
     if(IS_MONOCHROME(vendor, product)) kb->features |= FEAT_MONOCHROME;
     kb->usbdelay = USB_DELAY_DEFAULT;

--- a/src/daemon/usb.h
+++ b/src/daemon/usb.h
@@ -53,13 +53,13 @@
 
 #define P_K65                0x1b17
 #define P_K65_STR            "1b17"
-#define P_K65_NRGB           0x1b07
-#define P_K65_NRGB_STR       "1b07"
+#define P_K65_LEGACY         0x1b07
+#define P_K65_LEGACY_STR     "1b07"
 #define P_K65_LUX            0x1b37
 #define P_K65_LUX_STR        "1b37"
 #define P_K65_RFIRE          0x1b39
 #define P_K65_RFIRE_STR      "1b39"
-#define IS_K65(kb)           ((kb)->vendor == V_CORSAIR && ((kb)->product == P_K65 || (kb)->product == P_K65_NRGB || (kb)->product == P_K65_LUX || (kb)->product == P_K65_RFIRE))
+#define IS_K65(kb)           ((kb)->vendor == V_CORSAIR && ((kb)->product == P_K65 || (kb)->product == P_K65_LEGACY || (kb)->product == P_K65_LUX || (kb)->product == P_K65_RFIRE))
 
 #define P_K68                0x1b4f
 #define P_K68_STR            "1b4f"
@@ -69,8 +69,8 @@
 
 #define P_K70                0x1b13
 #define P_K70_STR            "1b13"
-#define P_K70_NRGB           0x1b09
-#define P_K70_NRGB_STR       "1b09"
+#define P_K70_LEGACY         0x1b09
+#define P_K70_LEGACY_STR     "1b09"
 #define P_K70_LUX            0x1b33
 #define P_K70_LUX_STR        "1b33"
 #define P_K70_LUX_NRGB	     0x1b36
@@ -79,19 +79,19 @@
 #define P_K70_RFIRE_STR      "1b38"
 #define P_K70_RFIRE_NRGB     0x1b3a
 #define P_K70_RFIRE_NRGB_STR "1b3a"
-#define IS_K70(kb)           ((kb)->vendor == V_CORSAIR && ((kb)->product == P_K70 || (kb)->product == P_K70_NRGB || (kb)->product == P_K70_RFIRE || (kb)->product == P_K70_RFIRE_NRGB || (kb)->product == P_K70_LUX || (kb)->product == P_K70_LUX_NRGB))
+#define IS_K70(kb)           ((kb)->vendor == V_CORSAIR && ((kb)->product == P_K70 || (kb)->product == P_K70_LEGACY || (kb)->product == P_K70_RFIRE || (kb)->product == P_K70_RFIRE_NRGB || (kb)->product == P_K70_LUX || (kb)->product == P_K70_LUX_NRGB))
 
-// The K90 NRGB behaves like a K95 NRGB.
-#define P_K90_NRGB           0x1b02
-#define P_K90_NRGB_STR       "1b02"
+// The Legacy K90 behaves like a Legacy K95.
+#define P_K90_LEGACY         0x1b02
+#define P_K90_LEGACY_STR     "1b02"
 
 #define P_K95                0x1b11
 #define P_K95_STR            "1b11"
-#define P_K95_NRGB           0x1b08
-#define P_K95_NRGB_STR       "1b08"
+#define P_K95_LEGACY         0x1b08
+#define P_K95_LEGACY_STR     "1b08"
 #define P_K95_PLATINUM       0x1b2d
 #define P_K95_PLATINUM_STR   "1b2d"
-#define IS_K95(kb)           ((kb)->vendor == V_CORSAIR && ((kb)->product == P_K90_NRGB || (kb)->product == P_K95 || (kb)->product == P_K95_NRGB || (kb)->product == P_K95_PLATINUM))
+#define IS_K95(kb)           ((kb)->vendor == V_CORSAIR && ((kb)->product == P_K90_LEGACY || (kb)->product == P_K95 || (kb)->product == P_K95_LEGACY || (kb)->product == P_K95_PLATINUM))
 
 #define P_STRAFE             0x1b20
 #define P_STRAFE_STR         "1b20"
@@ -162,21 +162,21 @@ const char* product_str(short product);
 /// RGB vs non-RGB test
 /// (note: non-RGB Strafe is still considered "RGB" in that it shares the same protocol.
 /// The difference is denoted with the "monochrome" feature).
-#define IS_RGB(vendor, product)         ((vendor) == (V_CORSAIR) && (product) != (P_K65_NRGB) && (product) != (P_K70_NRGB) && (product) != (P_K95_NRGB) && (product) != (P_K90_NRGB))
+#define IS_LEGACY(vendor, product)      ((vendor) == (V_CORSAIR) && ((product) == (P_K65_LEGACY) || (product) == (P_K70_LEGACY) || (product) == P_K90_LEGACY || (product) == (P_K95_LEGACY)))
 
 /// The difference between non RGB and monochrome is, that monochrome has lights, but just in one color.
 /// nonRGB has no lights.
 /// Change this if new \b monochrome devices are added
 #define IS_MONOCHROME(vendor, product)  ((vendor) == (V_CORSAIR) && ((product) == (P_K68_NRGB) || (product) == (P_STRAFE_NRGB) || (product) == (P_STRAFE_NRGB_2)))
 
-/// For calling with a usbdevice*, vendor and product are extracted and IS_RGB() is returned.
-#define IS_RGB_DEV(kb)                  IS_RGB((kb)->vendor, (kb)->product)
+/// For calling with a usbdevice*, vendor and product are extracted and IS_LEGACY() is returned.
+#define IS_LEGACY_DEV(kb)               IS_LEGACY((kb)->vendor, (kb)->product)
 
 /// For calling with a usbdevice*, vendor and product are extracted and IS_MONOCHROME() is returned.
 #define IS_MONOCHROME_DEV(kb)           IS_MONOCHROME((kb)->vendor, (kb)->product)
 
 /// Full color range (16.8M) vs partial color range (512)
-#define IS_FULLRANGE(kb)                (IS_RGB((kb)->vendor, (kb)->product) && (kb)->product != P_K65 && (kb)->product != P_K70 && (kb)->product != P_K95 && (kb)->product != P_STRAFE_NRGB)
+#define IS_FULLRANGE(kb)                (!IS_LEGACY((kb)->vendor, (kb)->product) && (kb)->product != P_K65 && (kb)->product != P_K70 && (kb)->product != P_K95 && (kb)->product != P_STRAFE_NRGB)
 
 /// Mouse vs keyboard test
 #define IS_MOUSE(vendor, product)       ((vendor) == (V_CORSAIR) && ((product) == (P_M65) || (product) == (P_M65_PRO) || (product) == (P_SABRE_O) || (product) == (P_SABRE_L) || (product) == (P_SABRE_N) || (product) == (P_SCIMITAR) || (product) == (P_SCIMITAR_PRO) || (product) == (P_SABRE_O2) || (product) == (P_GLAIVE) || (product) == (P_HARPOON)))

--- a/src/daemon/usb_mac.c
+++ b/src/daemon/usb_mac.c
@@ -409,7 +409,7 @@ void* os_inputmain(void* context){
     int index = INDEX_OF(kb, keyboard);
     // Monitor input transfers on all endpoints for non-RGB devices
     // For RGB, monitor all but the last, as it's used for input/output
-    int count = IS_RGB_DEV(kb) ? (kb->epcount - 1) : kb->epcount;
+    int count = IS_LEGACY_DEV(kb) ? kb->epcount : (kb->epcount - 1);
     // Schedule async events for the device on this thread
     CFRunLoopRef runloop = kb->input_loop = CFRunLoopGetCurrent();
     for(int i = 0; i < count; i++){
@@ -912,7 +912,7 @@ int usbmain(){
     int vendor = V_CORSAIR;
     int products[] = {
         // Keyboards
-        P_K55, P_K63_NRGB, P_K65, P_K65_NRGB, P_K65_LUX, P_K65_RFIRE, P_K68, P_K68_NRGB, P_K70, P_K70_NRGB, P_K70_LUX, P_K70_LUX_NRGB, P_K70_RFIRE, P_K70_RFIRE_NRGB, P_K90_NRGB, P_K95, P_K95_NRGB, P_K95_PLATINUM, P_STRAFE, P_STRAFE_NRGB, P_STRAFE_NRGB_2,
+        P_K55, P_K63_NRGB, P_K65, P_K65_LEGACY, P_K65_LUX, P_K65_RFIRE, P_K68, P_K68_NRGB, P_K70, P_K70_LEGACY, P_K70_LUX, P_K70_LUX_NRGB, P_K70_RFIRE, P_K70_RFIRE_NRGB, P_K90_LEGACY, P_K95, P_K95_LEGACY, P_K95_PLATINUM, P_STRAFE, P_STRAFE_NRGB, P_STRAFE_NRGB_2,
         // Mice
         P_M65, P_M65_PRO, P_GLAIVE, P_SABRE_O, P_SABRE_L, P_SABRE_N, P_SCIMITAR, P_SCIMITAR_PRO, P_SABRE_O2, P_HARPOON
     };


### PR DESCRIPTION
Since devices like the K90 use an entirely different protocol,
they should have a name reflecting that. This now means that "NRGB"
refers to a device which has controllable single-colour backlighting.