### PR TITLE
Remove restarting capabilities

### DIFF
--- a/src/daemon/command.c
+++ b/src/daemon/command.c
@@ -52,8 +52,7 @@ static const char* const cmd_strings[CMD_COUNT - 1] = {
 
     "notify",
     "inotify",
-    "get",
-    "restart"
+    "get"
 };
 
 #define TRY_WITH_RESET(action)  \
@@ -99,8 +98,7 @@ int readcmd(usbdevice* kb, const char* line){
                 if(command != SWITCH
                         && command != HWLOAD && command != HWSAVE
                         && command != ACTIVE && command != IDLE
-                        && command != ERASE && command != ERASEPROFILE
-                        && command != RESTART)
+                        && command != ERASE && command != ERASEPROFILE)
                     goto next_loop;
                 break;
             }
@@ -213,14 +211,6 @@ int readcmd(usbdevice* kb, const char* line){
                 // bad parameter to handle false commands like "delay off"
                 kb->delay = 0; // No delay.
             }
-            continue;
-        }
-        case RESTART: {
-            char mybuffer[] = "no reason specified";
-            if (sscanf(line, " %[^\n]", word) == -1) { ///< Because length of word is length of line + 1, there should be no problem with buffer overflow.
-                word = mybuffer;
-            }
-            vt->do_cmd[command](kb, mode, notifynumber, 0, word);
             continue;
         }
         default:;

--- a/src/daemon/command.h
+++ b/src/daemon/command.h
@@ -58,9 +58,8 @@ typedef enum {
     NOTIFY,
     INOTIFY,
     GET,
-    RESTART,
 
-    CMD_LAST = RESTART
+    CMD_LAST = GET
 } cmd;
 #define CMD_COUNT       (CMD_LAST - CMD_FIRST + 2)
 #define CMD_DEV_COUNT   (CMD_LAST - CMD_VT_FIRST + 1)
@@ -118,7 +117,6 @@ typedef union devcmd {
         cmdhandler notify;
         cmdhandler inotify;
         cmdhandler get;
-        cmdhandler restart;
 
         // Extra functions not command-related
         // device.h

--- a/src/daemon/device_vtable.c
+++ b/src/daemon/device_vtable.c
@@ -83,7 +83,6 @@ const devcmd vtable_keyboard = {
     .notify = cmd_notify,
     .inotify = cmd_inotify,
     .get = cmd_get,
-    .restart = cmd_restart,
 
     .start = start_dev,
     .setmodeindex = int1_void_none,             ///< is just for non rgb keyboards
@@ -130,7 +129,6 @@ const devcmd vtable_keyboard_legacy = {
     .notify = cmd_notify,
     .inotify = cmd_inotify,
     .get = cmd_get,
-    .restart = cmd_restart,
 
     .start = start_kb_legacy,
     .setmodeindex = setmodeindex_legacy,        ///< This is special for legacy keyboards
@@ -177,7 +175,6 @@ const devcmd vtable_mouse = {
     .notify = cmd_notify,
     .inotify = cmd_none,
     .get = cmd_get,
-    .restart = cmd_restart,
 
     .start = start_dev,
     .setmodeindex = int1_void_none,         ///< Mice do not have different modes

--- a/src/daemon/main.c
+++ b/src/daemon/main.c
@@ -5,16 +5,12 @@
 #include "notify.h"
 #include <ckbnextconfig.h>
 
-static int main_ac;
-static char **main_av;
-
 // usb.c
 extern volatile int reset_stop;
 extern int features_mask;
 // device.c
 extern int hwload_mode;
 static void quitWithLock(char mut);
-extern int restart();
 
 // Timespec utility function
 void timespec_add(struct timespec* timespec, long nanoseconds){
@@ -90,8 +86,6 @@ int main(int argc, char** argv){
     // Set output pipes to buffer on newlines, if they weren't set that way already
     setlinebuf(stdout);
     setlinebuf(stderr);
-    main_ac = argc;
-    main_av = argv;
 
     printf("ckb-next: Corsair RGB driver %s\n", CKB_NEXT_VERSION_STR);
     // If --help occurs anywhere in the command-line, don't launch the program but instead print usage
@@ -217,22 +211,14 @@ int main(int argc, char** argv){
     sigdelset(&signals, SIGTERM);
     sigdelset(&signals, SIGINT);
     sigdelset(&signals, SIGQUIT);
-    sigdelset(&signals, SIGUSR1);
     // Set up signal handlers for quitting the service.
     sigprocmask(SIG_SETMASK, &signals, 0);
     signal(SIGTERM, sighandler);
     signal(SIGINT, sighandler);
     signal(SIGQUIT, sighandler);
-    signal(SIGUSR1, (void (*)())restart);
 
     // Start the USB system
     int result = usbmain();
     quit();
     return result;
-}
-
-int restart() {
-    ckb_err("restart called, running quit without mutex-lock.\n");
-    quitWithLock(0);
-    return main(main_ac, main_av);
 }

--- a/src/daemon/notify.c
+++ b/src/daemon/notify.c
@@ -219,15 +219,3 @@ void cmd_get(usbdevice* kb, usbmode* mode, int nnumber, int dummy, const char* s
     _cmd_get(kb, mode, nnumber, setting);
     pthread_mutex_unlock(imutex(kb));
 }
-
-extern int restart();
-
-void cmd_restart(usbdevice* kb, usbmode* mode, int nnumber, int dummy, const char* content) {
-    (void)mode;
-    (void)nnumber;
-    (void)dummy;
-
-    ckb_info("RESTART called with %s\n", content);
-    nprintf(kb, -1, 0, "RESTART called with %s\n", content);
-    restart();
-}

--- a/src/daemon/notify.h
+++ b/src/daemon/notify.h
@@ -24,8 +24,4 @@ void cmd_notify(usbdevice* kb, usbmode* mode, int nnumber, int keyindex, const c
 // MUTEXES: Locks imutex during operation. Unlocks on close.
 void cmd_get(usbdevice* kb, usbmode* mode, int nnumber, int dummy, const char* setting);
 
-// Just for debugging puposes. Should echo the given string to stderr ([I]) and all open notify channels.
-// At last it does a restart of the daemon
-void cmd_restart(usbdevice* kb, usbmode* mode, int nnumber, int dummy, const char* content);
-
 #endif  // NOTIFY_H


### PR DESCRIPTION
As discussed in `#ckb-next` on friday the 25. january of 2019, the restart
functionality is ok to be remove.

This commit basically reverts the function to restart the daemon which
was introduced in 64bebfef. This decision was based on the fact, that
this functionality is a) not widespreadedly enough used to b) justify
the suboptimal implementation (and its impact on the debugging).