### PR TITLE
Update udev rules to create symlinks for devices

### DIFF
--- a/linux/udev/99-ckb-daemon.rules
+++ b/linux/udev/99-ckb-daemon.rules
@@ -1,4 +1,4 @@
-# Create base ckb-next devices
+# Mark ckb devices as not a joystick
 ACTION=="add|change", SUBSYSTEM=="input", ATTRS{name}=="ckb[0-9]: [A-Za-z0-9]*", ENV{ID_INPUT_JOYSTICK}=""
 
 # If the device isn't an event input device with a recognised

--- a/linux/udev/99-ckb-daemon.rules
+++ b/linux/udev/99-ckb-daemon.rules
@@ -1,26 +1,2 @@
 # Mark ckb devices as not a joystick
-ACTION=="add|change", SUBSYSTEM=="input", ATTRS{name}=="ckb[0-9]: [A-Za-z0-9]*", ENV{ID_INPUT_JOYSTICK}=""
-
-# If the device isn't an event input device with a recognised
-# class, do nothing
-KERNEL!="event*", GOTO="input_ckb_ids_end"
-SUBSYSTEM!="input", GOTO="input_ckb_ids_end"
-ENV{.INPUT_CLASS}!="?*", GOTO="input_ckb_ids_end"
-
-# Store name in .INPUT_NAME, replace spaces with underscores and remove the digit and colon following ckb
-PROGRAM="/usr/bin/sed 's/ /_/g;s/.//6;s/./-/5;s/.//4' /sys/class/input/%k/device/name", ENV{.INPUT_NAME}="%c"
-# Separate into both emulated devices
-PROGRAM="/usr/bin/cat /sys/class/input/%k/device/capabilities/ev", ENV{.INPUT_EMUNUM}="%c"
-# Filter to only match ckb-next supported devices
-ENV{.INPUT_NAME}!="ckb*", GOTO="input_ckb_ids_end"
-
-# Add a by-id symlink, with EV value to separate type:
-SYMLINK+="input/by-id/%E{.INPUT_NAME}-event-%E{.INPUT_EMUNUM}"
-
-# Add a systemd .device service unit:
-TAG+="systemd"
-# Alternatively we can add additional paths for the .device units
-# ENV{SYSTEMD_ALIAS}+="/input/by-name/%E{.INPUT_NAME}"
-
-# Exit
-LABEL="input_ckb_ids_end"
+ACTION=="add|change", SUBSYSTEM=="input", ATTRS{name}=="ckb[0-9]: [A-Za-z0-9]*", ENV{ID_INPUT_JOYSTICK}="", PROGRAM="/usr/bin/sed 's/[0-9]: /-/' /sys/class/input/%k/device/name", ENV{.INPUT_NAME}="%c, "SYMLINK+="input/by-id/%E{.INPUT_NAME}-event"

--- a/linux/udev/99-ckb-daemon.rules
+++ b/linux/udev/99-ckb-daemon.rules
@@ -1,1 +1,26 @@
+# Create base ckb-next devices
 ACTION=="add|change", SUBSYSTEM=="input", ATTRS{name}=="ckb[0-9]: [A-Za-z0-9]*", ENV{ID_INPUT_JOYSTICK}=""
+
+# If the device isn't an event input device with a recognised
+# class, do nothing
+KERNEL!="event*", GOTO="input_ckb_ids_end"
+SUBSYSTEM!="input", GOTO="input_ckb_ids_end"
+ENV{.INPUT_CLASS}!="?*", GOTO="input_ckb_ids_end"
+
+# Store name in .INPUT_NAME, replace spaces with underscores and remove the digit and colon following ckb
+PROGRAM="/usr/bin/sed 's/ /_/g;s/.//6;s/./-/5;s/.//4' /sys/class/input/%k/device/name", ENV{.INPUT_NAME}="%c"
+# Separate into both emulated devices
+PROGRAM="/usr/bin/cat /sys/class/input/%k/device/capabilities/ev", ENV{.INPUT_EMUNUM}="%c"
+# Filter to only match ckb-next supported devices
+ENV{.INPUT_NAME}!="ckb*", GOTO="input_ckb_ids_end"
+
+# Add a by-id symlink, with EV value to separate type:
+SYMLINK+="input/by-id/%E{.INPUT_NAME}-event-%E{.INPUT_EMUNUM}"
+
+# Add a systemd .device service unit:
+TAG+="systemd"
+# Alternatively we can add additional paths for the .device units
+# ENV{SYSTEMD_ALIAS}+="/input/by-name/%E{.INPUT_NAME}"
+
+# Exit
+LABEL="input_ckb_ids_end"

