### PR TITLE
Strafe cleanup

### DIFF
--- a/src/daemon/device_keyboard.c
+++ b/src/daemon/device_keyboard.c
@@ -30,13 +30,13 @@ int setactive_kb(usbdevice* kb, int active){
     pthread_mutex_unlock(imutex(kb));
 
     uchar msg[3][MSG_SIZE] = {
-        { CMD_SET, FIELD_SPECIAL, 0 },                // Disables or enables HW control for top row
-        { CMD_SET, FIELD_KEYINPUT, 0 },               // Selects key input
-        { CMD_SET, FIELD_LIGHTING, 2, 0, 0x03, 0x00 } // Commits key input selection
+        { CMD_SET, FIELD_SPECIAL, 0 },                         // Disables or enables HW control for top row
+        { CMD_SET, FIELD_KEYINPUT, 0 },                        // Selects key input
+        { CMD_SET, FIELD_LIGHTING, MODE_SOFTWARE, 0, 0x03, 0 } // Commits key input selection
     };
     if(active){
         // Put the M-keys (K95) as well as the Brightness/Lock keys into software-controlled mode.
-        msg[0][2] = MODE_SOFTWARE;
+        //msg[0][2] = MODE_SOFTWARE;
         if(!usbsend(kb, msg[0], 1))
             return -1;
         DELAY_MEDIUM(kb);

--- a/src/daemon/led_keyboard.c
+++ b/src/daemon/led_keyboard.c
@@ -106,7 +106,7 @@ int updatergb_kb(usbdevice* kb, int force){
             return -1;
     } else if(IS_FULLRANGE(kb)) {
         // Update strafe sidelights if necessary
-        if(lastlight->sidelight != newlight->sidelight) {
+        if(IS_STRAFE(kb) && (lastlight->sidelight != newlight->sidelight)) {
             uchar data_pkt[1][MSG_SIZE] = {
                 { CMD_SET, FIELD_LIGHTING, MODE_SIDELIGHT, 0 },
             };

--- a/src/daemon/led_keyboard.c
+++ b/src/daemon/led_keyboard.c
@@ -107,14 +107,13 @@ int updatergb_kb(usbdevice* kb, int force){
     } else if(IS_FULLRANGE(kb)) {
         // Update strafe sidelights if necessary
         if(lastlight->sidelight != newlight->sidelight) {
-            uchar data_pkt[2][MSG_SIZE] = {
-                 { CMD_SET, FIELD_LIGHTING, MODE_SIDELIGHT, 0x00, 0x00 },
-                 { CMD_SET, FIELD_LIGHTING, MODE_SOFTWARE, 0, 0x03 }
-             };
-             if (newlight->sidelight)
-                 data_pkt[0][4] = 1;    // turn on
-             if(!usbsend(kb, data_pkt[0], 2))
-                 return -1;
+            uchar data_pkt[1][MSG_SIZE] = {
+                { CMD_SET, FIELD_LIGHTING, MODE_SIDELIGHT, 0 },
+            };
+            if (newlight->sidelight)
+                data_pkt[0][4] = 1;    // turn on
+            if(!usbsend(kb, data_pkt[0], 1))
+                return -1;
         }
         if (kb->product == P_K68_NRGB) {
             // The K68 NRGB doesn't support winlock setting through the


### PR DESCRIPTION
This PR removes unnecessary "switch to SW mode" commands that were sent on every strafe sidelight update.
It also doesn't send sidelight updates on non-Strafe fullrange keyboards.

Some testing would be appreciated.