### PR TITLE
Named Threads

### DIFF
--- a/src/daemon/includes.h
+++ b/src/daemon/includes.h
@@ -66,4 +66,6 @@ void timespec_add(struct timespec* timespec, long nanoseconds);
 // Common structs
 #include "structures.h"
 
+#define THREAD_NAME_MAX 16
+
 #endif  // INCLUDES_H

--- a/src/daemon/input.c
+++ b/src/daemon/input.c
@@ -83,6 +83,10 @@ static void* play_macro(void* param) {
     usbdevice* kb = ptr->kb;
     keymacro* macro = ptr->macro;
 
+#ifdef OS_MAC
+    pthread_setname_np("ckb macro");
+#endif // OS_MAC
+
     /// First have a look if we are the first and only macro-thread to run. If not, wait.
     /// So enqueue our thread first, so it is remembered for us and can be seen by all others.
     pthread_mutex_lock(mmutex2(kb));
@@ -160,8 +164,11 @@ static void inputupdate_keys(usbdevice* kb){
                         } else {
                             macro->triggered = 1;
 
-                            // name thread if it was created, ignore the result
+#ifndef OS_MAC
+                            // name thread externally if it was created on non-mac systems
+                            // ignore the result
                             pthread_setname_np(thread, "ckb macro");
+#endif // OS_MAC
                         }
                     }
                 }

--- a/src/daemon/input.c
+++ b/src/daemon/input.c
@@ -1,3 +1,5 @@
+#include "os.h"
+
 #include <limits.h>
 #include "device.h"
 #include "input.h"
@@ -157,6 +159,9 @@ static void inputupdate_keys(usbdevice* kb){
                             perror("inputupdate_keys: Creating thread returned not null");
                         } else {
                             macro->triggered = 1;
+
+                            // name thread if it was created, ignore the result
+                            pthread_setname_np(thread, "ckb macro");
                         }
                     }
                 }

--- a/src/daemon/input_linux.c
+++ b/src/daemon/input_linux.c
@@ -209,9 +209,15 @@ int os_setupindicators(usbdevice* kb){
     kb->hw_ileds = kb->hw_ileds_old = kb->ileds = 0;
     // Create and detach thread to read LED events
     pthread_t thread;
+    // Give the thread a reasonable name
+    char ledthread_name[THREAD_NAME_MAX] = "ckbX led";
+
     int err = pthread_create(&thread, 0, _ledthread, kb);
     if(err != 0)
         return err;
+
+    ledthread_name[3] = INDEX_OF(kb, keyboard) + '0';
+    pthread_setname_np(thread, ledthread_name);
     pthread_detach(thread);
     return 0;
 }

--- a/src/daemon/input_mac.c
+++ b/src/daemon/input_mac.c
@@ -185,7 +185,7 @@ void os_keypress(usbdevice* kb, int scancode, int down){
     }
     // Pick the appropriate add or remove function
     add_remove_keys = down ? &add_to_keys : &remove_from_keys;
-    
+
     if(scancode == KEY_FN) {
         (*add_remove_keys)(scancode, &(kb->kbinput_avtopcase.keys));
         IOConnectCallStructMethod(kb->event, post_apple_vendor_top_case_input_report, &kb->kbinput_avtopcase, sizeof(kb->kbinput_avtopcase), NULL, 0);
@@ -209,8 +209,13 @@ void os_keypress(usbdevice* kb, int scancode, int down){
                     // The thread is only spawned if kb->indicthread is null.
                     // Due to the logic inside the thread, this means that it could theoretically be spawned twice, but never a third time.
                     // Moreover, if it is spawned more than once, the indicator state will remain correct due to dmutex staying locked.
-                    if(!pthread_create(&kb->indicthread, 0, indicator_update, kb))
+                    if(!pthread_create(&kb->indicthread, 0, indicator_update, kb)) {
+                        char indicthread_name[THREAD_NAME_MAX] = "ckbX indicator";
+                        indicthread_name[3] = INDEX_OF(kb, keyboard) + '0';
+                        pthread_setname_np(kb->indicthread, indicthread_name);
+
                         pthread_detach(kb->indicthread);
+                    }
                 }
             }
         }

