### PR TITLE
Convert usb ids to unsigned shorts

### DIFF
--- a/src/daemon/firmware.c
+++ b/src/daemon/firmware.c
@@ -33,7 +33,7 @@ int getfwversion(usbdevice* kb){
         sprintf(ident_str + (3 * i), "%02hhx ", in_pkt[i]);
     }
     ckb_info("Received identification packet: %s\n", ident_str);
-    short vendor, product, version, bootloader;
+    ushort vendor, product, version, bootloader;
     // Copy the vendor ID, product ID, version, and poll rate from the firmware data
     memcpy(&version, in_pkt + 8, 2);
     memcpy(&bootloader, in_pkt + 10, 2);

--- a/src/daemon/structures.h
+++ b/src/daemon/structures.h
@@ -261,7 +261,7 @@ typedef struct {
     // Device serial number
     char serial[SERIAL_LEN];
     // USB vendor and product IDs
-    short vendor, product;
+    ushort vendor, product;
     // Firmware version
     ushort fwversion;
     // Poll rate (ms), or -1 if unsupported

--- a/src/daemon/usb.c
+++ b/src/daemon/usb.c
@@ -79,7 +79,7 @@ int features_mask = -1;
 /// else it returns ""
 ///
 /// \attention There is also a string defined V_CORSAIR_STR, which returns the device number as string in hex "1b1c".
-const char* vendor_str(short vendor){
+const char* vendor_str(ushort vendor){
     if(vendor == V_CORSAIR)
         return "corsair";
     return "";
@@ -106,7 +106,7 @@ const char* vendor_str(short vendor){
 /// The macros need the \a kb*,
 /// product_str() needs the \a product \a ID
 ///
-const char* product_str(short product){
+const char* product_str(ushort product){
     if(product == P_K95 || product == P_K95_LEGACY)
         return "k95";
     if(product == P_K95_PLATINUM)
@@ -162,7 +162,7 @@ const char* product_str(short product){
 ///
 /// \todo Is the last point really a good decision and always correct?
 ///
-static const devcmd* get_vtable(short vendor, short product){
+static const devcmd* get_vtable(ushort vendor, ushort product){
     // return IS_MOUSE(vendor, product) ? &vtable_mouse : !IS_LEGACY(vendor, product) ? &vtable_keyboard : &vtable_keyboard_nonrgb;
     if(IS_MOUSE(vendor, product))
         return &vtable_mouse;
@@ -300,7 +300,7 @@ static void* _setupusb(void* context){
     usbdevice* kb = context;
     pthread_mutex_lock(imutex(kb));
     // Set standard fields
-    short vendor = kb->vendor, product = kb->product;
+    ushort vendor = kb->vendor, product = kb->product;
     const devcmd* vt = kb->vtable = get_vtable(vendor, product);
     kb->features = (IS_LEGACY(vendor, product) ? FEAT_STD_LEGACY : FEAT_STD_RGB) & features_mask;
     if(IS_MOUSE(vendor, product)) kb->features |= FEAT_ADJRATE;

--- a/src/daemon/usb.h
+++ b/src/daemon/usb.h
@@ -14,9 +14,8 @@
 ///
 /// The list of defines in the first part of the file describes the various types of equipment from Corsair
 /// and summarizes them according to specific characteristics.
-/// \n Each device type is described with two defines:
-/// - On the one hand the device ID with which the device can be recognized on the USB as a short
-/// - and on the other hand the same representation as a string, but without leading "0x".
+/// \n Each device type is described with a define:
+///  - The device ID with which the device can be recognized on the USB as a ushort
 ///
 /// First entry-pair is the Provider ID (vendorID) from Corsair.
 ///
@@ -134,15 +133,15 @@ extern ushort models[];
 
 ///
 /// \brief vendor_str Vendor/product string representations
-/// \param vendor \a short vendor ID
+/// \param vendor \a ushort vendor ID
 /// \return a string: either "" or "corsair"
-const char* vendor_str(short vendor);
+const char* vendor_str(ushort vendor);
 
 ///
 /// \brief product_str returns a condensed view on what type of device we have.
-/// \param product is the \a short USB device product ID
+/// \param product is the \a ushort USB device product ID
 /// \return string to identify a type of device (see below)
-const char* product_str(short product);
+const char* product_str(ushort product);
 
 // Used for devices that use the CUE protocol but have no backlight
 #define HAS_NO_LIGHTS(kb)               (IS_K66(kb))

--- a/src/daemon/usb_linux.c
+++ b/src/daemon/usb_linux.c
@@ -270,7 +270,7 @@ void os_sendindicators(usbdevice* kb) {
 void* os_inputmain(void* context){
     usbdevice* kb = context;
     int fd = kb->handle - 1;
-    short vendor = kb->vendor, product = kb->product;
+    ushort vendor = kb->vendor, product = kb->product;
     int index = INDEX_OF(kb, keyboard);
     ckb_info("Starting input thread for %s%d\n", devpath, index);
 
@@ -614,7 +614,7 @@ int os_setupusb(usbdevice* kb) {
     return 0;
 }
 
-int usbadd(struct udev_device* dev, short vendor, short product) {
+int usbadd(struct udev_device* dev, ushort vendor, ushort product) {
     const char* path = udev_device_get_devnode(dev);
     const char* syspath = udev_device_get_syspath(dev);
     if(!path || !syspath || path[0] == 0 || syspath[0] == 0){

--- a/src/gui/fwupgradedialog.cpp
+++ b/src/gui/fwupgradedialog.cpp
@@ -6,8 +6,8 @@
 
 // IDs for verifying firmware suitability
 struct KbId {
-    short vendor;
-    short product;
+    ushort vendor;
+    ushort product;
     const char* feature;
 };
 
@@ -68,8 +68,8 @@ void FwUpgradeDialog::cleanBlob(){
 }
 
 // Returns firmware version if valid for device, 0 if invalid
-static float verifyFw(const QByteArray& blob, const short productID) {
-    short vendor = 0x1b1c;      ///< Corsair has at the moment just one vendorID
+static float verifyFw(const QByteArray& blob, const ushort productID) {
+    ushort vendor = 0x1b1c;      ///< Corsair has at the moment just one vendorID
     if(blob.length() < 0x0108)
         return 0.f;
     const char* bData = blob.data();
@@ -88,7 +88,7 @@ static float verifyFw(const QByteArray& blob, const short productID) {
 }
 
 int FwUpgradeDialog::exec(){
-    short productID = kb->productID;
+    ushort productID = kb->productID;
 
     if(!blob.isEmpty()){
         // If a blob was already specified, check its version and validity

--- a/src/gui/kb.h
+++ b/src/gui/kb.h
@@ -17,7 +17,7 @@ public:
     // Device information
     QString features, firmware, pollrate;
     bool monochrome;
-    short productID;
+    ushort productID;
     bool hwload;
 
     // Keyboard model

--- a/src/gui/kbfirmware.cpp
+++ b/src/gui/kbfirmware.cpp
@@ -134,7 +134,7 @@ void KbFirmware::processDownload(QNetworkReply* reply){
         fw.ckbVersion = KbManager::parseVersionString(components[4]);       // Minimum ckb version
         fw.fileName = QUrl::fromPercentEncoding(components[5].toLatin1());  // Name of file inside zip
         fw.hash = QByteArray::fromHex(components[6].toLatin1());            // SHA256 of file inside zip
-        fw.productID = components[7].toShort(&ok, 16);                      // Hex productID assigned to this FW
+        fw.productID = components[7].toUShort(&ok, 16);                      // Hex productID assigned to this FW
         // Update entry
         fwTable[QString::number(fw.productID)] = fw;
         // qDebug() << "saving fwTabel entry[" << QString::number(fw.productID) << "] for device" << device
@@ -152,7 +152,7 @@ void KbFirmware::downloadFinished(){
     emit downloaded();
 }
 
-float KbFirmware::_latestForBoard(const short productID, bool waitForComplete) {
+float KbFirmware::_latestForBoard(const ushort productID, bool waitForComplete) {
     if((tableDownload || checkUpdates()) && waitForComplete){
         // If waiting is desired, enter an event loop and stay here until the download is finished
         QEventLoop loop(this);
@@ -173,7 +173,7 @@ float KbFirmware::_latestForBoard(const short productID, bool waitForComplete) {
     return info.fwVersion;
 }
 
-QByteArray KbFirmware::_fileForBoard(const short productID){
+QByteArray KbFirmware::_fileForBoard(const ushort productID){
     FW info = fwTable.value(QString::number(productID));
     if(info.hash.isEmpty())
         return "";

--- a/src/gui/kbfirmware.h
+++ b/src/gui/kbfirmware.h
@@ -19,10 +19,10 @@ public:
 
     // Latest firmware version for a keyboard model. Will check for updates automatically and return the latest known version.
     // Zero if version unknown, -1.0 if ckb needs to be upgraded.
-    static inline float         versionForBoard(const short productID, bool waitForComplete = false)  { return instance._latestForBoard(productID, waitForComplete); }
+    static inline float         versionForBoard(const ushort productID, bool waitForComplete = false)  { return instance._latestForBoard(productID, waitForComplete); }
 
     // Downloads and extracts the latest firmware for a keyboard. Returns an empty array on failure.
-    static inline QByteArray    dataForBoard(const short productID)                                   { return instance._fileForBoard(productID); }
+    static inline QByteArray    dataForBoard(const ushort productID)                                   { return instance._fileForBoard(productID); }
 
     // Network manager object to use with QtNetwork
     QNetworkAccessManager* 	networkManager;
@@ -38,7 +38,7 @@ private:
         QString     url, fileName;
         QByteArray  hash;
         float       fwVersion, ckbVersion;
-        short       productID;
+        ushort       productID;
         FW();
     };
     QMap<QString, FW>   fwTable;
@@ -53,8 +53,8 @@ private:
 
     // Singleton instance
     bool                _checkUpdates();
-    float               _latestForBoard(const short productID, bool waitForComplete);
-    QByteArray          _fileForBoard(const short productID);
+    float               _latestForBoard(const ushort productID, bool waitForComplete);
+    QByteArray          _fileForBoard(const ushort productID);
     static KbFirmware   instance;
 
 signals:


### PR DESCRIPTION
The reason for this is that the usb id for the Y730 is 0xc935, which doesn't fit in a signed short.
https://github.com/ckb-next/ckb-next/issues/330#issuecomment-451611244

That said, I'm not sure why they were a signed shorts in the first place. Both VID/PID are unsigned 16 bit numbers.

Tested minimally, but everything seems to function, including firmware updates.