### PR TITLE
Show virtual device type in name

### DIFF
--- a/src/daemon/input_linux.c
+++ b/src/daemon/input_linux.c
@@ -64,7 +64,8 @@ int os_inputopen(usbdevice* kb){
     int index = INDEX_OF(kb, keyboard);
     struct uinput_user_dev indev;
     memset(&indev, 0, sizeof(indev));
-    snprintf(indev.name, UINPUT_MAX_NAME_SIZE, "ckb%d: %s", index, kb->name);
+    snprintf(indev.name, UINPUT_MAX_NAME_SIZE - 5, "ckb%d: %s", index, kb->name);
+    strcat(indev.name, " vKB");
     indev.id.bustype = BUS_USB;
     indev.id.vendor = kb->vendor;
     indev.id.product = kb->product;
@@ -75,6 +76,8 @@ int os_inputopen(usbdevice* kb){
     if(fd <= 0)
         return 0;
     // Open mouse
+    snprintf(indev.name, UINPUT_MAX_NAME_SIZE - 5, "ckb%d: %s", index, kb->name);
+    strcat(indev.name, " vM");
     fd = uinputopen(&indev, 1);
     kb->uinput_mouse = fd;
     return fd <= 0;


### PR DESCRIPTION
With this change, the daemon appends "vKB" and "vM" for virtual keyboard and virtual mouse uinput device names.
Needed for #217 as libinput can't detect the device type properly.

```
[848724.859946] input: ckb2: Corsair Gaming M65 Pro RGB Mouse vKB as /devices/virtual/input/input718
[848724.887514] input: ckb2: Corsair Gaming M65 Pro RGB Mouse vM as /devices/virtual/input/input719
[848724.919955] input: ckb1: Corsair K70 RGB Gaming Keyboard vKB as /devices/virtual/input/input720
[848724.921555] input: ckb1: Corsair K70 RGB Gaming Keyboard vM as /devices/virtual/input/input721
```