--- a/linux/udev/99-ckb-daemon.rules
+++ b/linux/udev/99-ckb-daemon.rules
@@ -1,2 +1,2 @@
 # Mark ckb devices as not a joystick and create symlinks to the virtual input devices
-ACTION=="add|change", SUBSYSTEM=="input", ATTRS{name}=="ckb[0-9]: [A-Za-z0-9]*", ENV{ID_INPUT_JOYSTICK}="", PROGRAM="/bin/sed 's/[0-9]: /-/' /sys/class/input/%k/device/name", ENV{.INPUT_NAME}="%c, "SYMLINK+="input/by-id/%E{.INPUT_NAME}-event"
+ACTION=="add|change", SUBSYSTEM=="input", ATTRS{name}=="ckb[0-9]: [A-Za-z0-9]*", ENV{ID_INPUT_JOYSTICK}="", PROGRAM="/usr/bin/env sed 's/[0-9]: /-/' /sys/class/input/%k/device/name", ENV{.INPUT_NAME}="%c, "SYMLINK+="input/by-id/%E{.INPUT_NAME}-event"

--- a/linux/udev/99-ckb-daemon.rules
+++ b/linux/udev/99-ckb-daemon.rules
@@ -1,2 +1,2 @@
 # Mark ckb devices as not a joystick and create symlinks to the virtual input devices
-ACTION=="add|change", SUBSYSTEM=="input", ATTRS{name}=="ckb[0-9]: [A-Za-z0-9]*", ENV{ID_INPUT_JOYSTICK}="", PROGRAM="/usr/bin/sed 's/[0-9]: /-/' $attr{name}", ENV{.INPUT_NAME}="%c, "SYMLINK+="input/by-id/%E{.INPUT_NAME}-event"
+ACTION=="add|change", SUBSYSTEM=="input", ATTRS{name}=="ckb[0-9]: [A-Za-z0-9]*", ENV{ID_INPUT_JOYSTICK}="", PROGRAM="/bin/sed 's/[0-9]: /-/' /sys/class/input/%k/device/name", ENV{.INPUT_NAME}="%c, "SYMLINK+="input/by-id/%E{.INPUT_NAME}-event"

--- a/linux/udev/99-ckb-daemon.rules
+++ b/linux/udev/99-ckb-daemon.rules
@@ -1,2 +1,2 @@
-# Mark ckb devices as not a joystick
+# Mark ckb devices as not a joystick and create symlinks to the virtual input devices
 ACTION=="add|change", SUBSYSTEM=="input", ATTRS{name}=="ckb[0-9]: [A-Za-z0-9]*", ENV{ID_INPUT_JOYSTICK}="", PROGRAM="/usr/bin/sed 's/[0-9]: /-/' /sys/class/input/%k/device/name", ENV{.INPUT_NAME}="%c, "SYMLINK+="input/by-id/%E{.INPUT_NAME}-event"

--- a/linux/udev/99-ckb-daemon.rules
+++ b/linux/udev/99-ckb-daemon.rules
@@ -1,2 +1,2 @@
 # Mark ckb devices as not a joystick and create symlinks to the virtual input devices
-ACTION=="add|change", SUBSYSTEM=="input", ATTRS{name}=="ckb[0-9]: [A-Za-z0-9]*", ENV{ID_INPUT_JOYSTICK}="", PROGRAM="/usr/bin/sed 's/[0-9]: /-/' /sys/class/input/%k/device/name", ENV{.INPUT_NAME}="%c, "SYMLINK+="input/by-id/%E{.INPUT_NAME}-event"
+ACTION=="add|change", SUBSYSTEM=="input", ATTRS{name}=="ckb[0-9]: [A-Za-z0-9]*", ENV{ID_INPUT_JOYSTICK}="", PROGRAM="/usr/bin/sed 's/[0-9]: /-/' $attr{name}", ENV{.INPUT_NAME}="%c, "SYMLINK+="input/by-id/%E{.INPUT_NAME}-event"


### PR DESCRIPTION
This change addresses issue [212](https://github.com/ckb-next/ckb-next/issues/212)
This change creates symlinks in /dev/input/by-id to the event objects for each device. Each ckb device has one mouse and one keyboard event that have the same name and little to distinguish them from each other, so to handle this I appended the EV count to the end of the name. 7 is mouse and 120003 is keyboard. Since these event objects are technically not the actually device but more of a fake device to facilitate remapping I felt it was appropriate to leave `ckb` at the front of the name rather than the traditional `usb`.

This is the first time I've ever done a pull request so if I messed up in protocol somewhere I apologize.