### PR TITLE
Fix DPI indicator not switching to sniper/other

### DIFF
--- a/src/gui/kbperf.cpp
+++ b/src/gui/kbperf.cpp
@@ -391,6 +391,7 @@ void KbPerf::baseDpiIdx(int newIdx) {
 }
 
 quint64 KbPerf::pushDpi(const QPoint& newDpi, bool sniper){
+    _sniper = sniper;
     emit dpiChanged((sniper ? 0 : 6));
     quint64 index = runningPushIdx++;
     pushedDpis[index] = newDpi;
@@ -563,7 +564,7 @@ void KbPerf::applyIndicators(int modeIndex, const bool indicatorState[]){
         return;
     if(_dpiIndicator){
         // Set DPI indicator according to index
-        int index = baseDpiIdx();
+        int index = pushedDpis.isEmpty() ? baseDpiIdx() : _sniper - 1;
         if(index == -1 || index > OTHER)
             index = OTHER;
         lightIndicator("dpi", dpiClr[index].rgba());

--- a/src/gui/kbperf.h
+++ b/src/gui/kbperf.h
@@ -170,6 +170,8 @@ private:
     bool _angleSnap;
     // Misc
     bool _needsUpdate, _needsSave;
+    // Helper to tell if the active DPI is a sniper one or not
+    bool _sniper;
 };
 
 #endif // KBPERF_H


### PR DESCRIPTION
The correct solution would be to store the flag for each dpi in the stack, however there's no point in it as all the mice with the sniper button have an RGB indicator that can only display a single active DPI stage.