### PR TITLE
Improved compliance for ISO C for the codebase

### DIFF
--- a/src/daemon/command.c
+++ b/src/daemon/command.c
@@ -108,7 +108,7 @@ int readcmd(usbdevice* kb, const char* line){
 
         // Set current notification node when given @number
         int newnotify;
-        if(sscanf(word, "@%u", &newnotify) == 1 && newnotify < OUTFIFO_MAX){
+        if(sscanf(word, "@%d", &newnotify) == 1 && newnotify < OUTFIFO_MAX){
             notifynumber = newnotify;
             continue;
         }
@@ -129,13 +129,13 @@ int readcmd(usbdevice* kb, const char* line){
         case NOTIFYON: {
             // Notification node on
             int notify;
-            if(sscanf(word, "%u", &notify) == 1)
+            if(sscanf(word, "%d", &notify) == 1)
                 mknotifynode(kb, notify);
             continue;
         } case NOTIFYOFF: {
             // Notification node off
             int notify;
-            if(sscanf(word, "%u", &notify) == 1 && notify != 0) // notify0 can't be removed
+            if(sscanf(word, "%d", &notify) == 1 && notify != 0) // notify0 can't be removed
                 rmnotifynode(kb, notify);
             continue;
         } case GET:
@@ -172,7 +172,7 @@ int readcmd(usbdevice* kb, const char* line){
         case MODE: {
             // Select a mode number (1 - 6)
             int newmode;
-            if(sscanf(word, "%u", &newmode) == 1 && newmode > 0 && newmode <= MODE_COUNT)
+            if(sscanf(word, "%d", &newmode) == 1 && newmode > 0 && newmode <= MODE_COUNT)
                 mode = profile->mode + newmode - 1;
             continue;
         }
@@ -283,7 +283,7 @@ int readcmd(usbdevice* kb, const char* line){
             continue;
         case RGB: {
             // RGB command has a special response for a single hex constant
-            int r, g, b;
+            uint r, g, b;
             if(sscanf(word, "%02x%02x%02x", &r, &g, &b) == 3){
                 // Set all keys
                 for(int i = 0; i < N_KEYS_EXTENDED; i++)
@@ -319,13 +319,13 @@ int readcmd(usbdevice* kb, const char* line){
         int position = 0, field = 0;
         char keyname[11] = { 0 };
         while(position < left && sscanf(word + position, "%10[^:,]%n", keyname, &field) == 1){
-            int keycode;
+            uint keycode;
             if(!strcmp(keyname, "all")){
                 // Set all keys
                 for(int i = 0; i < N_KEYS_EXTENDED; i++)
                     vt->do_cmd[command](kb, mode, notifynumber, i, right);
-            } else if((sscanf(keyname, "#%d", &keycode) && keycode >= 0 && keycode < N_KEYS_EXTENDED)
-                      || (sscanf(keyname, "#x%x", &keycode) && keycode >= 0 && keycode < N_KEYS_EXTENDED)){
+            } else if((sscanf(keyname, "#%u", &keycode) && keycode < N_KEYS_EXTENDED)
+                      || (sscanf(keyname, "#x%x", &keycode) && keycode < N_KEYS_EXTENDED)){
                 // Set a key numerically
                 vt->do_cmd[command](kb, mode, notifynumber, keycode, right);
             } else {

--- a/src/daemon/input.c
+++ b/src/daemon/input.c
@@ -310,7 +310,7 @@ void cmd_bind(usbdevice* kb, usbmode* mode, int dummy, int keyindex, const char*
     if(keyindex >= N_KEYS_INPUT)
         return;
     // Find the key to bind to
-    int tocode = 0;
+    uint tocode = 0;
     if(sscanf(to, "#x%ux", &tocode) != 1 && sscanf(to, "#%u", &tocode) == 1 && tocode < N_KEYS_INPUT){
         pthread_mutex_lock(imutex(kb));
         mode->bind.base[keyindex] = tocode;
@@ -370,9 +370,9 @@ static void _cmd_macro(usbmode* mode, const char* keys, const char* assignment, 
     int position = 0, field = 0;
     char keyname[24];
     while(position < left && sscanf(keys + position, "%10[^+]%n", keyname, &field) == 1){
-        int keycode;
-        if((sscanf(keyname, "#%d", &keycode) && keycode >= 0 && keycode < N_KEYS_INPUT)
-                  || (sscanf(keyname, "#x%x", &keycode) && keycode >= 0 && keycode < N_KEYS_INPUT)){
+        uint keycode;
+        if((sscanf(keyname, "#%u", &keycode) && keycode < N_KEYS_INPUT)
+                  || (sscanf(keyname, "#x%x", &keycode) && keycode < N_KEYS_INPUT)){
             // Set a key numerically
             SET_KEYBIT(macro.combo, keycode);
             empty = 0;
@@ -422,9 +422,9 @@ static void _cmd_macro(usbmode* mode, const char* keys, const char* assignment, 
 
         int down = (keyname[0] == '+');
         if(down || keyname[0] == '-'){
-            int keycode;
-            if((sscanf(keyname + 1, "#%d", &keycode) && keycode >= 0 && keycode < N_KEYS_INPUT)
-                      || (sscanf(keyname + 1, "#x%x", &keycode) && keycode >= 0 && keycode < N_KEYS_INPUT)){
+            uint keycode;
+            if((sscanf(keyname + 1, "#%u", &keycode) && keycode < N_KEYS_INPUT)
+                      || (sscanf(keyname + 1, "#x%x", &keycode) && keycode < N_KEYS_INPUT)){
                 // Set a key numerically
                 macro.actions[macro.actioncount].scan = kb->keymap[keycode].scan;
                 macro.actions[macro.actioncount].down = down;

--- a/src/daemon/profile.c
+++ b/src/daemon/profile.c
@@ -3,6 +3,7 @@
 #include "input.h"
 #include "led.h"
 #include "profile.h"
+#include "stdint.h"
 
 // Percent-enconding conversions
 void urldecode2(char* dst, const char* src){
@@ -62,9 +63,9 @@ void urlencode2(char* dst, const char* src){
 
 // GUID conversions
 int setid(usbid* id, const char* guid){
-    int32_t data1;
-    int16_t data2, data3, data4a;
-    char data4b[6];
+    uint data1;
+    ushort data2, data3, data4a;
+    uchar data4b[6];
     if(sscanf(guid, "{%08X-%04hX-%04hX-%04hX-%02hhX%02hhX%02hhX%02hhX%02hhX%02hhX}",
               &data1, &data2, &data3, &data4a, data4b, data4b + 1, data4b + 2, data4b + 3, data4b + 4, data4b + 5) != 10)
         return 0;
@@ -77,9 +78,9 @@ int setid(usbid* id, const char* guid){
 }
 
 char* getid(usbid* id){
-    int32_t data1;
-    int16_t data2, data3, data4a;
-    char data4b[6];
+    uint data1;
+    ushort data2, data3, data4a;
+    uchar data4b[6];
     memcpy(&data1, id->guid + 0x0, 4);
     memcpy(&data2, id->guid + 0x4, 2);
     memcpy(&data3, id->guid + 0x6, 2);
@@ -171,7 +172,7 @@ void cmd_id(usbdevice* kb, usbmode* mode, int dummy1, int dummy2, const char* id
     (void)dummy2;
 
     // ID is either a GUID or an 8-digit hex number
-    int newmodified;
+    uint newmodified;
     if(!setid(&mode->id, id) && sscanf(id, "%08x", &newmodified) == 1)
         memcpy(mode->id.modified, &newmodified, sizeof(newmodified));
 }
@@ -182,7 +183,7 @@ void cmd_profileid(usbdevice* kb, usbmode* mode, int dummy1, int dummy2, const c
     (void)dummy2;
 
     usbprofile* profile = kb->profile;
-    int newmodified;
+    uint newmodified;
     if(!setid(&profile->id, id) && sscanf(id, "%08x", &newmodified) == 1)
         memcpy(profile->id.modified, &newmodified, sizeof(newmodified));
 

--- a/src/gui/gradientbutton.cpp
+++ b/src/gui/gradientbutton.cpp
@@ -45,7 +45,7 @@ void GradientButton::fromString(const QString& string){
     uchar a, r, g, b;
     while(1){
         int scanned = 0;
-        char newpos;
+        signed char newpos;
         if(sscanf(data, "%hhd:%2hhx%2hhx%2hhx%2hhx%n", &newpos, &a, &r, &g, &b, &scanned) != 5)
             break;
         data += scanned;

--- a/src/gui/keymap.cpp
+++ b/src/gui/keymap.cpp
@@ -108,10 +108,10 @@ static const KeyPatch patchSE[] = {
     {"angle", "<", "bslash_iso"}, {"minus", "-", "slash"},
 };
 
-static const KeyPatch patchJP[] = {
-    /*{"lbrace", "[", "rbrace"},
-    {"rbrace", "]", "hash"},*/
-};
+/*static const KeyPatch patchJP[] = {
+    {"lbrace", "[", "rbrace"},
+    {"rbrace", "]", "hash"},
+};*/
 
 static const KeyPatch patchDvorak[] = {
     {0, "[", "minus"}, {0, "]", "equal"},

--- a/src/libs/ckb-next/include/ckb-next/animation.h
+++ b/src/libs/ckb-next/include/ckb-next/animation.h
@@ -114,7 +114,7 @@
 
 #define CKB_PARSE_LONG(param_name, value_ptr)                       if(!strcmp(name, param_name) && sscanf(value, "%ld", value_ptr) == 1)
 #define CKB_PARSE_DOUBLE(param_name, value_ptr)                     if(!strcmp(name, param_name) && sscanf(value, "%lf", value_ptr) == 1)
-#define CKB_PARSE_BOOL(param_name, value_ptr)                       if(!strcmp(name, param_name) && sscanf(value, "%u", value_ptr) == 1)
+#define CKB_PARSE_BOOL(param_name, value_ptr)                       if(!strcmp(name, param_name) && sscanf(value, "%d", value_ptr) == 1)
 #define CKB_PARSE_RGB(param_name, r_ptr, g_ptr, b_ptr)              if(!strcmp(name, param_name) && sscanf(value, "%2hhx%2hhx%2hhx", r_ptr, g_ptr, b_ptr) == 3)
 #define CKB_PARSE_ARGB(param_name, a_ptr, r_ptr, g_ptr, b_ptr)      if(!strcmp(name, param_name) && sscanf(value, "%2hhx%2hhx%2hhx%2hhx", a_ptr, r_ptr, g_ptr, b_ptr) == 4)
 #define CKB_PARSE_GRADIENT(param_name, gradient_ptr)                if(!strcmp(name, param_name) && ckb_scan_grad(value, gradient_ptr, 0))
@@ -302,7 +302,7 @@ int ckb_scan_grad(const char* string, ckb_gradient* gradient, int alpha){
     int count = 0;
     while(1){
         int scanned = 0;
-        char newpos;
+        signed char newpos;
         if(sscanf(string, "%hhd:%2hhx%2hhx%2hhx%2hhx%n", &newpos, &a, &r, &g, &b, &scanned) != 5)
             break;
         string += scanned;


### PR DESCRIPTION
Hello again,
I have again done some general minor fixes across the code base. Mainly in regards to some of the errors shown in the pedantic flags.

Some of these errors are likely to cause undefined or weird behaviour. Such as on clang the use of designated initializers as that is a GCC only extension.

Mostly just fixed issues with respect to sscanf, but at least now the code compiles under pedantic and seems to function.

I hope these changes are useful.

Kind regards,
Krish