### PR TITLE
Dev detect in gui

### DIFF
--- a/ckb-next-dev-detect
+++ b/ckb-next-dev-detect
@@ -3,19 +3,24 @@
 # Newline
 N=$'\n'
 
-echo "This script will collect information about the Corsair devices in your system."
-read -p "Please make sure they are plugged in and press Enter.${N}"
+if [[ "$1" != "--nouserinput" ]]; then
+    OUTPATH="${PWD}/"
+    echo "This script will collect information about the Corsair devices in your system."
+    read -p "Please make sure they are plugged in and press Enter.${N}"
+else
+    OUTPATH="/tmp/"
+fi
 
 # Force English
 export LC_ALL=C
 
 #Check if user can write to the PWD
-touch ckb-next-dev-detect-report.gz
+touch "${OUTPATH}ckb-next-dev-detect-report.gz"
 TOUCHRET=$?
 if [ $TOUCHRET -ne 0 ]; then
-    echo "Could not write the report to disk, make sure this user can write to ${PWD}/"
+    echo "Could not write the report to disk, make sure this user can write to ${OUTPATH}"
     echo "Retval: $TOUCHRET"
-    exit
+    exit $TOUCHRET
 fi
 
 OUT="ckb-next-dev-detect - $(date)"
@@ -49,7 +54,7 @@ else
 fi
 
 # Gzip and write output
-echo "$OUT" | gzip > ckb-next-dev-detect-report.gz
+echo "$OUT" | gzip > "${OUTPATH}ckb-next-dev-detect-report.gz"
 
 echo "Done! Please send the following report to the developers."
-echo "Location: ${PWD}/ckb-next-dev-detect-report.gz"
+echo "Location: ${OUTPATH}ckb-next-dev-detect-report.gz"

--- a/src/dev-detect/CMakeLists.txt
+++ b/src/dev-detect/CMakeLists.txt
@@ -3,7 +3,7 @@
 #
 #   Redistribution and use in source and binary forms, with or without
 #   modification, are permitted provided that the following conditions are met:
-#   
+#
 #   1. Redistributions of source code must retain the above copyright notice,
 #   this list of conditions and the following disclaimer.
 #   2. Redistributions in binary form must reproduce the above copyright
@@ -11,8 +11,8 @@
 #   documentation and/or other materials provided with the distribution.
 #   3. Neither the name of the copyright holder nor the names of its
 #   contributors may be used to endorse or promote products derived from this
-#   software without specific prior written permission. 
-#   
+#   software without specific prior written permission.
+#
 #   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
 #   AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
 #   IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
@@ -25,24 +25,8 @@
 #   ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 #   POSSIBILITY OF SUCH DAMAGE.
 
-# Export version, etc. to source code
-set(CKB_NEXT_VERSION_STR "${ckb-next_VERSION}")
-set(CKB_NEXT_ANIMATIONS_PATH "${CMAKE_INSTALL_PREFIX}/${INSTALL_DIR_ANIMATIONS}")
-configure_file(
-    ${CMAKE_CURRENT_LIST_DIR}/ckbnextconfig.h.in
-    ${CMAKE_BINARY_DIR}/ckbnextconfig.h)
-
-# Include this directory so that it's possible to write #include <ckbnextconfig.h> in source files
-include_directories("${CMAKE_BINARY_DIR}")
-
-add_subdirectory(dev-detect)
-add_subdirectory(daemon)
-add_subdirectory(libs)
-
-if (WITH_ANIMATIONS)
-    add_subdirectory(animations)
-endif ()
-
-if (WITH_GUI)
-    add_subdirectory(gui)
+if (MACOS)
+    install(PROGRAMS "${PROJECT_SOURCE_DIR}/ckb-next-dev-detect" DESTINATION "ckb-next.app/Contents/Resources")
+elseif (LINUX)
+    install(PROGRAMS "${PROJECT_SOURCE_DIR}/ckb-next-dev-detect" DESTINATION "bin")
 endif ()

--- a/src/gui/settingswidget.h
+++ b/src/gui/settingswidget.h
@@ -3,6 +3,7 @@
 
 #include <QWidget>
 #include "extrasettingswidget.h"
+#include <QProcess>
 
 namespace Ui {
 class SettingsWidget;
@@ -25,26 +26,24 @@ public:
 
 private slots:
     void on_pushButton_clicked();
-
     void on_capsBox_activated(int index);
     void on_shiftBox_activated(int index);
     void on_ctrlBox_activated(int index);
     void on_altBox_activated(int index);
     void on_winBox_activated(int index);
-
     void on_autoFWBox_clicked(bool checked);
     void on_loginItemBox_clicked(bool checked);
-
     void on_extraButton_clicked();
-
     void on_aboutQt_clicked();
+    void on_generateReportButton_clicked();
+    void devDetectFinished(int retVal);
+    void devDetectDestroyed();
 
 private:
+    QProcess* devDetect;
     Ui::SettingsWidget *ui;
     friend class MainWindow;
-
     ExtraSettingsWidget* extra;
-
     void updateModifiers();
 };
 

