### PR TITLE
Add GUI DPI indicator

### DIFF
--- a/src/gui/kbperf.cpp
+++ b/src/gui/kbperf.cpp
@@ -386,10 +386,12 @@ void KbPerf::baseDpiIdx(int newIdx) {
     pushedDpis.clear();
     dpiBaseIdx = newIdx;
     _curDpi(dpi(dpiBaseIdx));
-    _needsUpdate = _needsSave = true; 
+    _needsUpdate = _needsSave = true;
+    emit dpiChanged(newIdx);
 }
 
-quint64 KbPerf::pushDpi(const QPoint& newDpi){
+quint64 KbPerf::pushDpi(const QPoint& newDpi, bool sniper){
+    emit dpiChanged((sniper ? 0 : 6));
     quint64 index = runningPushIdx++;
     pushedDpis[index] = newDpi;
     _curDpi(newDpi);
@@ -408,6 +410,7 @@ void KbPerf::popDpi(quint64 pushIdx){
         _curDpi(map_last(pushedDpis));
     } 
     _needsUpdate = _needsSave = true;
+    emit dpiChanged(dpiBaseIdx);
 }
 
 void KbPerf::dpiUp(){
@@ -620,3 +623,6 @@ void KbPerf::applyIndicators(int modeIndex, const bool indicatorState[]){
         lightIndicator("scroll", indicatorState[2] ? iColor[SCROLL][0].rgba() : iColor[SCROLL][1].rgba());
 }
 
+int KbPerf::getDpiIdx(){
+    return dpiBaseIdx;
+}

--- a/src/gui/kbperf.h
+++ b/src/gui/kbperf.h
@@ -74,9 +74,9 @@ public:
 
     // Push/pop a DPI state onto the DPI stack. Used for sniper and custom DPIs,
     // which are only active while a key is held.
-    quint64         pushDpi(const QPoint& newDpi);
-    inline quint64  pushDpi(int newDpi)             { return pushDpi(QPoint(newDpi, newDpi)); }
-    inline quint64  pushSniper()                    { return pushDpi(sniperDpi()); }
+    quint64         pushDpi(const QPoint& newDpi, bool sniper);
+    inline quint64  pushDpi(int newDpi, bool sniper)        { return pushDpi(QPoint(newDpi, newDpi), sniper); }
+    inline quint64  pushSniper()                            { return pushDpi(sniperDpi(), true); }
     void            popDpi(quint64 pushIdx);
 
     // Indicator opacity [0, 1]
@@ -121,10 +121,12 @@ public:
 
     // Get indicator status to send to KbLight
     void applyIndicators(int modeIndex, const bool indicatorState[HW_I_COUNT]);
+    int getDpiIdx();
 
 signals:
     void didLoad();
     void settingsUpdated();
+    void dpiChanged(int index);
 
 private:
     // Related objects

--- a/src/gui/keyaction.cpp
+++ b/src/gui/keyaction.cpp
@@ -320,7 +320,7 @@ void KeyAction::keyEvent(KbBind* bind, bool down){
             if(xy.x() <= 0 || xy.y() <= 0)
                 break;
             if(down)
-                sniperValue = perf->pushDpi(xy);
+                sniperValue = perf->pushDpi(xy, false);
             else {
                 perf->popDpi(sniperValue);
                 sniperValue = 0;

--- a/src/gui/mperfwidget.cpp
+++ b/src/gui/mperfwidget.cpp
@@ -16,6 +16,13 @@ MPerfWidget::MPerfWidget(QWidget *parent) :
     stages[3].indicator = ui->iButton3; stages[3].xSlider = ui->xSlider3; stages[3].ySlider = ui->ySlider3; stages[3].xBox = ui->xBox3; stages[3].yBox = ui->yBox3; stages[3].enableCheck = ui->eBox3;
     stages[4].indicator = ui->iButton4; stages[4].xSlider = ui->xSlider4; stages[4].ySlider = ui->ySlider4; stages[4].xBox = ui->xBox4; stages[4].yBox = ui->yBox4; stages[4].enableCheck = ui->eBox4;
     stages[5].indicator = ui->iButton5; stages[5].xSlider = ui->xSlider5; stages[5].ySlider = ui->ySlider5; stages[5].xBox = ui->xBox5; stages[5].yBox = ui->yBox5; stages[5].enableCheck = ui->eBox5;
+    stages[0].indicatorLabel = ui->iLabel0;
+    stages[1].indicatorLabel = ui->iLabel1;
+    stages[2].indicatorLabel = ui->iLabel2;
+    stages[3].indicatorLabel = ui->iLabel3;
+    stages[4].indicatorLabel = ui->iLabel4;
+    stages[5].indicatorLabel = ui->iLabel5;
+
     ui->iButtonO->setLabel(false);
     ui->iButtonO->bigIcons(true);
     ui->iButtonO->allowAlpha(true);
@@ -42,7 +49,11 @@ MPerfWidget::MPerfWidget(QWidget *parent) :
         boxYMapper.setMapping(stages[i].yBox, i);
         if(stages[i].enableCheck)
             enableMapper.setMapping(stages[i].enableCheck, i);
+        // Hide indicator arrows
+        stages[i].indicatorLabel->setVisible(false);
     }
+    ui->iLabelO->setVisible(false);
+
     // Connect to slots
     connect(&buttonMapper1, SIGNAL(mapped(int)), this, SLOT(colorClicked(int)));
     connect(&buttonMapper2, SIGNAL(mapped(int)), this, SLOT(colorChanged(int)));
@@ -76,6 +87,8 @@ void MPerfWidget::setPerf(KbPerf *newPerf, KbProfile *newProfile){
     ui->aSnapBox->setChecked(perf->angleSnap());
     ui->lHeightBox->setCurrentIndex(perf->liftHeight() - 1);
     ui->indicBox->setChecked(perf->dpiIndicator());
+    highlightDpiBox(perf->getDpiIdx());
+    connect(perf, &KbPerf::dpiChanged, this, &MPerfWidget::highlightDpiBox);
 }
 
 void MPerfWidget::colorClicked(int index){
@@ -220,4 +233,18 @@ void MPerfWidget::on_spinBox_valueChanged(int arg1){
     if(!perf)
         return;
     perf->iOpacity(arg1 / 100.f);
+}
+
+void MPerfWidget::highlightDpiBox(int index){
+    for(int i = 0; i < DPI_COUNT; i++){
+        stages[i].indicatorLabel->setVisible(false);
+    }
+    ui->iLabelO->setVisible(false);
+
+    if(index > DPI_COUNT - 1){
+        ui->iLabelO->setVisible(true);
+        return;
+    }
+
+    stages[index].indicatorLabel->setVisible(true);
 }

--- a/src/gui/mperfwidget.h
+++ b/src/gui/mperfwidget.h
@@ -7,6 +7,7 @@
 #include <QCheckBox>
 #include <QRadioButton>
 #include <QSignalMapper>
+#include <QLabel>
 #include "kbperf.h"
 #include "kbprofile.h"
 #include "colorbutton.h"
@@ -39,6 +40,7 @@ private:
         QSlider* xSlider, *ySlider;
         QSpinBox* xBox, *yBox;
         QCheckBox* enableCheck;
+        QLabel* indicatorLabel;
     };
     DpiUi stages[DPI_COUNT];
     bool _xyLink;
@@ -60,13 +62,13 @@ private slots:
     void boxXChanged(int index);
     void boxYChanged(int index);
     void enableChanged(int index);
-
     void on_xyBox_clicked(bool checked);
     void on_indicBox_clicked(bool checked);
     void on_aSnapBox_clicked(bool checked);
     void on_lHeightBox_activated(int index);
     void on_copyButton_clicked();
     void on_spinBox_valueChanged(int arg1);
+    void highlightDpiBox(int index);
 };
 
 #endif // MPERFWIDGET_H

--- a/src/gui/mperfwidget.ui
+++ b/src/gui/mperfwidget.ui
@@ -1000,6 +1000,55 @@
        </property>
       </widget>
      </item>
+     <item row="6" column="0">
+      <widget class="QLabel" name="iLabel1">
+       <property name="text">
+        <string>→</string>
+       </property>
+      </widget>
+     </item>
+     <item row="7" column="0">
+      <widget class="QLabel" name="iLabel2">
+       <property name="text">
+        <string>→</string>
+       </property>
+      </widget>
+     </item>
+     <item row="8" column="0">
+      <widget class="QLabel" name="iLabel3">
+       <property name="text">
+        <string>→</string>
+       </property>
+      </widget>
+     </item>
+     <item row="9" column="0">
+      <widget class="QLabel" name="iLabel4">
+       <property name="text">
+        <string>→</string>
+       </property>
+      </widget>
+     </item>
+     <item row="10" column="0">
+      <widget class="QLabel" name="iLabel5">
+       <property name="text">
+        <string>→</string>
+       </property>
+      </widget>
+     </item>
+     <item row="11" column="0">
+      <widget class="QLabel" name="iLabel0">
+       <property name="text">
+        <string>→</string>
+       </property>
+      </widget>
+     </item>
+     <item row="12" column="0">
+      <widget class="QLabel" name="iLabelO">
+       <property name="text">
+        <string>→</string>
+       </property>
+      </widget>
+     </item>
     </layout>
    </item>
    <item>


### PR DESCRIPTION
Adds a simple indicator to the GUI showing the active DPI state.
Useful for when editing DPI stages and having the LED indicator disabled.

Code-wise, it adds a signal that gets emitted every time the DPI changes, and can be repurposed later for other uses.

![85f65d508533](https://user-images.githubusercontent.com/6003656/41962739-78275cec-79fe-11e8-8b54-ffd8c47970c3.jpg)
