### PR TITLE
K68 NRGB winlock fix

### DIFF
--- a/src/daemon/led_keyboard.c
+++ b/src/daemon/led_keyboard.c
@@ -116,6 +116,17 @@ int updatergb_kb(usbdevice* kb, int force){
              if(!usbsend(kb, data_pkt[0], 2))
                  return -1;
         }
+        if (kb->product == P_K68_NRGB) {
+            // The K68 NRGB doesn't support winlock setting through the
+            // normal packets, so we have to use a different packet to set it.
+            // 8 is the winlock ("lock") led position in keymap.c
+            uchar winlock_status = (newlight->r[8] || newlight->g[8] || newlight->b[8]);
+            uchar winlock_pkt[MSG_SIZE] = {
+                CMD_SET, FIELD_LIGHTING, MODE_WINLOCK, 0, winlock_status, 0
+            };
+            if (!usbsend(kb, winlock_pkt, 1))
+                return -1;
+        }
         // 16.8M color lighting works fine on strafe and is the only way it actually works
         uchar data_pkt[12][MSG_SIZE] = {
             // Red

--- a/src/daemon/protocol.h
+++ b/src/daemon/protocol.h
@@ -37,6 +37,7 @@
 #define MODE_HARDWARE  0x01 // This should be hardware controlled and not generate an event.
 #define MODE_SOFTWARE  0x02 // This should be software controlled and generate an event.
 #define MODE_SIDELIGHT 0x08 // Strafe sidelighting control.
+#define MODE_WINLOCK   0x09 // K68 winlock control.
 
 // Used for FIELD_MOUSE. All subcommands are read/write.
 #define MOUSE_DPI      0x02 // Mouse DPI mode.


### PR DESCRIPTION
I forgot to PR this and just rediscovered it on my laptop.

It lights up the K68 NRGB's winlock light on anything which isn't complete black, which is a hack, but the code is now in place should we decide to change that.