--- a/src/gui/settingswidget.ui
+++ b/src/gui/settingswidget.ui
@@ -14,6 +14,22 @@
    <string>Form</string>
   </property>
   <layout class="QGridLayout" name="gridLayout">
+   <property name="bottomMargin">
+    <number>6</number>
+   </property>
+   <item row="25" column="1">
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>40</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
    <item row="6" column="0" colspan="2">
     <widget class="QLabel" name="label">
      <property name="font">
@@ -51,7 +67,7 @@
      </item>
     </layout>
    </item>
-   <item row="16" column="0">
+   <item row="17" column="0">
     <spacer name="verticalSpacer_8">
      <property name="orientation">
       <enum>Qt::Vertical</enum>
@@ -66,16 +82,6 @@
       </size>
      </property>
     </spacer>
-   </item>
-   <item row="16" column="1">
-    <widget class="QCheckBox" name="loginItemBox">
-     <property name="toolTip">
-      <string>ckb-next will be started when you log in to your computer.</string>
-     </property>
-     <property name="text">
-      <string>Start ckb-next at login</string>
-     </property>
-    </widget>
    </item>
    <item row="15" column="0">
     <spacer name="verticalSpacer_6">
@@ -92,19 +98,6 @@
       </size>
      </property>
     </spacer>
-   </item>
-   <item row="15" column="1">
-    <widget class="QCheckBox" name="autoFWBox">
-     <property name="toolTip">
-      <string>You will be notified when new firmware versions are available. You'll have the option to install them immediately or wait until later.</string>
-     </property>
-     <property name="text">
-      <string>Check for new firmware automatically</string>
-     </property>
-     <property name="checked">
-      <bool>true</bool>
-     </property>
-    </widget>
    </item>
    <item row="1" column="0" colspan="2">
     <widget class="Line" name="line">
@@ -366,31 +359,7 @@
      </property>
     </widget>
    </item>
-   <item row="17" column="1">
-    <layout class="QHBoxLayout" name="horizontalLayout">
-     <item>
-      <widget class="QPushButton" name="extraButton">
-       <property name="text">
-        <string>More settings</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <spacer name="horizontalSpacer_2">
-       <property name="orientation">
-        <enum>Qt::Horizontal</enum>
-       </property>
-       <property name="sizeHint" stdset="0">
-        <size>
-         <width>40</width>
-         <height>20</height>
-        </size>
-       </property>
-      </spacer>
-     </item>
-    </layout>
-   </item>
-   <item row="17" column="0">
+   <item row="18" column="0">
     <spacer name="verticalSpacer_7">
      <property name="orientation">
       <enum>Qt::Vertical</enum>
@@ -406,25 +375,39 @@
      </property>
     </spacer>
    </item>
-   <item row="19" column="1">
-    <layout class="QVBoxLayout" name="verticalLayout_3">
+   <item row="14" column="1">
+    <layout class="QVBoxLayout" name="verticalLayout">
      <property name="spacing">
-      <number>0</number>
+      <number>3</number>
      </property>
      <item>
-      <layout class="QHBoxLayout" name="horizontalLayout_4">
+      <layout class="QHBoxLayout" name="horizontalLayout_3">
        <item>
-        <widget class="QLabel" name="label_2">
-         <property name="text">
-          <string>© 2014-2016 &lt;a href=&quot;https://github.com/ccMSC/&quot; style=&quot;text-decoration:none;&quot;&gt;ccMSC&lt;/a&gt;.&lt;br/&gt;© 2017-2018 &lt;a href=&quot;https://github.com/ckb-next/ckb-next/graphs/contributors&quot; style=&quot;text-decoration:none;&quot;&gt;The ckb-next development team&lt;/a&gt;.</string>
-         </property>
-         <property name="alignment">
-          <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
-         </property>
-         <property name="openExternalLinks">
-          <bool>true</bool>
-         </property>
-        </widget>
+        <layout class="QVBoxLayout" name="verticalLayout_5">
+         <item>
+          <widget class="QCheckBox" name="loginItemBox">
+           <property name="toolTip">
+            <string>ckb-next will be started when you log in to your computer.</string>
+           </property>
+           <property name="text">
+            <string>Start ckb-next at login</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QCheckBox" name="autoFWBox">
+           <property name="toolTip">
+            <string>You will be notified when new firmware versions are available. You'll have the option to install them immediately or wait until later.</string>
+           </property>
+           <property name="text">
+            <string>Check for new firmware automatically</string>
+           </property>
+           <property name="checked">
+            <bool>true</bool>
+           </property>
+          </widget>
+         </item>
+        </layout>
        </item>
        <item>
         <spacer name="horizontalSpacer_3">
