### PR TITLE
ensure KissFFT is static

### DIFF
--- a/src/libs/kissfft/CMakeLists.txt
+++ b/src/libs/kissfft/CMakeLists.txt
@@ -30,7 +30,8 @@
 # Upstream version from https://sourceforge.net/projects/kissfft/
 project(KissFFT LANGUAGES C VERSION 1.3.0)
 
-add_library(KissFFT kiss_fft.c)
+add_library(KissFFT STATIC
+            kiss_fft.c)
 add_library(KissFFT::KissFFT ALIAS KissFFT)
 
 target_sources(


### PR DESCRIPTION
This should fix issue #188 

See: https://cmake.org/cmake/help/latest/command/add_library.html

Library is meant to be build as static so mark it as so.