### PR TITLE
Force a frame to the daemon on profile switch

### DIFF
--- a/src/gui/kb.cpp
+++ b/src/gui/kb.cpp
@@ -797,6 +797,7 @@ void Kb::setCurrentMode(KbProfile* profile, KbMode* mode, bool spontaneous){
         _needsSave = true;
         emit modeChanged(spontaneous);
     }
+    mode->light()->forceFrameUpdate();
 }
 
 ////

--- a/src/gui/kblight.cpp
+++ b/src/gui/kblight.cpp
@@ -8,13 +8,13 @@ static int _shareDimming = -1;
 static QSet<KbLight*> activeLights;
 
 KbLight::KbLight(KbMode* parent, const KeyMap& keyMap) :
-    QObject(parent), _previewAnim(0), lastFrameSignal(0), _dimming(0), _lastFrameDimming(0), _start(false), _needsSave(true), _needsMapRefresh(true)
+    QObject(parent), _previewAnim(0), lastFrameSignal(0), _dimming(0), _lastFrameDimming(0), _start(false), _needsSave(true), _needsMapRefresh(true), _forceFrame(false)
 {
     map(keyMap);
 }
 
 KbLight::KbLight(KbMode* parent, const KeyMap& keyMap, const KbLight& other) :
-    QObject(parent), _previewAnim(0), _map(other._map), _qColorMap(other._qColorMap), lastFrameSignal(0), _dimming(other._dimming), _lastFrameDimming(other._lastFrameDimming), _start(false), _needsSave(true), _needsMapRefresh(true)
+    QObject(parent), _previewAnim(0), _map(other._map), _qColorMap(other._qColorMap), lastFrameSignal(0), _dimming(other._dimming), _lastFrameDimming(other._lastFrameDimming), _start(false), _needsSave(true), _needsMapRefresh(true), _forceFrame(false)
 {
     map(keyMap);
     // Duplicate animations
@@ -293,6 +293,10 @@ QRgb monoRgb(float r, float g, float b){
     return qRgb(value, value, value);
 }
 
+void KbLight::forceFrameUpdate(){
+    _forceFrame = true;
+}
+
 void KbLight::frameUpdate(QFile& cmd, bool monochrome){
     rebuildBaseMap();
     _animMap = _colorMap;
@@ -304,8 +308,11 @@ void KbLight::frameUpdate(QFile& cmd, bool monochrome){
         _previewAnim->blend(_animMap, timestamp);
 
     // Avoid expensive processing if nothing has changed from the last frame.
-    if(_animMap == _lastFrameAnimMap && _indicatorMap == _lastFrameIndicatorMap && _lastFrameDimming == _dimming)
+    if(_animMap == _lastFrameAnimMap && _indicatorMap == _lastFrameIndicatorMap && _lastFrameDimming == _dimming && !_forceFrame)
         return;
+
+     _forceFrame = false;
+
     _lastFrameAnimMap = _animMap;
     _lastFrameIndicatorMap = _indicatorMap;
     _lastFrameDimming = _dimming;

--- a/src/gui/kblight.h
+++ b/src/gui/kblight.h
@@ -84,6 +84,10 @@ public:
     void lightExport(QSettings* settings);
     void lightImport(QSettings* settings);
 
+    // Used to force a frame to be sent to the daemon
+    // Needed for when switching profiles as the daemon wipes the old data on switch
+    void forceFrameUpdate();
+
 signals:
     void didLoad();
     void updated();
@@ -99,7 +103,7 @@ private:
     quint64         lastFrameSignal;
     int             _dimming, _lastFrameDimming;
     bool            _start;
-    bool            _needsSave, _needsMapRefresh;
+    bool            _needsSave, _needsMapRefresh, _forceFrame;
 
     // Rebuild base ColorMap (if needed)
     void rebuildBaseMap();


### PR DESCRIPTION
This is needed as the daemon wipes the RGB data when deleting
and creating a new profile, resulting in a black keyboard when
switching to a static profile