### PR TITLE
Add winlock warning

### DIFF
--- a/src/gui/kbbindwidget.cpp
+++ b/src/gui/kbbindwidget.cpp
@@ -56,6 +56,9 @@ void KbBindWidget::newLayout(){
 void KbBindWidget::newSelection(QStringList selection){
     currentSelection = selection;
     ui->rbWidget->setSelection(selection, true);
+    // Throw a warning if the user is trying to bind a win key while winlock is on
+    if((selection.contains("rwin") || selection.contains("lwin")) && bind->winLock())
+        QMessageBox::warning(this, tr("Winlock Warning"), tr("Windows key lock is currently enabled.\n\nThe binding will not function until winlock has been disabled."));
     updateSelDisplay();
 }
 


### PR DESCRIPTION
Adds a popup warning that shows up only when winlock is enabled on the current profile and the user selects a win key to bind.

![63da2cf2bcfa](https://user-images.githubusercontent.com/6003656/41501425-c9a40318-71ac-11e8-8a55-a3008dfbd54b.jpg)
