### PR TITLE
Don't hardcode /usr/lib

### DIFF
--- a/src/daemon/CMakeLists.txt
+++ b/src/daemon/CMakeLists.txt
@@ -419,7 +419,7 @@ if ("${CKB_NEXT_INIT_SYSTEM}" STREQUAL "launchd")
 elseif ("${CKB_NEXT_INIT_SYSTEM}" STREQUAL "systemd")
     install(
         FILES "${CMAKE_CURRENT_BINARY_DIR}/service/ckb-next-daemon.service"
-        DESTINATION "/usr/lib/systemd/system"
+        DESTINATION "${CMAKE_INSTALL_LIBDIR}/systemd/system"
         PERMISSIONS
         OWNER_READ OWNER_WRITE
         GROUP_READ

--- a/src/libs/ckb-next/CMakeLists.txt
+++ b/src/libs/ckb-next/CMakeLists.txt
@@ -75,12 +75,12 @@ if(NOT MACOS)
         NAMESPACE
           ${CMAKE_PROJECT_NAME}::
         DESTINATION
-          "/usr/lib/cmake/${CMAKE_PROJECT_NAME}/${PROJECT_NAME}")
+          "${CMAKE_INSTALL_LIBDIR}/cmake/${CMAKE_PROJECT_NAME}/${PROJECT_NAME}")
 
     install(
         FILES
           "cmake/${PROJECT_NAME}Config.cmake"
           "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}/${PROJECT_NAME}ConfigVersion.cmake"
         DESTINATION
-          "/usr/lib/cmake/${CMAKE_PROJECT_NAME}/${PROJECT_NAME}")
+          "${CMAKE_INSTALL_LIBDIR}/cmake/${CMAKE_PROJECT_NAME}/${PROJECT_NAME}")
 endif()


### PR DESCRIPTION
Use CMAKE_INSTALL_LIBDIR (provided by GNUInstallDirs module)
instead of hardcoding /usr/lib.