### PR TITLE
Make absence of uinput a fatal error

### DIFF
--- a/src/daemon/usb_linux.c
+++ b/src/daemon/usb_linux.c
@@ -837,12 +837,12 @@ static void udev_enum(){
 ///
 int usbmain(){
     /// First check whether the uinput module is loaded by the kernel.
-    /// \todo Why isn't missing of uinput
-    /// a fatal error?
     ///
     // Load the uinput module (if it's not loaded already)
-    if(system("modprobe uinput") != 0)
-        ckb_warn("Failed to load uinput module\n");
+    if(system("modprobe uinput") != 0) {
+        ckb_fatal("Failed to load uinput module\n");
+        return -1;
+    }
 
     ///
     /// Create the udev object with udev_new() (is a function from libudev.h)


### PR DESCRIPTION
Hi all,

This pull request is the result of my bad experience with ckb-next. I use a custom configured kernel and I didn't compile uinput into kernel or as a module. I used quickinstall script to install ckb-next, which automatically enables and starts the systemd service. But this caused a huge problem for me, absence of uinput made ckb-next make my Corsair keyboard and mouse useless. Since I didn't have any other keyboard, mouse or bootable media around, I couldn't disable systemd service and I had to bring a keyboard from my office to home to just disable the service and debug it. While debugging it, I saw that I need uinput. I compiled uinput as a module and that fixed my problem.

This part seems like has already been marked with a todo item so decided to implement it. I don't know if it would be better to add similar checks to uinput writes, but I am sure that the program shouldn't continue from this if statement if it can't load uinput.