--- a/src/daemon/input_mac_legacy.c
+++ b/src/daemon/input_mac_legacy.c
@@ -378,6 +378,10 @@ void os_keypress(usbdevice* kb, int scancode, int down){
             // Due to the logic inside the thread, this means that it could theoretically be spawned twice, but never a third time.
             // Moreover, if it is spawned more than once, the indicator state will remain correct due to dmutex staying locked.
             if(!pthread_create(&kb->indicthread, 0, indicator_update, kb))
+                char indicthread_name[THREAD_NAME_MAX] = "ckbX indicator";
+                indicthread_name[3] = INDEX_OF(kb, keyboard) + '0';
+                pthread_setname_np(kb->indicthread, indicthread_name);
+
                 pthread_detach(kb->indicthread);
         }
     }

--- a/src/daemon/input_mac_legacy.c
+++ b/src/daemon/input_mac_legacy.c
@@ -301,7 +301,12 @@ void keyretrigger(CFRunLoopTimerRef timer, void* info){
 // However, updating indicator state requires locking dmutex and we never want to do that in the input thread.
 // Instead, we launch a single-shot thread to update the state.
 static void* indicator_update(void* context){
+    char indicthread_name[THREAD_NAME_MAX] = "ckbX indicator";
     usbdevice* kb = context;
+
+    indicthread_name[3] = INDEX_OF(kb, keyboard) + '0';
+    pthread_setname_np(indicthread_name);
+
     pthread_mutex_lock(dmutex(kb));
     {
         pthread_mutex_lock(imutex(kb));
@@ -378,10 +383,6 @@ void os_keypress(usbdevice* kb, int scancode, int down){
             // Due to the logic inside the thread, this means that it could theoretically be spawned twice, but never a third time.
             // Moreover, if it is spawned more than once, the indicator state will remain correct due to dmutex staying locked.
             if(!pthread_create(&kb->indicthread, 0, indicator_update, kb))
-                char indicthread_name[THREAD_NAME_MAX] = "ckbX indicator";
-                indicthread_name[3] = INDEX_OF(kb, keyboard) + '0';
-                pthread_setname_np(kb->indicthread, indicthread_name);
-
                 pthread_detach(kb->indicthread);
         }
     }

--- a/src/daemon/usb_mac.c
+++ b/src/daemon/usb_mac.c
@@ -395,9 +395,15 @@ void register_mouse_event_tap(CFRunLoopTimerRef timer, void* info) {
 extern void keyretrigger(CFRunLoopTimerRef timer, void* info);
 #endif
 void* os_inputmain(void* context){
+    char inputthread_name[THREAD_NAME_MAX] = "ckbX input";
     usbdevice* kb = context;
 
     int index = INDEX_OF(kb, keyboard);
+
+    // name thread for debugging purposes
+    inputthread_name[3] = index + '0';
+    pthread_setname_np(inputthread_name);
+
     // Monitor input transfers on all endpoints for legacy devices
     // For non legacy ones, monitor all but the last, as it's used for input/output
     int count = IS_LEGACY_DEV(kb) ? kb->epcount : (kb->epcount - 1);


### PR DESCRIPTION
This PR addresses #329 

Use `pthread_setname_np` to supply names to threads to help differentiating them when debugging. This unfortunately needs to be separately done on BSD and Linux systems because the BSD version of this function only names the current thread and thus needs to be called from within the appropriate thread. The Linux version needs the thread to be named as its first argument and thus needs to be calls outside of the thread.

This PR makes the necessary distinctions between the mac and non-mac code and uses the above mentioned routine to name the threads.

Tested named usb- and input-threads on Arch Linux x86 kernel v4.20, and macOS Mojave. (I didn't test the macro threads, though.)