### PR TITLE
Debianizing ckb-next

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -116,7 +116,13 @@ if (MACOS)
     set(INSTALL_DIR_ANIMATIONS "ckb-next.app/Contents/Resources/${ANIMATIONS_DIR_NAME}"
         CACHE STRING "Where to install animations.")
 elseif (LINUX)
-    set(INSTALL_DIR_ANIMATIONS "${CMAKE_INSTALL_LIBEXECDIR}/${ANIMATIONS_DIR_NAME}"
+    option(DEBIANIZE_INSTALL_PATHS "Install files according to Debian and FreeDesktop.org policy" OFF)
+    if (${DEBIANIZE_INSTALL_PATHS})
+        set(_ANIMATION_PREFIX ${CMAKE_INSTALL_LIBDIR})
+    else()
+        set(_ANIMATION_PREFIX ${CMAKE_INSTALL_LIBEXECDIR})
+    endif()
+    set(INSTALL_DIR_ANIMATIONS "${_ANIMATION_PREFIX}/${ANIMATIONS_DIR_NAME}"
         CACHE STRING "Where to install animations.")
 endif ()
 

--- a/linux/ckb-next.autostart.desktop.in
+++ b/linux/ckb-next.autostart.desktop.in
@@ -2,7 +2,6 @@
 # Distributed under the terms of the GNU General Public License v2
 
 [Desktop Entry]
-Encoding=UTF-8
 Version=1.0
 Type=Application
 Name=ckb-next

--- a/linux/ckb-next.desktop.in
+++ b/linux/ckb-next.desktop.in
@@ -2,7 +2,6 @@
 # Distributed under the terms of the GNU General Public License v2
 
 [Desktop Entry]
-Encoding=UTF-8
 Version=1.0
 Type=Application
 Name=ckb-next

--- a/linux/man/ckb-next-daemon.8
+++ b/linux/man/ckb-next-daemon.8
@@ -1,0 +1,38 @@
+.TH CKB-NEXT-DAEMON 8
+.SH NAME
+ckb-next-daemon \- Corsair RGB driver daemon
+.SH SYNOPSIS
+.B ckb-next-daemon
+[\fB\-\-gid\fR=\fI<gid>\fR]
+[\fB\-\-hwload\fR=\fI<always|\f[BI]try\fI|never>\fR]
+[\fB\-\-nonotify\fR]
+[\fB\-\-nobind\fR]
+[\fB\-\-nonroot\fR]
+.SH DESCRIPTION
+See \fIhttps://github.com/ckb-next/ckb-next/blob/master/DAEMON.md\fR
+for full instructions.
+.SH OPTIONS
+.TP
+.BR \-\-gid =\fI<gid>\fR
+Restrict access to /dev/input/ckb* nodes to users in group \fI<gid>\fR.
+.TP
+.BR \-\-hwload =\fI<always|\f[BI]try\fI|never>\fR
+\-\-hwload=\fIalways\fR will force loading of stored hardware profiles on
+compatible devices. May result in long startup times.
+.br
+\-\-hwload=\fItry\fR will try to load the profiles, but give up if not
+immediately successful (default).
+.br
+\-\-hwload=\fInever\fR will ignore hardware profiles completely.
+.TP
+.BR \-\-nonotify
+Disables key monitoring/notifications. Note that this makes reactive lighting
+impossible.
+.TP
+.BR \-\-nobind
+Disables all key rebinding, macros, and notifications. Implies
+\fB\-\-nonotify\fR.
+.TP
+.BR \-\-nonroot
+Allows running \fBckb-next-daemon\fR as a non root user. This will almost
+certainly not work. Use only if you know what you're doing.

--- a/linux/man/ckb-next-dev-detect.1
+++ b/linux/man/ckb-next-dev-detect.1
@@ -1,0 +1,18 @@
+.TH CKB-NEXT-DEV-DETECT 1
+.SH NAME
+ckb-next-dev-detect \- generate a ckb device summary for bug reports
+.SH SYNOPSIS
+.B ckb-next-dev-detect
+[\fB\-\-nouserinput\fR]
+.SH DESCRIPTION
+.B ckb-next-dev-detect
+generates a report of the current platofrm including kernel, qt, and xdg
+version, journalctl output, and the date. The report is output to
+ckb-next-dev-detect-report.gz in the current/working directory.
+.PP
+Submit the bug and report to \fIhttps://github.com/ckb-next/ckb-next/issues\fR
+.SH OPTIONS
+.TP
+.BR \-\-nouserinput\fR
+Changes the output directory to /tmp instead of the current/working directory
+and inhibits some messages to stdout.

--- a/linux/man/ckb-next.1
+++ b/linux/man/ckb-next.1
@@ -1,0 +1,23 @@
+.TH CKB-NEXT 1
+.SH NAME
+ckb-next \- Open source Corsair input device driver for linux and OSX
+.SH SYNOPSIS
+.B ckb-next
+[\fBoptions\fR]
+.SH DESCRIPTION
+.B ckb-next
+communicates with the ckb-next-daemon, using it to communicate with the Corsair
+input device to drive animations, and map keybindings.
+.SH OPTIONS
+.TP
+.BR \-v ", "\-\-version\fR
+Displays version information.
+.TP
+.BR \-h ", "\-\-help\fR
+Displays this help.
+.TP
+.BR \-b ", "\-\-background\fR
+Starts in background, without display the main window.
+.TP
+.BR \-c ", " \-\-close\fR
+Causes already running instance (if any) to exit.

--- a/linux/systemd/ckb-next-daemon.service.in
+++ b/linux/systemd/ckb-next-daemon.service.in
@@ -3,6 +3,7 @@
 
 [Unit]
 Description=Corsair Keyboards and Mice Daemon
+Documentation=man:ckb-next-daemon
 
 [Service]
 ExecStart=@CMAKE_INSTALL_PREFIX@/bin/ckb-next-daemon

--- a/src/animations/invaders/main.c
+++ b/src/animations/invaders/main.c
@@ -10,7 +10,7 @@ void ckb_info(){
     CKB_COPYRIGHT("2017-8", "Maksim Vladimirovich <edush.maxim@gmail.com>\nTasos Sahanidis <code@tasossah.com>");
     CKB_LICENSE("GPLv2");
     CKB_GUID("{54DD2975-E192-457D-BCFC-D912A24E33B9}");
-    CKB_DESCRIPTION("Space invaders - like game.\n\nFire projectiles using the higlighted keys on the left column.\nF1-F12 indicate the level.\nThe \"prtscn\", \"scroll\", and \"pause\" columns indicate continues.\nEsc resets the game.");
+    CKB_DESCRIPTION("Space invaders - like game.\n\nFire projectiles using the highlighted keys on the left column.\nF1-F12 indicate the level.\nThe \"prtscn\", \"scroll\", and \"pause\" columns indicate continues.\nEsc resets the game.");
 
     // Timing/input parameters
     CKB_KPMODE(CKB_KP_NAME);

--- a/src/daemon/CMakeLists.txt
+++ b/src/daemon/CMakeLists.txt
@@ -417,9 +417,14 @@ if ("${CKB_NEXT_INIT_SYSTEM}" STREQUAL "launchd")
         GROUP_READ
         WORLD_READ)
 elseif ("${CKB_NEXT_INIT_SYSTEM}" STREQUAL "systemd")
+    if(${DEBIANIZE_INSTALL_PATHS})
+        set(_SYSTEMD_PATH "/lib/systemd/system")
+    else()
+        set(_SYSTEMD_PATH "/usr/lib/systemd/system")
+    endif()
     install(
         FILES "${CMAKE_CURRENT_BINARY_DIR}/service/ckb-next-daemon.service"
-        DESTINATION "/usr/lib/systemd/system"
+        DESTINATION ${_SYSTEMD_PATH}
         PERMISSIONS
         OWNER_READ OWNER_WRITE
         GROUP_READ
@@ -467,9 +472,14 @@ if (LINUX)
         endif()
     endif() ")
   endif ()
+  if (${DEBIANIZE_INSTALL_PATHS})
+    set(_UDEV_PATH "/lib/udev/rules.d")
+  else()
+    set(_UDEV_PATH "/usr/lib/udev/rules.d")
+  endif()
   install(
     FILES "${CMAKE_SOURCE_DIR}/linux/udev/99-ckb-next-daemon.rules"
-    DESTINATION "/usr/lib/udev/rules.d"
+    DESTINATION ${_UDEV_PATH}
     PERMISSIONS
     OWNER_READ OWNER_WRITE
     GROUP_READ

--- a/src/daemon/CMakeLists.txt
+++ b/src/daemon/CMakeLists.txt
@@ -474,6 +474,36 @@ if (LINUX)
     OWNER_READ OWNER_WRITE
     GROUP_READ
     WORLD_READ)
+
+  add_custom_command(
+    OUTPUT 
+      "${CMAKE_CURRENT_BINARY_DIR}/ckb-next-dev-detect.1.gz"
+      "${CMAKE_CURRENT_BINARY_DIR}/ckb-next.1.gz"
+      "${CMAKE_CURRENT_BINARY_DIR}/ckb-next-daemon.8.gz"
+    COMMAND gzip -c "${CMAKE_SOURCE_DIR}/linux/man/ckb-next-dev-detect.1" > "${CMAKE_CURRENT_BINARY_DIR}/ckb-next-dev-detect.1.gz"
+    COMMAND gzip -c "${CMAKE_SOURCE_DIR}/linux/man/ckb-next.1" > "${CMAKE_CURRENT_BINARY_DIR}/ckb-next.1.gz"
+    COMMAND gzip -c "${CMAKE_SOURCE_DIR}/linux/man/ckb-next-daemon.8" > "${CMAKE_CURRENT_BINARY_DIR}/ckb-next-daemon.8.gz"
+    DEPENDS 
+      "${CMAKE_SOURCE_DIR}/linux/man/ckb-next-dev-detect.1"
+      "${CMAKE_SOURCE_DIR}/linux/man/ckb-next.1"
+      "${CMAKE_SOURCE_DIR}/linux/man/ckb-next-daemon.8"
+    COMMENT "Generating man pages")
+
+  add_custom_target(man ALL
+    DEPENDS 
+      "${CMAKE_CURRENT_BINARY_DIR}/ckb-next-dev-detect.1.gz"
+      "${CMAKE_CURRENT_BINARY_DIR}/ckb-next.1.gz"
+      "${CMAKE_CURRENT_BINARY_DIR}/ckb-next-daemon.8.gz"
+  )
+
+  install(
+    FILES 
+      "${CMAKE_CURRENT_BINARY_DIR}/ckb-next-dev-detect.1.gz"
+      "${CMAKE_CURRENT_BINARY_DIR}/ckb-next.1.gz"
+    DESTINATION "${CMAKE_INSTALL_FULL_MANDIR}/man1/")
+  install(
+    FILES "${CMAKE_CURRENT_BINARY_DIR}/ckb-next-daemon.8.gz"
+    DESTINATION "${CMAKE_INSTALL_FULL_MANDIR}/man8/")
 endif ()
 
 if (MACOS AND NOT MAC_LEGACY)

--- a/src/gui/kbprofiledialog.cpp
+++ b/src/gui/kbprofiledialog.cpp
@@ -285,7 +285,7 @@ void KbProfileDialog::on_exportButton_clicked(){
     bool compress = JlCompress::compressFiles(filename, tmpExported);
 
     if(!compress)
-        QMessageBox::warning(this, tr("Error"), tr("An error occured while exporting the selected profiles."), QMessageBox::Ok);
+        QMessageBox::warning(this, tr("Error"), tr("An error occurred while exporting the selected profiles."), QMessageBox::Ok);
 
     extractedFileCleanup(tmpExported);
 

--- a/src/gui/keyaction.cpp
+++ b/src/gui/keyaction.cpp
@@ -466,7 +466,7 @@ void KeyAction::macroDisplay() {
     qDebug() << "isMacro returns" << (isMacro() ? "true" : "false");
     qDebug() << "isValidMacro returns" << (isValidMacro() ? "true" : "false");
     QStringList ret =_value.split(":");
-    qDebug() << "Macro definition conains" << ret.count() << "elements";
+    qDebug() << "Macro definition contains" << ret.count() << "elements";
     qDebug() << "Macro definition is" << _value;
 }
 

--- a/src/gui/settingswidget.cpp
+++ b/src/gui/settingswidget.cpp
@@ -198,7 +198,7 @@ void SettingsWidget::on_generateReportButton_clicked(){
 
     // Check if it was started successfully
     if(!devDetect->waitForStarted()){
-        QMessageBox::critical(this, tr("Error executing ckb-next-dev-detect"), tr("An error occured while trying to execute ckb-next-dev-detect.\n"
+        QMessageBox::critical(this, tr("Error executing ckb-next-dev-detect"), tr("An error occurred while trying to execute ckb-next-dev-detect.\n"
                                                                                   "File not found or not executable."));
         devDetect->deleteLater();
     }
@@ -207,7 +207,7 @@ void SettingsWidget::on_generateReportButton_clicked(){
 void SettingsWidget::devDetectFinished(int retVal){
     QFile report("/tmp/ckb-next-dev-detect-report.gz");
     if(retVal || !report.exists()){
-        QString errMsg(tr("An error occured while trying to execute ckb-next-dev-detect.\n\n"));
+        QString errMsg(tr("An error occurred while trying to execute ckb-next-dev-detect.\n\n"));
         errMsg.append(devDetect->readAllStandardError());
         errMsg.append("\n");
         errMsg.append(QString(tr("Return code %1")).arg(retVal));


### PR DESCRIPTION
I'm packaging ckb-next for inclusion in Debian main repositories (and Debian-based distros like Ubuntu).  This pull request contains all of the patches I made to get this accepted into Debian.

These commits are all related in some way to Debian's lintian tags.

I've added man pages for each binary[1] and referenced it in the service file[2] 

I've added a CMake option for using FreeDesktop.org-standardized install paths (The ones used currently are only appropriate for RedHat and Arch-based distros).  This is important for systemd unit files[3], udev rules[4], and libexec[5].  Builders can now `-DDEBIANIZE_INSTALL_PATHS=ON` to install these files to debian-friendly paths.  It is disabled by default so your users will not experience any changes unless they set this.

I've removed a deprecated and unnecessary tag from desktop entry files (no functional changes)[6].

I fixed some spelling errors in binaries [7].

[1] https://lintian.debian.org/tags/binary-without-manpage.html
[2] https://lintian.debian.org/tags/systemd-service-file-missing-documentation-key.html
[3] https://lintian.debian.org/tags/systemd-service-file-outside-lib.html
[4] https://wiki.debian.org/udev
[5] https://lists.debian.org/debian-devel/2005/05/msg00412.html
[6] https://lintian.debian.org/tags/desktop-entry-contains-encoding-key.html
[7] https://lintian.debian.org/tags/spelling-error-in-binary.html


