### PR TITLE
Created a Docker image that creates ckb_next debs for Ubuntu 18.04

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,7 +39,6 @@ list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/cmake/modules/sanitizer
 include(MacroEnsureOutOfSourceBuild)
 macro_ensure_out_of_source_build("ckb-next requires an out of source build. \
 Please create a separate build directory and run 'cmake /path/to/ckb-next [options]' there.")
-
 # Make sure we don't install in anaconda
 if("$ENV{PATH}" MATCHES "anaconda")
     string(REPLACE ":" ";" ENVLIST "$ENV{PATH}")
@@ -171,3 +170,30 @@ if (MACOS AND WITH_GUI)
         USES_TERMINAL
         VERBATIM)
 endif ()
+
+if (CMAKE_SIZEOF_VOID_P EQUAL 8)
+    message(STATUS "*** Have SIZEOF void * = 8, so 64-bit")
+    set(IS_64_BIT 1)
+else ()
+    message(STATUS "*** SIZEOF void * != 8, so not 64-bit")
+endif ()
+
+set(CPACK_GENERATOR "DEB")
+set(CPACK_PACKAGE_NAME "ckb-next")
+set(CPACK_PACKAGE_VENDOR "K DeSouza")
+set(CPACK_PACKAGE_CONTACT "ckb-next@googlegroups.com")
+set(CPACK_PACKAGE_DESCRIPTION_SUMMARY "ckb-next is an open-source driver for Corsair keyboards and mice. \
+It aims to bring the features of Corsair's proprietary CUE software to the Linux and Mac operating systems.")
+set(CPACK_PACKAGE_FILE_NAME "ckb-next")
+set(CPACK_PACKAGE_VERSION_MAJOR "${ckb-next_VERSION_MAJOR}")
+set(CPACK_PACKAGE_VERSION_MINOR "${ckb-next_VERSION_MINOR}")
+set(CPACK_PACKAGE_VERSION_PATCH "${ckb-next_VERSION_PATCH}-${ckb-next_VERSION_PATCH_EXTRA}")
+set(CPACK_SOURCE_IGNORE_FILES "*.cmake")
+set(CPACK_DEBIAN_PACKAGE_SHLIBDEPS ON)
+set(CPACK_DEBIAN_PACKAGE_CONTROL_EXTRA "${CMAKE_SOURCE_DIR}/linux/debian/postinst;")
+if(IS_64_BIT)
+	set(CPACK_DEBIAN_PACKAGE_ARCHITECTURE amd64)
+else()
+	set(CPACK_DEBIAN_PACKAGE_ARCHITECTURE i386)
+endif()
+include(CPack)

--- a/linux/debian/DOCKER/BUILD_CREATE_DOCKER.md
+++ b/linux/debian/DOCKER/BUILD_CREATE_DOCKER.md
@@ -1,0 +1,12 @@
+To build run this instruction in the root directory
+
+docker build -t ckb_image -f ./linux/debian/DOCKER/Dockerfile .
+To create a container from this run
+docker container create ckb-image
+
+To pull releases
+
+docker cp $(docker ps -l --format '{{.Names}}'):/ckb-next/build/ckb-next.deb .
+
+This pulls the release folder from the container. Within the container is a 
+copy of a deb which should install.

--- a/linux/debian/DOCKER/Dockerfile
+++ b/linux/debian/DOCKER/Dockerfile
@@ -1,0 +1,15 @@
+FROM ubuntu:18.04
+LABEL maintainer="Krish <K.DeSouza@Outlook.com>"
+WORKDIR /ckb-next
+RUN apt-get update && apt-get install -y bash dpkg systemd git build-essential cmake libudev-dev qt5-default zlib1g-dev libappindicator-dev libpulse-dev libquazip5-dev
+COPY . /ckb-next
+ARG LC_ALL
+ENV LC_ALL C
+RUN mkdir -p /run/systemd/system
+RUN rm -rf ./build && \
+    cmake -H. -Bbuild -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr -DSAFE_INSTALL=OFF -DSAFE_UNINSTALL=OFF && \
+    cmake --build build --target all -- -j 2 && \
+    cd build && \
+    cmake . && \
+    make package
+ENTRYPOINT ["sh",".linux/debian/DOCKER/entry_point.sh"]

--- a/linux/debian/DOCKER/entry_point.sh
+++ b/linux/debian/DOCKER/entry_point.sh
@@ -1,0 +1,2 @@
+#/bin/bash
+exec "$@"

--- a/linux/debian/postinst
+++ b/linux/debian/postinst
@@ -1,0 +1,6 @@
+#/bin/bash
+echo "restarting ckb-next-daemon"
+sudo systemctl daemon-reload
+sudo systemctl enable ckb-next-daemon.service
+sudo systemctl start ckb-next-daemon.service
+sudo service ckb-next-daemon restart


### PR DESCRIPTION
Hello,
I am a young software developer looking to get in some contributions to open code. I have created a Dockerscript that builds ckb-next in deb form for Ubuntu 18.04. The packages recommended came from looking up ldd on ckb-next and ckb-next-daemon and using apt-file to find corresponding dependencies.

Ideally, this can be used in a pipeline or something like that to enable people to install ckb-next and hopefully this can be added to Ubuntu universe. I would love to have comments or changes if that is necessary.

Kind regards,
Krish