### PR TITLE
Cope with kernels that do not have CONFIG_MODULES set

### DIFF
--- a/src/daemon/input_linux.c
+++ b/src/daemon/input_linux.c
@@ -65,7 +65,6 @@ int os_inputopen(usbdevice* kb){
     if(fd < 0){
         if(system("modprobe uinput") != 0) {
             ckb_fatal("Failed to load uinput module\n");
-            close(fd);
             return 1;
         }
     }

--- a/src/daemon/input_linux.c
+++ b/src/daemon/input_linux.c
@@ -55,13 +55,21 @@ int uinputopen(struct uinput_user_dev* indev, int mouse){
 ///
 /// Some tips on using [uinput_user_dev in](http://thiemonge.org/getting-started-with-uinput)
 int os_inputopen(usbdevice* kb){
-    /// First check whether the uinput module is loaded by the kernel.
-    ///
-    // Load the uinput module (if it's not loaded already)
-    if(system("modprobe uinput") != 0) {
-        ckb_fatal("Failed to load uinput module\n");
-        return 1;
+    /// Let's see if uinput is already available
+    int fd = open("/dev/uinput", O_RDWR);
+    if(fd < 0){
+        fd = open("/dev/input/uinput", O_RDWR);
     }
+
+    // If not available, load the module
+    if(fd < 0){
+        if(system("modprobe uinput") != 0) {
+            ckb_fatal("Failed to load uinput module\n");
+            close(fd);
+            return 1;
+        }
+    }
+    close(fd);
 
     if(IS_SINGLE_EP(kb)) {
         kb->uinput_kb = 0;
@@ -79,7 +87,7 @@ int os_inputopen(usbdevice* kb){
     indev.id.product = kb->product;
     indev.id.version = kb->fwversion;
     // Open keyboard
-    int fd = uinputopen(&indev, 0);
+    fd = uinputopen(&indev, 0);
     kb->uinput_kb = fd;
     if(fd <= 0)
         return 0;

--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -281,15 +281,6 @@ void MainWindow::updateVersion(){
         QString kextstatOut(kextstat.readAll());
         if(kextstatOut.isEmpty())
             daemonWarning.append(tr("<br /><b>Warning:</b> System Extension by \"Fumihiko Takayama\" is not allowed in Security & Privacy. Please allow it and then unplug and replug your devices."));
-#elif defined(Q_OS_LINUX)
-            QProcess modprobe;
-            modprobe.start("modprobe", QStringList("uinput"));
-
-            if(!modprobe.waitForFinished())
-                qDebug() << "Modprobe error";
-
-            if(modprobe.exitCode())
-                daemonWarning.append(tr("<br /><b>Warning:</b> The uinput module could not be loaded. If this issue persists after rebooting, compile a kernel with CONFIG_INPUT_UINPUT=y."));
 #endif
         settingsWidget->setStatus(tr("No devices connected") + daemonWarning);
     }

--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -281,6 +281,15 @@ void MainWindow::updateVersion(){
         QString kextstatOut(kextstat.readAll());
         if(kextstatOut.isEmpty())
             daemonWarning.append(tr("<br /><b>Warning:</b> System Extension by \"Fumihiko Takayama\" is not allowed in Security & Privacy. Please allow it and then unplug and replug your devices."));
+#elif defined(Q_OS_LINUX)
+            QProcess modprobe;
+            modprobe.start("modprobe", QStringList("uinput"));
+
+            if(!modprobe.waitForFinished())
+                qDebug() << "Modprobe error";
+
+            if(modprobe.exitCode())
+                daemonWarning.append(tr("<br /><b>Warning:</b> The uinput module could not be loaded. If this issue persists after rebooting, compile a kernel with CONFIG_INPUT_UINPUT=y."));
 #endif
         settingsWidget->setStatus(tr("No devices connected") + daemonWarning);
     }

--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -282,17 +282,15 @@ void MainWindow::updateVersion(){
         if(kextstatOut.isEmpty())
             daemonWarning.append(tr("<br /><b>Warning:</b> System Extension by \"Fumihiko Takayama\" is not allowed in Security & Privacy. Please allow it and then unplug and replug your devices."));
 #elif defined(Q_OS_LINUX)
-            if (!QFileInfo("/dev/uinput").exists()){
-                if (!QFileInfo("/dev/input/uinput").exists()){
-                    QProcess modprobe;
-                    modprobe.start("modprobe", QStringList("uinput"));
+            if(!(QFileInfo("/dev/uinput").exists() || QFileInfo("/dev/input/uinput").exists())){
+                QProcess modprobe;
+                modprobe.start("modprobe", QStringList("uinput"));
 
-                    if(!modprobe.waitForFinished())
-                        qDebug() << "Modprobe error";
+                if(!modprobe.waitForFinished())
+                    qDebug() << "Modprobe error";
 
-                    if(modprobe.exitCode())
-                        daemonWarning.append(tr("<br /><b>Warning:</b> The uinput module could not be loaded. If this issue persists after rebooting, compile a kernel with CONFIG_INPUT_UINPUT=y."));
-                }
+                if(modprobe.exitCode())
+                    daemonWarning.append(tr("<br /><b>Warning:</b> The uinput module could not be loaded. If this issue persists after rebooting, compile a kernel with CONFIG_INPUT_UINPUT=y."));
             }
 #endif
         settingsWidget->setStatus(tr("No devices connected") + daemonWarning);

--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -282,10 +282,8 @@ void MainWindow::updateVersion(){
         if(kextstatOut.isEmpty())
             daemonWarning.append(tr("<br /><b>Warning:</b> System Extension by \"Fumihiko Takayama\" is not allowed in Security & Privacy. Please allow it and then unplug and replug your devices."));
 #elif defined(Q_OS_LINUX)
-            QFileInfo uinput("/dev/uinput");
-            if (!uinput.exists()){
-                QFileInfo uinput2("/dev/input/uinput");
-                if (!uinput2.exists()){
+            if (!QFileInfo("/dev/uinput").exists()){
+                if (!QFileInfo("/dev/input/uinput").exists()){
                     QProcess modprobe;
                     modprobe.start("modprobe", QStringList("uinput"));
 

--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -282,14 +282,20 @@ void MainWindow::updateVersion(){
         if(kextstatOut.isEmpty())
             daemonWarning.append(tr("<br /><b>Warning:</b> System Extension by \"Fumihiko Takayama\" is not allowed in Security & Privacy. Please allow it and then unplug and replug your devices."));
 #elif defined(Q_OS_LINUX)
-            QProcess modprobe;
-            modprobe.start("modprobe", QStringList("uinput"));
+            QFileInfo uinput("/dev/uinput");
+            if (!uinput.exists()){
+                QFileInfo uinput2("/dev/input/uinput");
+                if (!uinput2.exists()){
+                    QProcess modprobe;
+                    modprobe.start("modprobe", QStringList("uinput"));
 
-            if(!modprobe.waitForFinished())
-                qDebug() << "Modprobe error";
+                    if(!modprobe.waitForFinished())
+                        qDebug() << "Modprobe error";
 
-            if(modprobe.exitCode())
-                daemonWarning.append(tr("<br /><b>Warning:</b> The uinput module could not be loaded. If this issue persists after rebooting, compile a kernel with CONFIG_INPUT_UINPUT=y."));
+                    if(modprobe.exitCode())
+                        daemonWarning.append(tr("<br /><b>Warning:</b> The uinput module could not be loaded. If this issue persists after rebooting, compile a kernel with CONFIG_INPUT_UINPUT=y."));
+                }
+            }
 #endif
         settingsWidget->setStatus(tr("No devices connected") + daemonWarning);
     }


### PR DESCRIPTION
The current logic seems to assume the module loader is enabled, and that calling modprobe will always succeed. On a monolithic kernel without a module loader, that results in:
`May 16 09:20:42 agamemnon systemd[1]: Started Corsair Keyboards and Mice Daemon.
May 16 09:20:42 agamemnon ckb-next-daemon[17144]: ckb-next: Corsair RGB driver 0.4.0
May 16 09:20:42 agamemnon ckb-next-daemon[17144]: [I] Root controller ready at /dev/input/ckb0
May 16 09:20:47 agamemnon ckb-next-daemon[17144]: [I] Connecting Corsair Gaming K95 RGB PLATINUM Keyboard at /dev/input/ckb1
May 16 09:20:47 agamemnon ckb-next-daemon[17144]: modprobe: FATAL: Module uinput not found in directory /lib/modules/5.1.0-11058-g83f3ef3de625-dirty
May 16 09:20:47 agamemnon ckb-next-daemon[17144]: [F] os_inputopen (input_linux.c:62): Failed to load uinput module
May 16 09:20:47 agamemnon ckb-next-daemon[17144]: [I] Disconnecting /dev/input/ckb1
May 16 09:20:47 agamemnon ckb-next-daemon[17144]: [I] Removed device path /dev/input/ckb1
`

Changing the logic slightly helps it cope. Try to open the endpoints, if either of them work, we have the module and don't need to modprobe. If neither of them work *and* the modprobe fails, that's cause for a fatal error.