### PR TITLE
Mutex fix

### DIFF
--- a/src/daemon/profile.c
+++ b/src/daemon/profile.c
@@ -93,19 +93,16 @@ char* getid(usbid* id){
 }
 
 // UTF-8/UTF-16 conversions (srclen and dstlen in characters - 1 byte UTF8, 2 bytes UTF16)
-static iconv_t utf8to16 = 0, utf16to8 = 0;
-
 void u16enc(char* in, ushort* out, size_t* srclen, size_t* dstlen){
-    if(!utf8to16)
-        utf8to16 = iconv_open("UTF-16LE", "UTF-8");
+    iconv_t utf8to16 = iconv_open("UTF-16LE", "UTF-8");
     memset(out, 0, *dstlen * 2);
     *dstlen = *dstlen * 2 - 2;
     iconv(utf8to16, &in, srclen, (char**)&out, dstlen);
+    iconv_close(utf8to16);
 }
 
 void u16dec(ushort* in, char* out, size_t* srclen, size_t* dstlen){
-    if(!utf16to8)
-        utf16to8 = iconv_open("UTF-8", "UTF-16LE");
+    iconv_t utf16to8 = iconv_open("UTF-8", "UTF-16LE");
     size_t srclen2 = 0, srclenmax = *srclen;
     for(; srclen2 < srclenmax; srclen2++){
         if(!in[srclen2])
@@ -113,6 +110,7 @@ void u16dec(ushort* in, char* out, size_t* srclen, size_t* dstlen){
     }
     *srclen = srclen2 * 2;
     iconv(utf16to8, (char**)&in, srclen, &out, dstlen);
+    iconv_close(utf16to8);
 }
 
 void cmd_name(usbdevice* kb, usbmode* mode, int dummy1, int dummy2, const char* name){

--- a/src/daemon/usb.c
+++ b/src/daemon/usb.c
@@ -298,6 +298,7 @@ static void* _setupusb(void* context){
     /// - the standard delay time is initialized in kb->usbdelay
     ///
     usbdevice* kb = context;
+    pthread_mutex_lock(dmutex(kb));
     pthread_mutex_lock(imutex(kb));
     // Set standard fields
     short vendor = kb->vendor, product = kb->product;

--- a/src/daemon/usb_linux.c
+++ b/src/daemon/usb_linux.c
@@ -651,6 +651,7 @@ int usbadd(struct udev_device* dev, short vendor, short product) {
                 strncpy(kbsyspath[index], syspath, FILENAME_MAX);
                 // Mutex remains locked
                 setupusb(kb);
+                pthread_mutex_unlock(dmutex(kb));
                 return 0;
             }
         }

--- a/src/daemon/usb_mac.c
+++ b/src/daemon/usb_mac.c
@@ -729,8 +729,7 @@ release:
     // If the HID handles are already opened, set up the device
     if(HAS_ALL_HANDLES(kb))
         setupusb(kb);
-    else
-        pthread_mutex_unlock(devmutex + index);
+    pthread_mutex_unlock(devmutex + index);
     *rm_notify = kb->rm_notify;
     return kb;
 
@@ -882,9 +881,8 @@ static usbdevice* add_hid(hid_dev_t handle, io_object_t** rm_notify){
     if(HAS_ALL_HANDLES(kb))
         // If all handles have been opened, we're ready to set up the device
         setupusb(kb);
-    else
-        // Otherwise, return and keep going
-        pthread_mutex_unlock(devmutex + index);
+    // Otherwise, return and keep going
+    pthread_mutex_unlock(devmutex + index);
     *rm_notify = kb->rm_notify + IFACE_MAX + 1 + handle_idx;
     return kb;
 


### PR DESCRIPTION
The dmutex used to be locked and unlocked by different threads, which is not defined.
Additionally, iconv was shared between threads, which caused data race warnings.