@@ -439,29 +422,33 @@
          </property>
         </spacer>
        </item>
-       <item>
-        <widget class="QPushButton" name="aboutQt">
-         <property name="text">
-          <string>About Qt</string>
-         </property>
-        </widget>
-       </item>
       </layout>
      </item>
      <item>
-      <layout class="QHBoxLayout" name="horizontalLayout_2">
+      <layout class="QHBoxLayout" name="horizontalLayout">
        <item>
-        <widget class="QLabel" name="label_3">
-         <property name="text">
-          <string>&lt;a href=&quot;https://github.com/ckb-next/ckb-next&quot; style=&quot;text-decoration:none;&quot;&gt;https://github.com/ckb-next/ckb-next&lt;/a&gt;</string>
+        <layout class="QVBoxLayout" name="verticalLayout_2">
+         <property name="spacing">
+          <number>6</number>
          </property>
-         <property name="openExternalLinks">
-          <bool>true</bool>
-         </property>
-        </widget>
+         <item>
+          <widget class="QPushButton" name="generateReportButton">
+           <property name="text">
+            <string>Generate report</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QPushButton" name="extraButton">
+           <property name="text">
+            <string>More settings</string>
+           </property>
+          </widget>
+         </item>
+        </layout>
        </item>
        <item>
-        <spacer name="horizontalSpacer">
+        <spacer name="horizontalSpacer_2">
          <property name="orientation">
           <enum>Qt::Horizontal</enum>
          </property>
@@ -472,6 +459,73 @@
           </size>
          </property>
         </spacer>
+       </item>
+      </layout>
+     </item>
+    </layout>
+   </item>
+   <item row="26" column="1">
+    <layout class="QHBoxLayout" name="horizontalLayout_2">
+     <property name="spacing">
+      <number>0</number>
+     </property>
+     <item>
+      <layout class="QVBoxLayout" name="verticalLayout_3">
+       <property name="spacing">
+        <number>0</number>
+       </property>
+       <item>
+        <widget class="QLabel" name="label_2">
+         <property name="text">
+          <string>© 2014-2016 &lt;a href=&quot;https://github.com/ccMSC/&quot; style=&quot;text-decoration:none;&quot;&gt;ccMSC&lt;/a&gt;.&lt;br/&gt;© 2017-2018 &lt;a href=&quot;https://github.com/ckb-next/ckb-next/graphs/contributors&quot; style=&quot;text-decoration:none;&quot;&gt;The ckb-next development team&lt;/a&gt;.</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+         </property>
+         <property name="openExternalLinks">
+          <bool>true</bool>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QLabel" name="label_3">
+         <property name="text">
+          <string>&lt;a href=&quot;https://github.com/ckb-next/ckb-next&quot; style=&quot;text-decoration:none;&quot;&gt;https://github.com/ckb-next/ckb-next&lt;/a&gt;</string>
+         </property>
+         <property name="openExternalLinks">
+          <bool>true</bool>
+         </property>
+        </widget>
+       </item>
+      </layout>
+     </item>
+     <item>
+      <spacer name="horizontalSpacer">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+     <item>
+      <layout class="QVBoxLayout" name="verticalLayout_4">
+       <property name="spacing">
+        <number>6</number>
+       </property>
+       <property name="bottomMargin">
+        <number>3</number>
+       </property>
+       <item>
+        <widget class="QPushButton" name="aboutQt">
+         <property name="text">
+          <string>About Qt</string>
+         </property>
+        </widget>
        </item>
        <item>
         <widget class="QPushButton" name="pushButton">
@@ -487,19 +541,6 @@
      </item>
     </layout>
    </item>
-   <item row="18" column="1">
-    <spacer name="verticalSpacer">
-     <property name="orientation">
-      <enum>Qt::Vertical</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>20</width>
-       <height>40</height>
-      </size>
-     </property>
-    </spacer>
-   </item>
   </layout>
  </widget>
  <tabstops>
@@ -508,10 +549,6 @@
   <tabstop>ctrlBox</tabstop>
   <tabstop>winBox</tabstop>
   <tabstop>altBox</tabstop>
-  <tabstop>autoFWBox</tabstop>
-  <tabstop>loginItemBox</tabstop>
-  <tabstop>extraButton</tabstop>
-  <tabstop>pushButton</tabstop>
  </tabstops>
  <resources/>
  <connections/>


### PR DESCRIPTION
This PR modifies dev-detect to not ask for any user input and write the report to `/tmp` when `--nouserinput` is specified.

Additionally, the script gets installed along with the GUI and daemon, and a button is added in the GUI under Settings to launch the script and generate a report.

When the report is successfully generated, the GUI tries to show the generated report in the default file manager.