### PR TITLE
Fix caps/num lock lag on K95 Platinum

### DIFF
--- a/src/daemon/input_linux.c
+++ b/src/daemon/input_linux.c
@@ -194,12 +194,12 @@ void* _ledthread(void* ctx){
                 ileds &= ~which;
         }
         // Update them if needed
-        pthread_mutex_lock(dmutex(kb));
+        pthread_mutex_lock(imutex(kb));
         if(kb->hw_ileds != ileds){
             kb->hw_ileds = ileds;
             kb->vtable->updateindicators(kb, 0);
         }
-        pthread_mutex_unlock(dmutex(kb));
+        pthread_mutex_unlock(imutex(kb));
     }
     return 0;
 }


### PR DESCRIPTION
**System**: ArchLinux with Linux Kernel 4.20.13-arch1-1-ARCH

**Original Issue:** Animation updates would cause a significant lag in caps/num lock indicator updates.

**Workaround:** Locking the input mutex instead of the device mutex.

Tested for several months on K95 Platinum, no issues observed and resolves delay issue with caps/num lock indicators.

I did expect this to cause an issue as the USB device is accessed in function **os_sendindicators** in file **input_linux.c**. So I feel there may be a better solution, perhaps with priority locking?

