### PR TITLE
Add SIGINT/SIGTERM handler to GUI

### DIFF
--- a/src/gui/mainwindow.h
+++ b/src/gui/mainwindow.h
@@ -8,6 +8,7 @@
 #include <QTimer>
 #include "kbwidget.h"
 #include "settingswidget.h"
+#include <QSocketNotifier>
 
 #ifdef USE_LIBAPPINDICATOR
 // 'signals' has to be undefined as GTK has its own signal mechanism
@@ -35,6 +36,8 @@ public:
     static MainWindow* mainWindow;
 
     void toggleTrayIcon(bool visible);
+    static int signalHandlerFd[2];
+    static void PosixSignalHandler(int signal);
 
 private:
     SettingsWidget* settingsWidget;
@@ -72,8 +75,11 @@ private slots:
     void cleanup();
     void showFwUpdateNotification(QWidget* widget, float version);
 
+    void QSignalHandler();
+
 private:
     Ui::MainWindow *ui;
+    QSocketNotifier* sigNotifier;
 };
 
 #endif // MAINWINDOW_H


### PR DESCRIPTION
Adds a sigint/sigterm handler to the GUI to gracefully handle ^C, making sure all devices are switched back to HW mode.

Need to use sockets as per Qt documentation due to all Qt functions not being safe for use inside signal handlers.
https://doc.qt.io/qt-5/unix-signals.html

```
QEventLoop: Cannot be used without QApplication
QDBusConnection: system D-Bus connection created before QCoreApplication. Application may misbehave.
Path to settings: "/home/tatokis/.config/ckb-next/ckb-next.conf"
Scanning "/usr/local/libexec/ckb-next-animations/gradient"
Scanning "/usr/local/libexec/ckb-next-animations/heat"
Scanning "/usr/local/libexec/ckb-next-animations/mviz"
Scanning "/usr/local/libexec/ckb-next-animations/pinwheel"
Scanning "/usr/local/libexec/ckb-next-animations/rain"
Scanning "/usr/local/libexec/ckb-next-animations/random"
Scanning "/usr/local/libexec/ckb-next-animations/ripple"
Scanning "/usr/local/libexec/ckb-next-animations/wave"
Downloaded new firmware list. 33 entries found.
^C
Signal 2 caught. Quitting...
```