### PR TITLE
Improve safety of signal handling

### DIFF
--- a/src/daemon/includes.h
+++ b/src/daemon/includes.h
@@ -17,8 +17,10 @@
 #include <sys/errno.h>
 #include <sys/ioctl.h>
 #include <sys/signal.h>
+#include <sys/socket.h>
 #include <sys/stat.h>
 #include <sys/time.h>
+#include <sys/types.h>
 
 // Unsigned char/short definition
 typedef unsigned char uchar;
@@ -67,5 +69,7 @@ void timespec_add(struct timespec* timespec, long nanoseconds);
 #include "structures.h"
 
 #define THREAD_NAME_MAX 16
+#define SIGHANDLER_SENDER   0
+#define SIGHANDLER_RECEIVER 1
 
 #endif  // INCLUDES_H

--- a/src/daemon/main.c
+++ b/src/daemon/main.c
@@ -234,13 +234,6 @@ int main(int argc, char** argv){
 
     // Attempt to setup signal-safe signal handlers using socketpair(2)
     if (socketpair(AF_LOCAL, SOCK_STREAM, 0, sighandler_pipe) != -1){
-        sigset_t signals;
-        sigfillset(&signals);
-        sigdelset(&signals, SIGTERM);
-        sigdelset(&signals, SIGINT);
-        sigdelset(&signals, SIGQUIT);
-        // Set up signal handlers for quitting the service.
-        sigprocmask(SIG_SETMASK, &signals, 0);
         signal(SIGTERM, sighandler);
         signal(SIGINT, sighandler);
         signal(SIGQUIT, sighandler);

--- a/src/daemon/usb.h
+++ b/src/daemon/usb.h
@@ -217,7 +217,7 @@ const char* product_str(ushort product);
 #define IS_MOUSEPAD_DEV(kb)             IS_MOUSEPAD((kb)->vendor, (kb)->product)
 
 #define USB_DELAY_DEFAULT   5
-        
+
 /// Start the USB main loop. Returns program exit code when finished
 int usbmain();
 
@@ -379,5 +379,9 @@ int _nk95cmd(usbdevice* kb, uchar bRequest, ushort wValue, const char* file, int
 int usb_tryreset(usbdevice* kb);
 
 void print_urb_buffer(const char* prefix, const unsigned char* buffer, int actual_length, const char* file, int line, const char* function, int devnum);
+
+// receive message from initial sighandler socketpair communication
+extern int sighandler_pipe[2];
+extern void exithandler(int type);
 
 #endif  // USB_H


### PR DESCRIPTION
This commit introduces a safer signal handling routine by splitting this
workflow into catching and handling of signals. In the catching routine
no unsafe function call is allowed (signal-safety(7)).

The general idea is generate a local socketpair (acting as an anonymous
pipe) that is written to with the caught signal type in the direct
sighandler routine. The calling of the routine that actually handles the
interrupts is elevated to the main loops, where the pipe is monitored.
As soon as data is available on the pipe it is read and the
sighandling-routine is called manually. This allows for greater freedom
of function calls to handle the signal with.

- Create anonymous socket pair for sending/receiving intent, only setup
  signal handlers if the socket pair exists.
- Call `write` to sender side of socket pair in signal-catching
  function.
- Replace `printf` with signal-safe `write` function in nested
  `ignore_signal` handler.
- [usb] Declare the socket pair and the exit condition as externally
  defined for calling them from inside the main loops.
- [macOS] Setup and read from receiver side via a core foundation socket
  object, that is registered as a CF Run Loop Source, deconstructed into
  a native socket and read from in the appropriate handler.
- [linux] Check whether data is available on the pipe when `select`
  returns -1, indicating that there has been an error (e.g. a signal).
  Manually call the signal handling routine with the read data if there
  is.