### PR TITLE
Add GUI start delay

### DIFF
--- a/src/gui/extrasettingswidget.cpp
+++ b/src/gui/extrasettingswidget.cpp
@@ -68,6 +68,9 @@ ExtraSettingsWidget::ExtraSettingsWidget(QWidget *parent) :
     bool macroDelay = settings.value("MacroDelay").toBool();
     Kb::macroDelay(macroDelay);
     ui->delayBox->setChecked(macroDelay);
+
+    // Read start delay
+    ui->startDelayBox->setChecked(settings.value("StartDelay").toBool());
 }
 
 ExtraSettingsWidget::~ExtraSettingsWidget(){
@@ -140,7 +143,11 @@ void ExtraSettingsWidget::on_sSpeedBox_valueChanged(int arg1){
     Kb::scrollSpeed(ui->sAccelBox->isChecked() ? arg1 : 0);
 }
 
-void ExtraSettingsWidget::on_delayBox_clicked(bool checked) {
+void ExtraSettingsWidget::on_delayBox_clicked(bool checked){
     CkbSettings::set("Program/MacroDelay", checked);
     Kb::macroDelay(checked);
+}
+
+void ExtraSettingsWidget::on_startDelayBox_clicked(bool checked){
+    CkbSettings::set("Program/StartDelay", checked);
 }

--- a/src/gui/extrasettingswidget.h
+++ b/src/gui/extrasettingswidget.h
@@ -23,11 +23,11 @@ private slots:
     void on_animScanButton_clicked();
     void on_fpsBox_valueChanged(int arg1);
     void on_ditherBox_clicked(bool checked);
-
     void on_mAccelBox_clicked(bool checked);
     void on_sAccelBox_clicked(bool checked);
     void on_sSpeedBox_valueChanged(int arg1);
     void on_delayBox_clicked(bool checked);
+    void on_startDelayBox_clicked(bool checked);
 
 private:
     Ui::ExtraSettingsWidget *ui;

--- a/src/gui/extrasettingswidget.ui
+++ b/src/gui/extrasettingswidget.ui
@@ -14,7 +14,98 @@
    <string>Application Settings</string>
   </property>
   <layout class="QGridLayout" name="gridLayout">
-   <item row="12" column="2">
+   <item row="14" column="5">
+    <widget class="QLabel" name="fpsWarnLabel">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="text">
+      <string>Warning: high frame rates may cause stability issues</string>
+     </property>
+    </widget>
+   </item>
+   <item row="19" column="0" colspan="7">
+    <widget class="Line" name="osxLine">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+    </widget>
+   </item>
+   <item row="16" column="1" colspan="6">
+    <widget class="QCheckBox" name="delayBox">
+     <property name="toolTip">
+      <string>When using macros with strings longer than 25 chars, some OS may lose characters (e.g. Mint 17.2). Select to prevent that bug.</string>
+     </property>
+     <property name="text">
+      <string>Use delay for very long macros</string>
+     </property>
+    </widget>
+   </item>
+   <item row="14" column="6">
+    <spacer name="horizontalSpacer">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>40</width>
+       <height>20</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item row="10" column="1">
+    <spacer name="verticalSpacer_6">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeType">
+      <enum>QSizePolicy::Fixed</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>10</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item row="6" column="1">
+    <spacer name="verticalSpacer_5">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeType">
+      <enum>QSizePolicy::Fixed</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>10</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item row="21" column="0">
+    <spacer name="verticalSpacer_11">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeType">
+      <enum>QSizePolicy::Fixed</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>0</width>
+       <height>28</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item row="14" column="2">
     <spacer name="horizontalSpacer_2">
      <property name="orientation">
       <enum>Qt::Horizontal</enum>
@@ -30,8 +121,130 @@
      </property>
     </spacer>
    </item>
-   <item row="2" column="0">
-    <spacer name="verticalSpacer">
+   <item row="12" column="0" colspan="7">
+    <widget class="Line" name="line_2">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+    </widget>
+   </item>
+   <item row="22" column="5">
+    <spacer name="verticalSpacer_2">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>40</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item row="7" column="0" colspan="7">
+    <widget class="QLabel" name="label_5">
+     <property name="font">
+      <font>
+       <weight>75</weight>
+       <bold>true</bold>
+      </font>
+     </property>
+     <property name="text">
+      <string>Animation scripts</string>
+     </property>
+    </widget>
+   </item>
+   <item row="18" column="0" colspan="7">
+    <widget class="QLabel" name="osxLabel">
+     <property name="font">
+      <font>
+       <weight>75</weight>
+       <bold>true</bold>
+      </font>
+     </property>
+     <property name="text">
+      <string>OS X tweaks</string>
+     </property>
+    </widget>
+   </item>
+   <item row="14" column="4">
+    <spacer name="horizontalSpacer_3">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="sizeType">
+      <enum>QSizePolicy::Fixed</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>10</width>
+       <height>20</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item row="9" column="1">
+    <widget class="QLabel" name="label_6">
+     <property name="text">
+      <string>Location:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="14" column="3">
+    <widget class="QSpinBox" name="fpsBox">
+     <property name="minimum">
+      <number>5</number>
+     </property>
+     <property name="maximum">
+      <number>60</number>
+     </property>
+     <property name="value">
+      <number>30</number>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="0" colspan="7">
+    <widget class="Line" name="line">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="1" colspan="6">
+    <widget class="QCheckBox" name="trayBox">
+     <property name="toolTip">
+      <string>The tray icon will not be displayed. The application will still run in the background; re-launch the app to see the GUI again.</string>
+     </property>
+     <property name="text">
+      <string>Hide tray icon</string>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="0" colspan="7">
+    <widget class="QLabel" name="label">
+     <property name="font">
+      <font>
+       <weight>75</weight>
+       <bold>true</bold>
+      </font>
+     </property>
+     <property name="text">
+      <string>Behavior</string>
+     </property>
+    </widget>
+   </item>
+   <item row="3" column="1" colspan="6">
+    <widget class="QCheckBox" name="brightnessBox">
+     <property name="toolTip">
+      <string>By default, the same brightness level will be applied to all profiles and all devices. Enable this to store it with the lighting mode instead.</string>
+     </property>
+     <property name="text">
+      <string>Set brightness per-mode</string>
+     </property>
+    </widget>
+   </item>
+   <item row="14" column="0">
+    <spacer name="verticalSpacer_9">
      <property name="orientation">
       <enum>Qt::Vertical</enum>
      </property>
@@ -62,166 +275,14 @@
      </property>
     </spacer>
    </item>
-   <item row="19" column="5">
-    <spacer name="verticalSpacer_2">
-     <property name="orientation">
-      <enum>Qt::Vertical</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>20</width>
-       <height>40</height>
-      </size>
-     </property>
-    </spacer>
-   </item>
-   <item row="12" column="5">
-    <widget class="QLabel" name="fpsWarnLabel">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-     <property name="text">
-      <string>Warning: high frame rates may cause stability issues</string>
-     </property>
-    </widget>
-   </item>
-   <item row="12" column="4">
-    <spacer name="horizontalSpacer_3">
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
-     </property>
-     <property name="sizeType">
-      <enum>QSizePolicy::Fixed</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>10</width>
-       <height>20</height>
-      </size>
-     </property>
-    </spacer>
-   </item>
-   <item row="12" column="1">
+   <item row="14" column="1">
     <widget class="QLabel" name="label_3">
      <property name="text">
       <string>Frame rate (FPS):</string>
      </property>
     </widget>
    </item>
-   <item row="12" column="3">
-    <widget class="QSpinBox" name="fpsBox">
-     <property name="minimum">
-      <number>5</number>
-     </property>
-     <property name="maximum">
-      <number>60</number>
-     </property>
-     <property name="value">
-      <number>30</number>
-     </property>
-    </widget>
-   </item>
-   <item row="7" column="0">
-    <spacer name="verticalSpacer_4">
-     <property name="orientation">
-      <enum>Qt::Vertical</enum>
-     </property>
-     <property name="sizeType">
-      <enum>QSizePolicy::Fixed</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>0</width>
-       <height>28</height>
-      </size>
-     </property>
-    </spacer>
-   </item>
-   <item row="12" column="0">
-    <spacer name="verticalSpacer_9">
-     <property name="orientation">
-      <enum>Qt::Vertical</enum>
-     </property>
-     <property name="sizeType">
-      <enum>QSizePolicy::Fixed</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>0</width>
-       <height>28</height>
-      </size>
-     </property>
-    </spacer>
-   </item>
-   <item row="7" column="1">
-    <widget class="QLabel" name="label_6">
-     <property name="text">
-      <string>Location:</string>
-     </property>
-    </widget>
-   </item>
-   <item row="8" column="1">
-    <spacer name="verticalSpacer_6">
-     <property name="orientation">
-      <enum>Qt::Vertical</enum>
-     </property>
-     <property name="sizeType">
-      <enum>QSizePolicy::Fixed</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>20</width>
-       <height>10</height>
-      </size>
-     </property>
-    </spacer>
-   </item>
-   <item row="4" column="1">
-    <spacer name="verticalSpacer_5">
-     <property name="orientation">
-      <enum>Qt::Vertical</enum>
-     </property>
-     <property name="sizeType">
-      <enum>QSizePolicy::Fixed</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>20</width>
-       <height>10</height>
-      </size>
-     </property>
-    </spacer>
-   </item>
-   <item row="18" column="1" colspan="4">
-    <widget class="QCheckBox" name="sAccelBox">
-     <property name="toolTip">
-      <string>Try this if you're having problems with the scroll wheel.</string>
-     </property>
-     <property name="text">
-      <string>Disable scroll acceleration</string>
-     </property>
-    </widget>
-   </item>
-   <item row="14" column="1">
-    <spacer name="verticalSpacer_7">
-     <property name="orientation">
-      <enum>Qt::Vertical</enum>
-     </property>
-     <property name="sizeType">
-      <enum>QSizePolicy::Fixed</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>20</width>
-       <height>10</height>
-      </size>
-     </property>
-    </spacer>
-   </item>
-   <item row="13" column="0">
+   <item row="15" column="0">
     <spacer name="verticalSpacer_8">
      <property name="orientation">
       <enum>Qt::Vertical</enum>
@@ -237,8 +298,8 @@
      </property>
     </spacer>
    </item>
-   <item row="17" column="0">
-    <spacer name="verticalSpacer_10">
+   <item row="9" column="0">
+    <spacer name="verticalSpacer_4">
      <property name="orientation">
       <enum>Qt::Vertical</enum>
      </property>
@@ -253,200 +314,7 @@
      </property>
     </spacer>
    </item>
-   <item row="18" column="0">
-    <spacer name="verticalSpacer_11">
-     <property name="orientation">
-      <enum>Qt::Vertical</enum>
-     </property>
-     <property name="sizeType">
-      <enum>QSizePolicy::Fixed</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>0</width>
-       <height>28</height>
-      </size>
-     </property>
-    </spacer>
-   </item>
-   <item row="12" column="6">
-    <spacer name="horizontalSpacer">
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>40</width>
-       <height>20</height>
-      </size>
-     </property>
-    </spacer>
-   </item>
-   <item row="10" column="0" colspan="7">
-    <widget class="Line" name="line_2">
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
-     </property>
-    </widget>
-   </item>
-   <item row="7" column="3" colspan="4">
-    <layout class="QHBoxLayout" name="horizontalLayout">
-     <item>
-      <widget class="QLabel" name="animPathLabel">
-       <property name="text">
-        <string>/path/to/animations</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QLabel" name="animCountLabel">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="text">
-        <string>0 animations found</string>
-       </property>
-       <property name="alignment">
-        <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QPushButton" name="animScanButton">
-       <property name="text">
-        <string>Re-scan</string>
-       </property>
-      </widget>
-     </item>
-    </layout>
-   </item>
-   <item row="3" column="1" colspan="6">
-    <widget class="QCheckBox" name="brightnessBox">
-     <property name="toolTip">
-      <string>By default, the same brightness level will be applied to all profiles and all devices. Enable this to store it with the lighting mode instead.</string>
-     </property>
-     <property name="text">
-      <string>Set brightness per-mode</string>
-     </property>
-    </widget>
-   </item>
-   <item row="2" column="1" colspan="6">
-    <widget class="QCheckBox" name="trayBox">
-     <property name="toolTip">
-      <string>The tray icon will not be displayed. The application will still run in the background; re-launch the app to see the GUI again.</string>
-     </property>
-     <property name="text">
-      <string>Hide tray icon</string>
-     </property>
-    </widget>
-   </item>
-   <item row="0" column="0" colspan="7">
-    <widget class="QLabel" name="label">
-     <property name="font">
-      <font>
-       <weight>75</weight>
-       <bold>true</bold>
-      </font>
-     </property>
-     <property name="text">
-      <string>Behavior</string>
-     </property>
-    </widget>
-   </item>
-   <item row="1" column="0" colspan="7">
-    <widget class="Line" name="line">
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
-     </property>
-    </widget>
-   </item>
-   <item row="5" column="0" colspan="7">
-    <widget class="QLabel" name="label_5">
-     <property name="font">
-      <font>
-       <weight>75</weight>
-       <bold>true</bold>
-      </font>
-     </property>
-     <property name="text">
-      <string>Animation scripts</string>
-     </property>
-    </widget>
-   </item>
-   <item row="6" column="0" colspan="7">
-    <widget class="Line" name="line_3">
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
-     </property>
-    </widget>
-   </item>
-   <item row="9" column="0" colspan="7">
-    <widget class="QLabel" name="label_2">
-     <property name="font">
-      <font>
-       <weight>75</weight>
-       <bold>true</bold>
-      </font>
-     </property>
-     <property name="text">
-      <string>Hardware</string>
-     </property>
-    </widget>
-   </item>
-   <item row="13" column="1" colspan="6">
-    <widget class="QCheckBox" name="ditherBox">
-     <property name="toolTip">
-      <string>May improve appearance on some keyboards.</string>
-     </property>
-     <property name="text">
-      <string>Use spatial dithering to simulate extra color resolution</string>
-     </property>
-    </widget>
-   </item>
-   <item row="14" column="1" colspan="6">
-    <widget class="QCheckBox" name="delayBox">
-     <property name="toolTip">
-      <string>When using macros with strings longer than 25 chars, some OS may lose characters (e.g. Mint 17.2). Select to prevent that bug.</string>
-     </property>
-     <property name="text">
-      <string>Use delay for very long macros</string>
-     </property>
-    </widget>
-   </item>
-   <item row="15" column="0" colspan="7">
-    <widget class="QLabel" name="osxLabel">
-     <property name="font">
-      <font>
-       <weight>75</weight>
-       <bold>true</bold>
-      </font>
-     </property>
-     <property name="text">
-      <string>OS X tweaks</string>
-     </property>
-    </widget>
-   </item>
-   <item row="16" column="0" colspan="7">
-    <widget class="Line" name="osxLine">
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
-     </property>
-    </widget>
-   </item>
-   <item row="17" column="1" colspan="6">
-    <widget class="QCheckBox" name="mAccelBox">
-     <property name="toolTip">
-      <string>Try this if you're having problems with mouse movement.</string>
-     </property>
-     <property name="text">
-      <string>Disable mouse acceleration</string>
-     </property>
-    </widget>
-   </item>
-   <item row="18" column="5" colspan="2">
+   <item row="21" column="5" colspan="2">
     <widget class="QWidget" name="sSpeedWidget" native="true">
      <property name="sizePolicy">
       <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
@@ -503,13 +371,152 @@
      </layout>
     </widget>
    </item>
-   <item row="20" column="0" colspan="7">
+   <item row="15" column="1" colspan="6">
+    <widget class="QCheckBox" name="ditherBox">
+     <property name="toolTip">
+      <string>May improve appearance on some keyboards.</string>
+     </property>
+     <property name="text">
+      <string>Use spatial dithering to simulate extra color resolution</string>
+     </property>
+    </widget>
+   </item>
+   <item row="21" column="1" colspan="4">
+    <widget class="QCheckBox" name="sAccelBox">
+     <property name="toolTip">
+      <string>Try this if you're having problems with the scroll wheel.</string>
+     </property>
+     <property name="text">
+      <string>Disable scroll acceleration</string>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="0">
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeType">
+      <enum>QSizePolicy::Fixed</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>0</width>
+       <height>28</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item row="8" column="0" colspan="7">
+    <widget class="Line" name="line_3">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+    </widget>
+   </item>
+   <item row="16" column="1">
+    <spacer name="verticalSpacer_7">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeType">
+      <enum>QSizePolicy::Fixed</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>10</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item row="9" column="3" colspan="4">
+    <layout class="QHBoxLayout" name="horizontalLayout">
+     <item>
+      <widget class="QLabel" name="animPathLabel">
+       <property name="text">
+        <string>/path/to/animations</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLabel" name="animCountLabel">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="text">
+        <string>0 animations found</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="animScanButton">
+       <property name="text">
+        <string>Re-scan</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item row="23" column="0" colspan="7">
     <widget class="QDialogButtonBox" name="buttonBox">
      <property name="orientation">
       <enum>Qt::Horizontal</enum>
      </property>
      <property name="standardButtons">
       <set>QDialogButtonBox::Ok</set>
+     </property>
+    </widget>
+   </item>
+   <item row="11" column="0" colspan="7">
+    <widget class="QLabel" name="label_2">
+     <property name="font">
+      <font>
+       <weight>75</weight>
+       <bold>true</bold>
+      </font>
+     </property>
+     <property name="text">
+      <string>Hardware</string>
+     </property>
+    </widget>
+   </item>
+   <item row="20" column="0">
+    <spacer name="verticalSpacer_10">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeType">
+      <enum>QSizePolicy::Fixed</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>0</width>
+       <height>28</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item row="20" column="1" colspan="6">
+    <widget class="QCheckBox" name="mAccelBox">
+     <property name="toolTip">
+      <string>Try this if you're having problems with mouse movement.</string>
+     </property>
+     <property name="text">
+      <string>Disable mouse acceleration</string>
+     </property>
+    </widget>
+   </item>
+   <item row="5" column="1" colspan="6">
+    <widget class="QCheckBox" name="startDelayBox">
+     <property name="text">
+      <string>Delay application start</string>
      </property>
     </widget>
    </item>

--- a/src/gui/main.cpp
+++ b/src/gui/main.cpp
@@ -169,13 +169,7 @@ int main(int argc, char *argv[]){
 
     // Seed the RNG for UsbIds
     qsrand(QDateTime::currentMSecsSinceEpoch());
-#ifdef Q_OS_MACOS
-    disableAppNap();
 
-    FILE *fp = fopen("/tmp/ckb", "w");
-    fprintf(fp, "%d", getpid());
-    fclose(fp);
-#endif
 #if QT_VERSION >= QT_VERSION_CHECK(5, 3, 0)
     // Enable HiDPI support
     qApp->setAttribute(Qt::AA_UseHighDpiPixmaps);
@@ -212,6 +206,23 @@ int main(int argc, char *argv[]){
         background = 1;
         break;
     }
+
+    bool startDelay = false;
+    {
+        QSettings tmp;
+        startDelay = tmp.value("Program/StartDelay", false).toBool();
+    }
+
+    if(startDelay)
+        QThread::sleep(5);
+
+#ifdef Q_OS_MACOS
+    disableAppNap();
+
+    FILE *fp = fopen("/tmp/ckb", "w");
+    fprintf(fp, "%d", getpid());
+    fclose(fp);
+#endif
 
     // Launch in background if requested, or if re-launching a previous session
     if(qApp->isSessionRestored())


### PR DESCRIPTION
Adds the option in the GUI to introduce a 5 second delay on start.
Useful for some rare cases that we are unable to reproduce choppy animations on macOS.