### PR TITLE
Clean up FindIconv.cmake test

### DIFF
--- a/cmake/modules/FindIconv.cmake
+++ b/cmake/modules/FindIconv.cmake
@@ -78,7 +78,7 @@ IF(ICONV_FOUND)
   #include <iconv.h>
   int main(){
     iconv_t conv = 0;
-    const char* in = 0;
+    char* in = 0;
     size_t ilen = 0;
     char* out = 0;
     size_t olen = 0;


### PR DESCRIPTION
The iconv.h header's iconv function does not take (const char **)
as its second argument, rather a (char **). Fixing the test
declaration allows paranoid compilers to continue.

Ref: http://pubs.opengroup.org/onlinepubs/7908799/xsh/iconv.h.html

Signed-off-by: Kevin Pearson <kevin.pearson@ortmanconsulting.com>