### PR TITLE
Rework input/mac USB code

### DIFF
--- a/src/daemon/keymap.c
+++ b/src/daemon/keymap.c
@@ -2,6 +2,7 @@
 #include "includes.h"
 #include "keymap.h"
 #include "usb.h"
+#include "input.h"
 
 const key keymap[N_KEYS_EXTENDED] = {
     // Keyboard keys
@@ -264,159 +265,186 @@ const key keymap[N_KEYS_EXTENDED] = {
     { "dpi5",       LED_MOUSE + 11, KEY_NONE },
 };
 
-void hid_kb_translate(unsigned char* kbinput, int endpoint, int length, const unsigned char* urbinput){
-    if(length < 1)
-        return;
-    // LUT for HID -> Corsair scancodes (-1 for no scan code, -2 for currently unsupported)
-    // Modified from Linux drivers/hid/usbhid/usbkbd.c, key codes replaced with keymap array indices and K95 keys added
-    // Make sure the indices match the keyindex as passed to nprintkey() in notify.c
-    static const short hid_codes[256] = {
-        -1,  -1,  -1,  -1,  37,  54,  52,  39,  27,  40,  41,  42,  32,  43,  44,  45,
-        56,  55,  33,  34,  25,  28,  38,  29,  31,  53,  26,  51,  30,  50,  13,  14,
-        15,  16,  17,  18,  19,  20,  21,  22,  82,   0,  86,  24,  64,  23,  84,  35,
-        79,  80,  81,  46,  47,  12,  57,  58,  59,  36,   1,   2,   3,   4,   5,   6,
-         7,   8,   9,  10,  11,  72,  73,  74,  75,  76,  77,  78,  87,  88,  89,  95,
-        93,  94,  92, 102, 103, 104, 105, 106, 107, 115, 116, 117, 112, 113, 114, 108,
-       109, 110, 118, 119,  49,  69,  -2,  -2,  -2,  -2,  -2,  -2,  -2,  -2,  -2,  -2,
-        -2,  -2,  -2,  -2,  -2,  -2,  -2,  -2,  98,  -2,  -2,  -2,  -2,  -2,  -2,  97,
-       130, 131,  -1,  -1,  -1,  -2,  -1,  83,  66,  85, 145, 144,  -2,  -1,  -1,  -1,
-        -2,  -2,  -2,  -2,  -2,  -1,  -1,  -1,  -1,  -1,  -1,  -1,  -1,  -1,  -1,  -1,
-        -1,  -1,  -1,  -1,  -1,  -1,  -1,  -1,  -1,  -1,  -1,  -1,  -1,  -1,  -1,  -1,
-        -1,  -1,  -1,  -1,  -1,  -1,  -1,  -1,  -1,  -1,  -1,  -1,  -1,  -1,  -1,  -1,
-        -1,  -1,  -1,  -1,  -1,  -1,  -1,  -1,  -1,  -1,  -1,  -1,  -3,  -1,  -1,  -1,  // <- -3 = non-RGB program key
-       120, 121, 122, 123, 124, 125, 126, 127, 128, 129, 136, 137, 138, 139, 140, 141,
-        60,  48,  62,  61,  91,  90,  67,  68, 142, 143,  99, 101,  -2, 130, 131,  97,
-        -2, 133, 134, 135,  -2,  96,  -2, 132,  -2,  -2,  71,  71,  71,  71,  -1,  -1,
-    };
-    switch(endpoint){
-    case 1:
-    case -1:
-        // EP 1: 6KRO input (RGB and non-RGB)
-        // Clear previous input
-        for(int i = 0; i < 256; i++){
-            if(hid_codes[i] >= 0)
-                CLEAR_KEYBIT(kbinput, hid_codes[i]);
-        }
-        // Set new input
-        for(int i = 0; i < 8; i++){
-            if((urbinput[0] >> i) & 1)
-                SET_KEYBIT(kbinput, hid_codes[i + 224]);
-        }
-        for(int i = 2; i < length; i++){
-            if(urbinput[i] > 3){
-                int scan = hid_codes[urbinput[i]];
-                if(scan >= 0)
-                    SET_KEYBIT(kbinput, scan);
+// LUT for HID -> Corsair scancodes (-1 for no scan code, -2 for currently unsupported)
+// Modified from Linux drivers/hid/usbhid/usbkbd.c, key codes replaced with keymap array indices and K95 keys added
+// Make sure the indices match the keyindex as passed to nprintkey() in notify.c
+static const short hid_codes[256] = {
+     -1,  -1,  -1,  -1,  37,  54,  52,  39,  27,  40,  41,  42,  32,  43,  44,  45,
+     56,  55,  33,  34,  25,  28,  38,  29,  31,  53,  26,  51,  30,  50,  13,  14,
+     15,  16,  17,  18,  19,  20,  21,  22,  82,   0,  86,  24,  64,  23,  84,  35,
+     79,  80,  81,  46,  47,  12,  57,  58,  59,  36,   1,   2,   3,   4,   5,   6,
+      7,   8,   9,  10,  11,  72,  73,  74,  75,  76,  77,  78,  87,  88,  89,  95,
+     93,  94,  92, 102, 103, 104, 105, 106, 107, 115, 116, 117, 112, 113, 114, 108,
+    109, 110, 118, 119,  49,  69,  -2,  -2,  -2,  -2,  -2,  -2,  -2,  -2,  -2,  -2,
+     -2,  -2,  -2,  -2,  -2,  -2,  -2,  -2,  98,  -2,  -2,  -2,  -2,  -2,  -2,  97,
+    130, 131,  -1,  -1,  -1,  -2,  -1,  83,  66,  85, 145, 144,  -2,  -1,  -1,  -1,
+     -2,  -2,  -2,  -2,  -2,  -1,  -1,  -1,  -1,  -1,  -1,  -1,  -1,  -1,  -1,  -1,
+     -1,  -1,  -1,  -1,  -1,  -1,  -1,  -1,  -1,  -1,  -1,  -1,  -1,  -1,  -1,  -1,
+     -1,  -1,  -1,  -1,  -1,  -1,  -1,  -1,  -1,  -1,  -1,  -1,  -1,  -1,  -1,  -1,
+     -1,  -1,  -1,  -1,  -1,  -1,  -1,  -1,  -1,  -1,  -1,  -1,  -3,  -1,  -1,  -1,  // <- -3 = non-RGB program key
+    120, 121, 122, 123, 124, 125, 126, 127, 128, 129, 136, 137, 138, 139, 140, 141,
+     60,  48,  62,  61,  91,  90,  67,  68, 142, 143,  99, 101,  -2, 130, 131,  97,
+     -2, 133, 134, 135,  -2,  96,  -2, 132,  -2,  -2,  71,  71,  71,  71,  -1,  -1,
+};
+
+// There are three types of keyboard input. 6KRO, NKRO and Corsair.
+//
+// 6KRO is only enabled in BIOS mode, and since we do not touch devices in bios mode,
+// we do not need to implement it.
+//
+// NKRO is enabled during normal operation. Key packets start with 0x01, media key packets with 0x02.
+// It does NOT get disabled when the keyboard is in software mode. Handled by hid_kb_translate()
+//
+// Corsair is enabled only after the keyboard has been set to software mode, all packets start with 0x03.
+// Since Corsair input packets are sent along with NKRO ones, in software mode, we need to ignore NKRO.
+// Handled by corsair_kbcopy()
+
+/// Process the input depending on type of device. Interpret the actual size of the URB buffer
+///
+/// device | detect with macro combination | seems to be endpoint # | actual buffer-length | function called
+/// ------ | ----------------------------- | ---------------------- | -------------------- | ---------------
+/// mouse (RGB and non RGB) | IS_MOUSE | nA | 8, 10 or 11 | hid_mouse_translate()
+/// mouse (RGB and non RGB) | IS_MOUSE | nA | MSG_SIZE (64) | corsair_mousecopy()
+/// RGB Keyboard | !IS_LEGACY && !IS_MOUSE | 1 | 8 (BIOS Mode) | hid_kb_translate()
+/// RGB Keyboard | !IS_LEGACY && !IS_MOUSE | 2 | 5 or 21, KB inactive! | hid_kb_translate()
+/// RGB Keyboard | !IS_LEGACY && !IS_MOUSE | 3? | MSG_SIZE | corsair_kbcopy()
+/// Legacy Keyboard | IS_LEGACY && !IS_MOUSE | nA | nA | hid_kb_translate()
+///
+
+void process_input_urb(void* context, unsigned char *buffer, int urblen, ushort ep){
+    usbdevice* kb = context;
+
+    // Get first byte of the response
+    uchar firstbyte = buffer[0];
+    // If the response starts with 0x0e, that means it needs to go to os_usbrecv()
+    if(urblen == MSG_SIZE && firstbyte == 0x0e){
+        int retval = pthread_mutex_lock(intmutex(kb));
+        if(retval)
+            ckb_fatal("Error locking interrupt mutex %i\n", retval);
+        memcpy(kb->interruptbuf, buffer, MSG_SIZE);
+        // signal os_usbrecv() that the data is ready.
+        retval = pthread_cond_broadcast(intcond(kb));
+        if(retval)
+            ckb_fatal("Error broadcasting pthread cond %i\n", retval);
+        retval = pthread_mutex_unlock(intmutex(kb));
+        if(retval)
+            ckb_fatal("Error unlocking interrupt mutex %i\n", retval);
+    } else {
+        pthread_mutex_lock(imutex(kb));
+        if(IS_LEGACY_DEV(kb)) {
+            hid_kb_translate(kb->input.keys, urblen, buffer, 1);
+        } else {
+            if(IS_MOUSE_DEV(kb)) {
+                // HID Mouse Input
+                if(firstbyte <= 0x01)
+                    hid_mouse_translate(kb->input.keys, &kb->input.rel_x, &kb->input.rel_y, urblen, buffer);
+                // Corsair Mouse Input
+                else if(firstbyte == 0x03)
+                    corsair_mousecopy(kb->input.keys, buffer);
                 else
-                    ckb_warn("Got unknown key press %d on EP 1\n", urbinput[i]);
+                    ckb_err("Unknown mouse data received in input thread %02x from endpoint %02x\n", firstbyte, ep);
+            } else {
+                // Assume Keyboard for everything else for now
+                // Accept NKRO only if device is active. 0x02 == media keys
+                if(firstbyte == 0x01 || firstbyte == 0x02) {
+                    if(!kb->active)
+                        hid_kb_translate(kb->input.keys, urblen, buffer, 0);
+                } else if(urblen == MSG_SIZE){
+                    if((kb->fwversion >= 0x130 || IS_V2_OVERRIDE(kb)) && firstbyte == 0x03) // Ugly hack due to old FW 1.15 packets having no header
+                        buffer++;
+                    corsair_kbcopy(kb->input.keys, buffer);
+                } else
+                    ckb_err("Unknown data received in input thread %02x from endpoint %02x\n", firstbyte, ep);
             }
         }
-        break;
-    case -2:
-        // EP 2 RGB: NKRO input
-        if(urbinput[0] == 1){
-            // Type 1: standard key
-            if(length != 21)
-                return;
-            for(int bit = 0; bit < 8; bit++){
-                if((urbinput[1] >> bit) & 1)
-                    SET_KEYBIT(kbinput, hid_codes[bit + 224]);
-                else
-                    CLEAR_KEYBIT(kbinput, hid_codes[bit + 224]);
-            }
-            for(int byte = 0; byte < 19; byte++){
-                char input = urbinput[byte + 2];
-                for(int bit = 0; bit < 8; bit++){
-                    int keybit = byte * 8 + bit;
-                    int scan = hid_codes[keybit];
-                    if((input >> bit) & 1){
-                        if(scan >= 0)
-                            SET_KEYBIT(kbinput, hid_codes[keybit]);
-                        else
-                            ckb_warn("Got unknown key press %d on EP 2\n", keybit);
-                    } else if(scan >= 0)
-                        CLEAR_KEYBIT(kbinput, hid_codes[keybit]);
-                }
-            }
-            break;
-        } else if (urbinput[0] == 2)
-            ; // Type 2: media key (implicitly falls through)
+        ///
+        /// The input data is transformed and copied to the kb structure. Now give it to the OS and unlock the imutex afterwards.
+        inputupdate(kb);
+        pthread_mutex_unlock(imutex(kb));
+    }
+}
+
+void handle_nkro_key_input(unsigned char* kbinput, const unsigned char* urbinput, int length, int legacy){
+    int start = !legacy; // Legacy packets start from 0x00, other ones start from 0x01
+    for(int bit = 0; bit < 8; bit++){
+        if((urbinput[start] >> bit) & 1)
+            SET_KEYBIT(kbinput, hid_codes[bit + 224]);
         else
-            break;  // No other known types
-        /* FALLTHRU */
-    case 2:
-        // EP 2 Non-RGB: media keys
-        CLEAR_KEYBIT(kbinput, 97);          // mute
-        CLEAR_KEYBIT(kbinput, 98);          // stop
-        CLEAR_KEYBIT(kbinput, 99);          // prev
-        CLEAR_KEYBIT(kbinput, 100);         // play
-        CLEAR_KEYBIT(kbinput, 101);         // next
-        CLEAR_KEYBIT(kbinput, 130);         // volup
-        CLEAR_KEYBIT(kbinput, 131);         // voldn
-        for(int i = 0; i < length; i++){
-            switch(urbinput[i]){
-            case 181:
-                SET_KEYBIT(kbinput, 101);   // next
-                break;
-            case 182:
-                SET_KEYBIT(kbinput, 99);    // prev
-                break;
-            case 183:
-                SET_KEYBIT(kbinput, 98);    // stop
-                break;
-            case 205:
-                SET_KEYBIT(kbinput, 100);   // play
-                break;
-            case 226:
-                SET_KEYBIT(kbinput, 97);    // mute
-                break;
-            case 233:
-                SET_KEYBIT(kbinput, 130);   // volup
-                break;
-            case 234:
-                SET_KEYBIT(kbinput, 131);   // voldn
-                break;
-            }
-        }
-        break;
-    case 3:
-        // EP 3 non-RGB: NKRO input
-        if(length != 15)
-            return;
+            CLEAR_KEYBIT(kbinput, hid_codes[bit + 224]);
+    }
+    int bytelen = (legacy ? 14 : 19);
+    for(int byte = 0; byte < bytelen; byte++){
+        char input = urbinput[start + byte + 1];
         for(int bit = 0; bit < 8; bit++){
-            if((urbinput[0] >> bit) & 1)
-                SET_KEYBIT(kbinput, hid_codes[bit + 224]);
-            else
-                CLEAR_KEYBIT(kbinput, hid_codes[bit + 224]);
+            int keybit = byte * 8 + bit;
+            int scan = hid_codes[keybit];
+            if((input >> bit) & 1){
+                if(scan >= 0)
+                    SET_KEYBIT(kbinput, hid_codes[keybit]);
+                else
+                    ckb_warn("Got unknown NKRO key press %d\n", keybit);
+            } else if(scan >= 0)
+                CLEAR_KEYBIT(kbinput, hid_codes[keybit]);
         }
-        for(int byte = 0; byte < 14; byte++){
-            char input = urbinput[byte + 1];
-            for(int bit = 0; bit < 8; bit++){
-                int keybit = byte * 8 + bit;
-                int scan = hid_codes[keybit];
-                if((input >> bit) & 1){
-                    if(scan >= 0)
-                        SET_KEYBIT(kbinput, hid_codes[keybit]);
-                    else
-                        ckb_warn("Got unknown key press %d on EP 3\n", keybit);
-                } else if(scan >= 0)
-                    CLEAR_KEYBIT(kbinput, hid_codes[keybit]);
-            }
+    }
+}
+void handle_nkro_media_keys(unsigned char* kbinput, const unsigned char* urbinput, int length){
+    // Media keys
+    CLEAR_KEYBIT(kbinput, 97);          // mute
+    CLEAR_KEYBIT(kbinput, 98);          // stop
+    CLEAR_KEYBIT(kbinput, 99);          // prev
+    CLEAR_KEYBIT(kbinput, 100);         // play
+    CLEAR_KEYBIT(kbinput, 101);         // next
+    CLEAR_KEYBIT(kbinput, 130);         // volup
+    CLEAR_KEYBIT(kbinput, 131);         // voldn
+    for(int i = 0; i < length; i++){
+        switch(urbinput[i]){
+        case 181:
+            SET_KEYBIT(kbinput, 101);   // next
+            break;
+        case 182:
+            SET_KEYBIT(kbinput, 99);    // prev
+            break;
+        case 183:
+            SET_KEYBIT(kbinput, 98);    // stop
+            break;
+        case 205:
+            SET_KEYBIT(kbinput, 100);   // play
+            break;
+        case 226:
+            SET_KEYBIT(kbinput, 97);    // mute
+            break;
+        case 233:
+            SET_KEYBIT(kbinput, 130);   // volup
+            break;
+        case 234:
+            SET_KEYBIT(kbinput, 131);   // voldn
+            break;
         }
-        break;
+    }
+}
+
+void hid_kb_translate(unsigned char* kbinput, int length, const unsigned char* urbinput, int legacy){
+    if(legacy) {
+        if(length == 4) // Media Keys
+            handle_nkro_media_keys(kbinput, urbinput, length);
+        else if(length == 15) // NKRO Input
+            handle_nkro_key_input(kbinput, urbinput, length, legacy);
+        else
+            ckb_warn("Got unknown legacy data\n");
+    } else {
+        if(urbinput[0] == 0x01)
+            handle_nkro_key_input(kbinput, urbinput, length, legacy);
+         else if (urbinput[0] == 0x02)
+            handle_nkro_media_keys(kbinput, urbinput, length);
+        else
+            ckb_warn("Got unknown data\n");
     }
 }
 
 #define BUTTON_HID_COUNT    5
 
-void hid_mouse_translate(unsigned char* kbinput, short* xaxis, short* yaxis, int endpoint, int length, const unsigned char* urbinput, void* context){
-    usbdevice* kb = context;
-    //The HID Input Endpoint on FWv3 is 64 bytes, so we can't check for length.
-    if((endpoint != 2 && endpoint != -2) || (kb->fwversion < 0x300 && !IS_V3_OVERRIDE(kb) && length < 10))
-        return;
-    // EP 2: mouse input
-    if(urbinput[0] != 1)
-        return;
+void hid_mouse_translate(unsigned char* kbinput, short* xaxis, short* yaxis, int length, const unsigned char* urbinput){
     // Byte 1 = mouse buttons (bitfield)
     for(int bit = 0; bit < BUTTON_HID_COUNT; bit++){
         if(urbinput[1] & (1 << bit))
@@ -439,21 +467,12 @@ void hid_mouse_translate(unsigned char* kbinput, short* xaxis, short* yaxis, int
         CLEAR_KEYBIT(kbinput, MOUSE_EXTRA_FIRST + 1);
 }
 
-void corsair_kbcopy(unsigned char* kbinput, int endpoint, const unsigned char* urbinput){
-    if(endpoint == 2 || endpoint == -2){
-        if(urbinput[0] != 3)
-            return;
-        urbinput++;
-    }
+void corsair_kbcopy(unsigned char* kbinput, const unsigned char* urbinput){
     memcpy(kbinput, urbinput, N_KEYBYTES_HW);
 }
 
-void corsair_mousecopy(unsigned char* kbinput, int endpoint, const unsigned char* urbinput){
-    if(endpoint == 2 || endpoint == -2){
-        if(urbinput[0] != 3)
-            return;
-        urbinput++;
-    }
+void corsair_mousecopy(unsigned char* kbinput, const unsigned char* urbinput){
+    urbinput++;
     for(int bit = BUTTON_HID_COUNT; bit < N_BUTTONS_HW; bit++){
         int byte = bit / 8;
         uchar test = 1 << (bit % 8);

--- a/src/daemon/keymap.h
+++ b/src/daemon/keymap.h
@@ -66,14 +66,16 @@ typedef struct {
 // List of keys, ordered according to where they appear in the keyboard input.
 // Begins with keyboard keys, followed by extra keys, then mouse buttons, and finally LED zones
 extern const key keymap[N_KEYS_EXTENDED];
+// Decides which of the following functions it needs to call
+void process_input_urb(void* context, unsigned char* buffer, int urblen, ushort ep);
 
 // Translates input from HID to a ckb input bitfield.
 // Use positive endpoint for non-RGB keyboards, negative endpoint for RGB
-void hid_kb_translate(unsigned char* kbinput, int endpoint, int length, const unsigned char* urbinput);
-void hid_mouse_translate(unsigned char* kbinput, short* xaxis, short* yaxis, int endpoint, int length, const unsigned char* urbinput, void* context);
+void hid_kb_translate(unsigned char* kbinput, int length, const unsigned char* urbinput, int legacy);
+void hid_mouse_translate(unsigned char* kbinput, short* xaxis, short* yaxis, int length, const unsigned char* urbinput);
 
 // Copies input from Corsair reports
-void corsair_kbcopy(unsigned char* kbinput, int endpoint, const unsigned char* urbinput);
-void corsair_mousecopy(unsigned char* kbinput, int endpoint, const unsigned char* urbinput);
+void corsair_kbcopy(unsigned char* kbinput, const unsigned char* urbinput);
+void corsair_mousecopy(unsigned char* kbinput, const unsigned char* urbinput);
 
 #endif // KEYMAP_H

--- a/src/daemon/protocol.h
+++ b/src/daemon/protocol.h
@@ -51,7 +51,7 @@
 #define COLOR_GREEN    0x02 // The green channel of RGB.
 #define COLOR_BLUE     0x03 // The blue channel of RGB.
 
-// HID input commnads
+// HID input commands
 // Keyboards
 #define NKRO_KEY_IN    0x01 // NKRO key input
 #define NKRO_MEDIA_IN  0x02 // NKRO media key input

--- a/src/daemon/protocol.h
+++ b/src/daemon/protocol.h
@@ -51,3 +51,11 @@
 #define COLOR_GREEN    0x02 // The green channel of RGB.
 #define COLOR_BLUE     0x03 // The blue channel of RGB.
 
+// HID input commnads
+// Keyboards
+#define NKRO_KEY_IN    0x01 // NKRO key input
+#define NKRO_MEDIA_IN  0x02 // NKRO media key input
+// Mice
+#define MOUSE_IN       0x01 // Standard HID mouse input (Position/Buttons)
+// Common
+#define CORSAIR_IN     0x03 // Corsair input. Doesn't apply to FW v1.15 on first gen devices.

--- a/src/daemon/usb.c
+++ b/src/daemon/usb.c
@@ -296,7 +296,7 @@ static void* _setupusb(void* context){
     if(IS_MONOCHROME(vendor, product)) kb->features |= FEAT_MONOCHROME;
     kb->usbdelay = USB_DELAY_DEFAULT;
 
-    /// Allocate memory for the os_usbrecv() buffer and create the mutex
+    /// Allocate memory for the os_usbrecv() buffer
     kb->interruptbuf = malloc(MSG_SIZE * sizeof(uchar));
     if(!kb->interruptbuf)
         ckb_fatal("Error allocating memory for usb_recv() %s\n", strerror(errno));
@@ -777,4 +777,15 @@ int closeusb(usbdevice* kb){
     kb->vtable->freeprofile(kb);
     memset(kb, 0, sizeof(usbdevice));
     return 0;
+}
+
+/// Formats and writes the current urb buffer to the console
+void print_urb_buffer(const char* prefix, const unsigned char* buffer, int actual_length, const char* file, int line, const char* function, int devnum){
+    char converted[actual_length * 3 + 1];
+    for(int i = 0; i < actual_length; i++)
+        sprintf(&converted[i * 3], "%02x ", buffer[i]);
+    if(line == 0)
+        ckb_info("ckb%i %s %s\n", devnum, prefix, converted);
+    else
+        ckb_info("ckb%i %s (via %s:%d) %s %s\n", devnum, function, file, line, prefix, converted);
 }

--- a/src/daemon/usb.h
+++ b/src/daemon/usb.h
@@ -364,4 +364,6 @@ int _nk95cmd(usbdevice* kb, uchar bRequest, ushort wValue, const char* file, int
 /// \return 0 on success, -1 otherwise
 int usb_tryreset(usbdevice* kb);
 
+void print_urb_buffer(const char* prefix, const unsigned char* buffer, int actual_length, const char* file, int line, const char* function, int devnum);
+
 #endif  // USB_H

--- a/src/daemon/usb_mac.c
+++ b/src/daemon/usb_mac.c
@@ -782,8 +782,7 @@ static usbdevice* add_hid(hid_dev_t handle, io_object_t** rm_notify){
             ckb_warn("Got unknown V3 handle (I: %d, O: %d, F: %d)\n", (int)input, (int)output, (int)feature);
             return 0;
         }
-    }
-    else if(IS_SINGLE_EP(&fakekb)) { // ST100 might be different 
+    } else if(IS_SINGLE_EP(&fakekb)) { // ST100 might be different
         if(feature == 64)
             handle_idx = 0;
         else if(input == 6)

--- a/src/daemon/usb_mac.c
+++ b/src/daemon/usb_mac.c
@@ -103,32 +103,28 @@ static int get_pipe_index(usb_iface_t handle, int desired_direction){
 
 int os_usbsend(usbdevice* kb, const uchar* out_msg, int is_recv, const char* file, int line){
     kern_return_t res = kIOReturnSuccess;
-    ///
-    /// \todo Be aware: This condition is exact inverted to the condition in the linux dependent os_usbsend(). It may be correct, but please check it.
-    if((kb->fwversion < 0x120 && !IS_V2_OVERRIDE(kb)) || is_recv){
-        int ep = kb->epcount;
-        // For old devices, or for receiving data, use control transfers
-        IOUSBDevRequestTO rq = { 0x21, 0x09, 0x0200, ep - 1, MSG_SIZE, (void*)out_msg, 0, 5000, 5000 };
-        res = (*kb->handle)->DeviceRequestTO(kb->handle, &rq);
-        if(res == kIOReturnNotOpen){
-            // Device handle not open - try to send directly to the endpoint instead
-            usb_iface_t h_usb = kb->ifusb[ep - 1];
-            hid_dev_t h_hid = kb->ifhid[ep - 1];
-            if(h_usb)
-                res = (*h_usb)->ControlRequestTO(h_usb, 0, &rq);
-            else if(h_hid)
-                res = (*h_hid)->setReport(h_hid, kIOHIDReportTypeFeature, 0, out_msg, MSG_SIZE, 5000, 0, 0, 0);
-        }
-    } else {
-        // For newer devices, use interrupt transfers
-        // macOS sees 4 endpoints (including ep0) for FW 3.XX
-        int ep = (IS_SINGLE_EP(kb) ? 4 : (kb->fwversion >= 0x130 && (kb->fwversion < 0x200 || kb->fwversion >= 0x300 || IS_V3_OVERRIDE(kb))) ? 4 : 3);
-        usb_iface_t h_usb = kb->ifusb[ep - 1];
-        hid_dev_t h_hid = kb->ifhid[ep - 1];
+
+    if (kb->fwversion >= 0x120 || IS_V2_OVERRIDE(kb)){
+        int ep = (kb->fwversion >= 0x300 || IS_V3_OVERRIDE(kb)) ? 1 : (IS_SINGLE_EP(kb) ? 0 : 2);
+        usb_iface_t h_usb = kb->ifusb[ep];
+        hid_dev_t h_hid = kb->ifhid[ep];
+
+        if(is_recv)
+            if(pthread_mutex_lock(intmutex(kb)))
+                ckb_fatal("Error locking interrupt mutex in os_usbsend()\n");
+
+        // Try sending an interrupt, and if that fails, fall back to setReport through the HID driver.
+        // Needed for single EP devices.
         if(h_usb)
             res = (*h_usb)->WritePipe(h_usb, get_pipe_index(h_usb, kUSBOut), (void*)out_msg, MSG_SIZE);
         else if(h_hid)
             res = (*h_hid)->setReport(h_hid, kIOHIDReportTypeOutput, 0, out_msg, MSG_SIZE, 5000, 0, 0, 0);
+        else
+            return 0;
+    } else {
+        // All devices that call this will have the exact same EP configuration.
+        IOUSBDevRequestTO rq = { 0x21, 0x09, 0x0200, 3, MSG_SIZE, (void*)out_msg, 0, 5000, 5000 };
+        res = (*kb->handle)->DeviceRequestTO(kb->handle, &rq);
     }
     kb->lastresult = res;
     if(res != kIOReturnSuccess){
@@ -138,24 +134,48 @@ int os_usbsend(usbdevice* kb, const uchar* out_msg, int is_recv, const char* fil
         else
             return 0;
     }
+
+#ifdef DEBUG_USB_SEND
+    print_urb_buffer("Sent:", out_msg, MSG_SIZE, file, line, __func__);
+#endif
+
     return MSG_SIZE;
 }
 
 int os_usbrecv(usbdevice* kb, uchar* in_msg, const char* file, int line){
-    int ep = kb->epcount;
-    IOUSBDevRequestTO rq = { 0xa1, 0x01, 0x0200, ep - 1, MSG_SIZE, in_msg, 0, 5000, 5000 };
-    kern_return_t res = (*kb->handle)->DeviceRequestTO(kb->handle, &rq);
-    CFIndex length = rq.wLenDone;
-    if(res == kIOReturnNotOpen){
-        // Device handle not open - try to send directly to the endpoint instead
-        usb_iface_t h_usb = kb->ifusb[ep - 1];
-        hid_dev_t h_hid = kb->ifhid[ep - 1];
-        if(h_usb)
-            res = (*h_usb)->ControlRequestTO(h_usb, 0, &rq);
-        else if(h_hid)
-            res = (*h_hid)->getReport(h_hid, kIOHIDReportTypeFeature, 0, in_msg, &length, 5000, 0, 0, 0);
+    UInt32 length = 0;
+    kern_return_t res = -1;
+
+    // Read the data from the input thread
+    if((kb->fwversion >= 0x120 || IS_V2_OVERRIDE(kb))) {
+        struct timespec condwait = {0, 0};
+        // Wait for 2s
+        condwait.tv_sec = time(NULL) + 2;
+        int condret = pthread_cond_timedwait(intcond(kb), intmutex(kb), &condwait);
+        if(condret != 0){
+            if(pthread_mutex_unlock(intmutex(kb)))
+                ckb_fatal("Error unlocking interrupt mutex in os_usbrecv()\n");
+            ckb_warn_fn("Interrupt cond error %i\n", file, line, condret);
+            return -1;
+        }
+        memcpy(in_msg, kb->interruptbuf, MSG_SIZE);
+        memset(kb->interruptbuf, 0, MSG_SIZE);
+        if(pthread_mutex_unlock(intmutex(kb)))
+            ckb_fatal("Error unlocking interrupt mutex in os_usbrecv()\n");
+
+#ifdef DEBUG_USB_RECV
+        print_urb_buffer("Recv:", in_msg, MSG_SIZE, file, line, __func__);
+#endif
+        return MSG_SIZE;
     }
+
+    // If we haven't returned yet,
+    // try to read the data directly for older firmware
+    IOUSBDevRequestTO rq = { 0xa1, 0x01, 0x0200, 3, MSG_SIZE, in_msg, 0, 5000, 5000 };
+    res = (*kb->handle)->DeviceRequestTO(kb->handle, &rq);
+    length = rq.wLenDone;
     kb->lastresult = res;
+
     if(res != kIOReturnSuccess){
         ckb_err_fn("Got return value 0x%x\n", file, line, res);
         if(IS_TEMP_FAILURE(res))
@@ -164,7 +184,11 @@ int os_usbrecv(usbdevice* kb, uchar* in_msg, const char* file, int line){
             return 0;
     }
     if(length != MSG_SIZE)
-        ckb_err_fn("Read %ld bytes (expected %d)\n", file, line, length, MSG_SIZE);
+        ckb_err_fn("Read %u bytes (expected %d)\n", file, line, length, MSG_SIZE);
+
+#ifdef DEBUG_USB_RECV
+    print_urb_buffer("Recv:", in_msg, MSG_SIZE, file, line, __func__);
+#endif
     return length;
 }
 
@@ -179,44 +203,31 @@ int _nk95cmd(usbdevice* kb, uchar bRequest, ushort wValue, const char* file, int
 }
 
 void os_sendindicators(usbdevice* kb){
-    void *ileds;
-    ushort leds;
-    if(kb->fwversion >= 0x300 || IS_V3_OVERRIDE(kb)) {
-        leds = (kb->ileds << 8) | 0x0001;
-        ileds = &leds;
-    }
-    else {
-        ileds = &kb->ileds;
-    }
-    IOUSBDevRequestTO rq = { 0x21, 0x09, 0x0200, 0x00, ((kb->fwversion >= 0x300 || IS_V3_OVERRIDE(kb)) ? 2 : 1), ileds, 0, 500, 500 };
-    kern_return_t res = (*kb->handle)->DeviceRequestTO(kb->handle, &rq);
-    if(res == kIOReturnNotOpen){
-        // Handle not open - try to go through the HID system instead
-        hid_dev_t handle = kb->ifhid[0];
-        if(handle){
-            uchar ileds = kb->ileds;
-            // Get a list of LED elements from handle 0
-            long ledpage = kHIDPage_LEDs;
-            const void* keys[] = { CFSTR(kIOHIDElementUsagePageKey) };
-            const void* values[] = { CFNumberCreate(kCFAllocatorDefault, kCFNumberLongType, &ledpage) };
-            CFDictionaryRef matching = CFDictionaryCreate(kCFAllocatorDefault, keys, values, 1, &kCFTypeDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks);
-            CFRelease(values[0]);
-            CFArrayRef leds;
-            kern_return_t res = (*handle)->copyMatchingElements(handle, matching, &leds, 0);
-            CFRelease(matching);
-            if(res != kIOReturnSuccess)
-                return;
-            // Iterate through them and update the LEDs which have changed
-            CFIndex count = CFArrayGetCount(leds);
-            for(CFIndex i = 0; i < count; i++){
-                IOHIDElementRef led = (void*)CFArrayGetValueAtIndex(leds, i);
-                uint32_t usage = IOHIDElementGetUsage(led);
-                IOHIDValueRef value = IOHIDValueCreateWithIntegerValue(kCFAllocatorDefault, led, 0, !!(ileds & (1 << (usage - 1))));
-                (*handle)->setValue(handle, led, value, 5000, 0, 0, 0);
-                CFRelease(value);
-            }
-            CFRelease(leds);
+    hid_dev_t handle = kb->ifhid[0];
+    kern_return_t res = 0;
+    if(handle){
+        uchar ileds = kb->ileds;
+        // Get a list of LED elements from handle 0
+        long ledpage = kHIDPage_LEDs;
+        const void* keys[] = { CFSTR(kIOHIDElementUsagePageKey) };
+        const void* values[] = { CFNumberCreate(kCFAllocatorDefault, kCFNumberLongType, &ledpage) };
+        CFDictionaryRef matching = CFDictionaryCreate(kCFAllocatorDefault, keys, values, 1, &kCFTypeDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks);
+        CFRelease(values[0]);
+        CFArrayRef leds;
+        res = (*handle)->copyMatchingElements(handle, matching, &leds, 0);
+        CFRelease(matching);
+        if(res != kIOReturnSuccess)
+            return;
+        // Iterate through them and update the LEDs which have changed
+        CFIndex count = CFArrayGetCount(leds);
+        for(CFIndex i = 0; i < count; i++){
+            IOHIDElementRef led = (void*)CFArrayGetValueAtIndex(leds, i);
+            uint32_t usage = IOHIDElementGetUsage(led);
+            IOHIDValueRef value = IOHIDValueCreateWithIntegerValue(kCFAllocatorDefault, led, 0, !!(ileds & (1 << (usage - 1))));
+            (*handle)->setValue(handle, led, value, 5000, 0, 0, 0);
+            CFRelease(value);
         }
+        CFRelease(leds);
     }
     if(res != kIOReturnSuccess)
         ckb_err("Got return value 0x%x\n", res);
@@ -233,55 +244,10 @@ int os_resetusb(usbdevice* kb, const char* file, int line){
 }
 
 static void intreport(void* context, IOReturn result, void* sender, IOHIDReportType reporttype, uint32_t reportid, uint8_t* data, CFIndex length){
-    usbdevice* kb = context;
-    pthread_mutex_lock(imutex(kb));
-    if(IS_MOUSE(kb->vendor, kb->product)){
-        switch(length){
-        case 7:
-        case 8:
-        case 10:
-        case 11:
-            hid_mouse_translate(kb->input.keys, &kb->input.rel_x, &kb->input.rel_y, -2, length, data, kb);
-            break;
-        case MSG_SIZE:
-            corsair_mousecopy(kb->input.keys, kb->epcount >= 4 ? -3 : -2, data);
-            break;
-        }
-    } else if(HAS_FEATURES(kb, FEAT_RGB)){
-        switch(length){
-        case 8:
-            // RGB EP 1: 6KRO (BIOS mode) input
-            hid_kb_translate(kb->input.keys, -1, length, data);
-            break;
-        case 21:
-        case 5:
-            // RGB EP 2: NKRO (non-BIOS) input. Accept only if keyboard is inactive
-            if(!kb->active)
-                hid_kb_translate(kb->input.keys, -2, length, data);
-            break;
-        case MSG_SIZE:
-            // RGB EP 3: Corsair input
-            corsair_kbcopy(kb->input.keys, kb->epcount >= 4 ? -3 : -2, data);
-            break;
-        }
-    } else {
-        switch(length){
-        case 8:
-            // Non-RGB EP 1: 6KRO input
-            hid_kb_translate(kb->input.keys, 1, length, data);
-            break;
-        case 4:
-            // Non-RGB EP 2: media keys
-            hid_kb_translate(kb->input.keys, 2, length, data);
-            break;
-        case 15:
-            // Non-RGB EP 3: NKRO input
-            hid_kb_translate(kb->input.keys, 3, length, data);
-            break;
-        }
-    }
-    inputupdate(kb);
-    pthread_mutex_unlock(imutex(kb));
+#ifdef DEBUG_USB_INPUT
+    print_urb_buffer("Input Recv:", data, length, NULL, 0, NULL);
+#endif
+    process_input_urb(context, data, length, 0);
 }
 
 typedef struct {
@@ -408,8 +374,9 @@ extern void keyretrigger(CFRunLoopTimerRef timer, void* info);
 
 void* os_inputmain(void* context){
     usbdevice* kb = context;
+
     int index = INDEX_OF(kb, keyboard);
-    // Monitor input transfers on all endpoints for non-RGB devices
+    // Monitor input transfers on all endpoints for non-legacy devices
     // For RGB, monitor all but the last, as it's used for input/output
     int count = IS_LEGACY_DEV(kb) ? kb->epcount : (kb->epcount - 1);
     // Schedule async events for the device on this thread
@@ -495,6 +462,11 @@ int os_setupusb(usbdevice* kb){
     kb->lastkeypress = KEY_NONE;
     // Get the device firmware version
     (*kb->handle)->GetDeviceReleaseNumber(kb->handle, &kb->fwversion);
+#ifdef DEBUG
+    int devnode = INDEX_OF(kb, keyboard);
+    ckb_info("ckb%i USB handles: 0: %p, 1: %p, 2:%p, 3: %p\n", devnode, kb->ifusb[0], kb->ifusb[1], kb->ifusb[2], kb->ifusb[3]);
+    ckb_info("ckb%i HID handles: 0: %p, 1: %p, 2:%p, 3: %p\n", devnode, kb->ifhid[0], kb->ifhid[1], kb->ifhid[2], kb->ifhid[3]);
+#endif
     return 0;
 }
 
@@ -700,6 +672,9 @@ static usbdevice* add_usb(usb_dev_t handle, io_object_t** rm_notify){
         err = (*if_handle)->USBInterfaceOpenSeize(if_handle);   // no wait_loop here because this is expected to fail
         if(err == kIOReturnSuccess){
             kb->ifusb[iface_count] = if_handle;
+#ifdef DEBUG
+            ckb_info("Adding USB handle with id %i\n", iface_count);
+#endif
             iface_success++;
             // Register for removal notification
             IOServiceAddInterestNotification(notify, iface, kIOGeneralInterest, remove_device, kb, kb->rm_notify + 1 + iface_count);
@@ -795,38 +770,58 @@ static usbdevice* add_hid(hid_dev_t handle, io_object_t** rm_notify){
     fakekb.vendor = idvendor;
     fakekb.product = idproduct;
 
-    // Handle 3 is for controlling the device (only exists for RGB)
-    if(feature == 64)
-        handle_idx = 3;
-    // Handle 2 is for Corsair inputs, unused on non-RGB
-    else if(feature == 0 &&
-            (((input == 64 ||
-               input == 15) && output == 0) ||
-            (input == 64 && output == 64) ||    // FW >= 1.20
-            (input <= 1 && output == 64)))      // FW >= 2.00 (Scimitar)
-        handle_idx = 2;
-    // Handle 0 is for BIOS mode input (RGB) or non-RGB key input
-    else if((output <= 1 && feature <= 1 &&
-                (input == 8 ||                  // Keyboards
-                 input == 7)) ||                // Mice
-            ((fwversion >= 0x300 ||             // FWv3 hack
-                IS_V3_OVERRIDE(&fakekb)) &&
-                input == 64 &&
-                output <= 2 &&
-                feature == 1))
-        handle_idx = 0;
-    // Handle 1 is for standard HID input (RGB) or media keys (non-RGB)
-    else if(output <= 1 && feature <= 1 &&
-            (input == 21 || input == 10 ||
-             input == 4 ||
-             input == 6 ||                      // Polaris' keyboard handle
-             input == 64))                      // FW >= 2.00 (Scimitar)
-        handle_idx = 1;
-    else {
-        ckb_warn("Got unknown handle (I: %d, O: %d, F: %d)\n", (int)input, (int)output, (int)feature);
-        return 0;
+    // This is getting unmaintainable now...
+    // These values can be obtained by dumping the *HID* descriptor of each interface and parsing it.
+    // It's the Report Count field for Input/Output/Feature reports
+    if(IS_V3_OVERRIDE(&fakekb) || fwversion >= 0x300) {
+        if(feature == 64)
+            handle_idx = 1;
+        else if(input == 64 && output <= 2 && feature == 1)
+            handle_idx = 0;
+        else {
+            ckb_warn("Got unknown V3 handle (I: %d, O: %d, F: %d)\n", (int)input, (int)output, (int)feature);
+            return 0;
+        }
     }
-
+    else if(IS_SINGLE_EP(&fakekb)) { // ST100 might be different 
+        if(feature == 64)
+            handle_idx = 0;
+        else if(input == 6)
+            handle_idx = 1; // This one is most likely useless
+        else {
+            ckb_warn("Got unknown SINGLE_EP handle (I: %d, O: %d, F: %d)\n", (int)input, (int)output, (int)feature);
+            return 0;
+        }
+    } else {
+        // Handle 3 is for controlling the device (only exists for RGB)
+        if(feature == 64)
+            handle_idx = 3;
+        // Handle 2 is for Corsair inputs, unused on non-RGB
+        else if(feature == 0 &&
+                (((input == 64 ||
+                   input == 15) && output == 0) ||
+                (input == 64 && output == 64) ||    // FW >= 1.20
+                (input <= 1 && output == 64)))      // FW >= 2.00 (Scimitar)
+            handle_idx = 2;
+        // Handle 0 is for BIOS mode input (RGB) or non-RGB key input
+        else if((output <= 1 && feature <= 1 &&
+                    (input == 8 ||                  // Keyboards
+                     input == 7)))               // Mice
+            handle_idx = 0;
+        // Handle 1 is for standard HID input (RGB) or media keys (non-RGB)
+        else if(output <= 1 && feature <= 1 &&
+                (input == 21 || input == 10 ||
+                 input == 4 ||
+                 input == 64))                      // FW >= 2.00 (Scimitar)
+            handle_idx = 1;
+        else {
+            ckb_warn("Got unknown handle (I: %d, O: %d, F: %d)\n", (int)input, (int)output, (int)feature);
+            return 0;
+        }
+    }
+#ifdef DEBUG
+        ckb_info("Adding HID handle with id %i\n", handle_idx);
+#endif
     // Use the location ID key to group the handles together
     uint32_t location = hidgetlong(handle, CFSTR(kIOHIDLocationIDKey));
     int index = find_device(idvendor, idproduct, location, handle_idx + 1);

--- a/src/daemon/usb_mac.c
+++ b/src/daemon/usb_mac.c
@@ -376,8 +376,8 @@ void* os_inputmain(void* context){
     usbdevice* kb = context;
 
     int index = INDEX_OF(kb, keyboard);
-    // Monitor input transfers on all endpoints for non-legacy devices
-    // For RGB, monitor all but the last, as it's used for input/output
+    // Monitor input transfers on all endpoints for legacy devices
+    // For non legacy ones, monitor all but the last, as it's used for input/output
     int count = IS_LEGACY_DEV(kb) ? kb->epcount : (kb->epcount - 1);
     // Schedule async events for the device on this thread
     CFRunLoopRef runloop = kb->input_loop = CFRunLoopGetCurrent();


### PR DESCRIPTION
Now mac and linux input code is shared.
Input logic has been moved to keymap.c and functions have been split.

macOS USB code was also necessarily modified to handle interrupts as handled by the shared input code.