### PR TITLE
src/daemon: fix installation location of udev rules.

### DIFF
--- a/src/daemon/CMakeLists.txt
+++ b/src/daemon/CMakeLists.txt
@@ -456,7 +456,7 @@ endif ()
 if (LINUX)
   install(
     FILES "${CMAKE_SOURCE_DIR}/linux/udev/99-ckb-daemon.rules"
-    DESTINATION "/etc/udev/rules.d"
+    DESTINATION "/usr/lib/udev/rules.d"
     PERMISSIONS
     OWNER_READ OWNER_WRITE
     GROUP_READ


### PR DESCRIPTION
Install to /usr/lib/udev/rules.d since that is the correct location
for package-provided configuration.

/etc/udev/rules.d is reserved for local administrators that takes
precedence over /usr/lib/udev/rules.d when udev is searching for rules