### PR TITLE
Reword and simplify the issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,34 +1,27 @@
-
 # Before you proceed
 
 - Read the [wiki](https://github.com/ckb-next/ckb-next/wiki).
-- Try the latest code by building the software manually.
 - Search in open and closed [Issues](https://github.com/ckb-next/ckb-next/issues).
+- If possible, try the latest code by building the software manually.
 - File unrelated issues separately.
 - Use [Markdown](https://github.com/adam-p/markdown-here/wiki/Markdown-Cheatsheet) to format the message.
-- There are 3 types of issues: new device, feature, bug. Use only one. Delete redundant sections before sending.
+
+This issue template has 3 main sections of which you should use only 1:
+- [New Device Support Request](#new-device-support-request),
+- [Feature Request](#feature-request), or
+- [Bug Report](#bug-report).
+
+If your issue doesn't fit in any of those categories, please use the [#something-else] section at the bottom.
+Delete the redundant sections before sending.
+
+**Click the `Generate Report` button in the `Settings` tab of the ckb-next user interface and attach the generated report to this issue.**
 
 ---
 
-# Devices information
-
-Open a terminal and execute:
-```
-curl https://raw.githubusercontent.com/ckb-next/ckb-next/master/ckb-next-dev-detect 2>/dev/null | bash
-```
-
-Upload `ckb-next-dev-detect-report.gz` with this issue.
-
----
 
 # New device support request
 
-Upload:
-  * Linux:
-    * `ckb-next-dev-detect-report.gz` from the section above
-  * macOS:
-    * `ckb-next-dev-detect-report.gz` from the section above
-    * full USB bus dump by following [the instructions](https://github.com/mattanger/ckb-next/issues/31#issuecomment-285380447)
+Enter the name of your device here and attach the report generated above.
 
 ---
 
@@ -56,9 +49,9 @@ Upload:
 
 ## Logs & crash reports
 
-Upload:
- * `ckb-next-dev-detect-report.gz` from the section above
- * any additional crash reports you've managed to gather
+Attach:
+ * The generated report from the section above
+ * Any additional crash reports you've managed to gather
 
 ## What is the program's current behavior?
 


### PR DESCRIPTION
I have simplified the issue template, and it no longer tells people to run curl | bash for dev detect, instead instructing them to click the Generate Report button in the GUI.

There were also some minor wording changes.