### PR TITLE
Issue 408/suspend preview animation

### DIFF
--- a/src/gui/extrasettingswidget.cpp
+++ b/src/gui/extrasettingswidget.cpp
@@ -72,6 +72,8 @@ ExtraSettingsWidget::ExtraSettingsWidget(QWidget *parent) :
     // Read start delay
     ui->startDelayBox->setChecked(settings.value("StartDelay").toBool());
 
+    ui->previewBox->setChecked(settings.value("DisablePreviewOnFocusLoss", true).toBool());
+
 #ifndef Q_OS_LINUX
     ui->scrollWarningLabel->hide();
 #endif
@@ -154,4 +156,9 @@ void ExtraSettingsWidget::on_delayBox_clicked(bool checked){
 
 void ExtraSettingsWidget::on_startDelayBox_clicked(bool checked){
     CkbSettings::set("Program/StartDelay", checked);
+}
+
+void ExtraSettingsWidget::on_previewBox_clicked(bool checked)
+{
+    CkbSettings::set("Program/DisablePreviewOnFocusLoss", checked);
 }

--- a/src/gui/extrasettingswidget.h
+++ b/src/gui/extrasettingswidget.h
@@ -28,6 +28,7 @@ private slots:
     void on_sSpeedBox_valueChanged(int arg1);
     void on_delayBox_clicked(bool checked);
     void on_startDelayBox_clicked(bool checked);
+    void on_previewBox_clicked(bool checked);
 
 private:
     Ui::ExtraSettingsWidget *ui;

--- a/src/gui/extrasettingswidget.ui
+++ b/src/gui/extrasettingswidget.ui
@@ -7,15 +7,15 @@
     <x>0</x>
     <y>0</y>
     <width>650</width>
-    <height>515</height>
+    <height>525</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string>Application Settings</string>
   </property>
   <layout class="QGridLayout" name="gridLayout">
-   <item row="2" column="0">
-    <spacer name="verticalSpacer">
+   <item row="19" column="0">
+    <spacer name="verticalSpacer_8">
      <property name="orientation">
       <enum>Qt::Vertical</enum>
      </property>
@@ -30,209 +30,13 @@
      </property>
     </spacer>
    </item>
-   <item row="16" column="5">
-    <widget class="QLabel" name="fpsWarnLabel">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-     <property name="text">
-      <string>Warning: high frame rates may cause stability issues</string>
-     </property>
-    </widget>
-   </item>
-   <item row="21" column="0" colspan="7">
-    <widget class="Line" name="osxLine">
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
-     </property>
-    </widget>
-   </item>
-   <item row="18" column="1" colspan="6">
+   <item row="20" column="1" colspan="6">
     <widget class="QCheckBox" name="delayBox">
      <property name="toolTip">
       <string>When using macros with strings longer than 25 chars, some OS may lose characters (e.g. Mint 17.2). Select to prevent that bug.</string>
      </property>
      <property name="text">
       <string>Use delay for very long macros</string>
-     </property>
-    </widget>
-   </item>
-   <item row="16" column="6">
-    <spacer name="horizontalSpacer">
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>40</width>
-       <height>20</height>
-      </size>
-     </property>
-    </spacer>
-   </item>
-   <item row="12" column="1">
-    <spacer name="verticalSpacer_6">
-     <property name="orientation">
-      <enum>Qt::Vertical</enum>
-     </property>
-     <property name="sizeType">
-      <enum>QSizePolicy::Fixed</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>20</width>
-       <height>10</height>
-      </size>
-     </property>
-    </spacer>
-   </item>
-   <item row="8" column="1">
-    <spacer name="verticalSpacer_5">
-     <property name="orientation">
-      <enum>Qt::Vertical</enum>
-     </property>
-     <property name="sizeType">
-      <enum>QSizePolicy::Fixed</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>20</width>
-       <height>10</height>
-      </size>
-     </property>
-    </spacer>
-   </item>
-   <item row="23" column="0">
-    <spacer name="verticalSpacer_11">
-     <property name="orientation">
-      <enum>Qt::Vertical</enum>
-     </property>
-     <property name="sizeType">
-      <enum>QSizePolicy::Fixed</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>0</width>
-       <height>28</height>
-      </size>
-     </property>
-    </spacer>
-   </item>
-   <item row="16" column="2">
-    <spacer name="horizontalSpacer_2">
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
-     </property>
-     <property name="sizeType">
-      <enum>QSizePolicy::Fixed</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>30</width>
-       <height>20</height>
-      </size>
-     </property>
-    </spacer>
-   </item>
-   <item row="14" column="0" colspan="7">
-    <widget class="Line" name="line_2">
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
-     </property>
-    </widget>
-   </item>
-   <item row="24" column="5">
-    <spacer name="verticalSpacer_2">
-     <property name="orientation">
-      <enum>Qt::Vertical</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>20</width>
-       <height>40</height>
-      </size>
-     </property>
-    </spacer>
-   </item>
-   <item row="9" column="0" colspan="7">
-    <widget class="QLabel" name="label_5">
-     <property name="font">
-      <font>
-       <weight>75</weight>
-       <bold>true</bold>
-      </font>
-     </property>
-     <property name="text">
-      <string>Animation scripts</string>
-     </property>
-    </widget>
-   </item>
-   <item row="20" column="0" colspan="7">
-    <widget class="QLabel" name="osxLabel">
-     <property name="font">
-      <font>
-       <weight>75</weight>
-       <bold>true</bold>
-      </font>
-     </property>
-     <property name="text">
-      <string>OS X tweaks</string>
-     </property>
-    </widget>
-   </item>
-   <item row="16" column="4">
-    <spacer name="horizontalSpacer_3">
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
-     </property>
-     <property name="sizeType">
-      <enum>QSizePolicy::Fixed</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>10</width>
-       <height>20</height>
-      </size>
-     </property>
-    </spacer>
-   </item>
-   <item row="11" column="1">
-    <widget class="QLabel" name="label_6">
-     <property name="text">
-      <string>Location:</string>
-     </property>
-    </widget>
-   </item>
-   <item row="16" column="3">
-    <widget class="QSpinBox" name="fpsBox">
-     <property name="minimum">
-      <number>5</number>
-     </property>
-     <property name="maximum">
-      <number>60</number>
-     </property>
-     <property name="value">
-      <number>30</number>
-     </property>
-    </widget>
-   </item>
-   <item row="1" column="0" colspan="7">
-    <widget class="Line" name="line">
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
-     </property>
-    </widget>
-   </item>
-   <item row="2" column="1" colspan="6">
-    <widget class="QCheckBox" name="trayBox">
-     <property name="toolTip">
-      <string>The tray icon will not be displayed. The application will still run in the background; re-launch the app to see the GUI again.</string>
-     </property>
-     <property name="text">
-      <string>Hide tray icon</string>
      </property>
     </widget>
    </item>
@@ -249,18 +53,196 @@
      </property>
     </widget>
    </item>
-   <item row="3" column="1" colspan="6">
-    <widget class="QCheckBox" name="brightnessBox">
+   <item row="19" column="1" colspan="6">
+    <widget class="QCheckBox" name="ditherBox">
      <property name="toolTip">
-      <string>By default, the same brightness level will be applied to all profiles and all devices. Enable this to store it with the lighting mode instead.</string>
+      <string>May improve appearance on some keyboards.</string>
      </property>
      <property name="text">
-      <string>Set brightness per-mode</string>
+      <string>Use spatial dithering to simulate extra color resolution</string>
      </property>
     </widget>
    </item>
-   <item row="16" column="0">
-    <spacer name="verticalSpacer_9">
+   <item row="2" column="1" colspan="6">
+    <widget class="QCheckBox" name="trayBox">
+     <property name="toolTip">
+      <string>The tray icon will not be displayed. The application will still run in the background; re-launch the app to see the GUI again.</string>
+     </property>
+     <property name="text">
+      <string>Hide tray icon</string>
+     </property>
+    </widget>
+   </item>
+   <item row="13" column="1">
+    <widget class="QLabel" name="label_6">
+     <property name="text">
+      <string>Location:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="23" column="0" colspan="7">
+    <widget class="Line" name="osxLine">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+    </widget>
+   </item>
+   <item row="14" column="1">
+    <spacer name="verticalSpacer_6">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeType">
+      <enum>QSizePolicy::Fixed</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>10</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item row="18" column="4">
+    <spacer name="horizontalSpacer_3">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="sizeType">
+      <enum>QSizePolicy::Fixed</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>10</width>
+       <height>20</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item row="10" column="1">
+    <spacer name="verticalSpacer_5">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeType">
+      <enum>QSizePolicy::Fixed</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>10</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item row="18" column="5">
+    <widget class="QLabel" name="fpsWarnLabel">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="text">
+      <string>Warning: high frame rates may cause stability issues</string>
+     </property>
+    </widget>
+   </item>
+   <item row="13" column="0">
+    <spacer name="verticalSpacer_4">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeType">
+      <enum>QSizePolicy::Fixed</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>0</width>
+       <height>28</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item row="1" column="0" colspan="7">
+    <widget class="Line" name="line">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+    </widget>
+   </item>
+   <item row="18" column="1">
+    <widget class="QLabel" name="label_3">
+     <property name="text">
+      <string>Frame rate (FPS):</string>
+     </property>
+    </widget>
+   </item>
+   <item row="4" column="1" colspan="6">
+    <widget class="QLabel" name="scrollWarningLabel">
+     <property name="enabled">
+      <bool>true</bool>
+     </property>
+     <property name="font">
+      <font>
+       <pointsize>8</pointsize>
+       <italic>true</italic>
+      </font>
+     </property>
+     <property name="text">
+      <string>Enabling per-mode brightness will disable scrolling on the tray icon to change the brightness level</string>
+     </property>
+    </widget>
+   </item>
+   <item row="18" column="3">
+    <widget class="QSpinBox" name="fpsBox">
+     <property name="minimum">
+      <number>5</number>
+     </property>
+     <property name="maximum">
+      <number>60</number>
+     </property>
+     <property name="value">
+      <number>30</number>
+     </property>
+    </widget>
+   </item>
+   <item row="13" column="3" colspan="4">
+    <layout class="QHBoxLayout" name="horizontalLayout">
+     <item>
+      <widget class="QLabel" name="animPathLabel">
+       <property name="text">
+        <string>/path/to/animations</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLabel" name="animCountLabel">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="text">
+        <string>0 animations found</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="animScanButton">
+       <property name="text">
+        <string>Re-scan</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item row="2" column="0">
+    <spacer name="verticalSpacer">
      <property name="orientation">
       <enum>Qt::Vertical</enum>
      </property>
@@ -291,15 +273,48 @@
      </property>
     </spacer>
    </item>
-   <item row="16" column="1">
-    <widget class="QLabel" name="label_3">
-     <property name="text">
-      <string>Frame rate (FPS):</string>
+   <item row="27" column="0" colspan="7">
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Ok</set>
      </property>
     </widget>
    </item>
-   <item row="17" column="0">
-    <spacer name="verticalSpacer_8">
+   <item row="11" column="0" colspan="7">
+    <widget class="QLabel" name="label_5">
+     <property name="font">
+      <font>
+       <weight>75</weight>
+       <bold>true</bold>
+      </font>
+     </property>
+     <property name="text">
+      <string>Animation scripts</string>
+     </property>
+    </widget>
+   </item>
+   <item row="3" column="1" colspan="6">
+    <widget class="QCheckBox" name="brightnessBox">
+     <property name="toolTip">
+      <string>By default, the same brightness level will be applied to all profiles and all devices. Enable this to store it with the lighting mode instead.</string>
+     </property>
+     <property name="text">
+      <string>Set brightness per-mode</string>
+     </property>
+    </widget>
+   </item>
+   <item row="7" column="1" colspan="6">
+    <widget class="QCheckBox" name="startDelayBox">
+     <property name="text">
+      <string>Delay application start</string>
+     </property>
+    </widget>
+   </item>
+   <item row="24" column="0">
+    <spacer name="verticalSpacer_10">
      <property name="orientation">
       <enum>Qt::Vertical</enum>
      </property>
@@ -314,8 +329,67 @@
      </property>
     </spacer>
    </item>
-   <item row="11" column="0">
-    <spacer name="verticalSpacer_4">
+   <item row="25" column="1" colspan="4">
+    <widget class="QCheckBox" name="sAccelBox">
+     <property name="toolTip">
+      <string>Try this if you're having problems with the scroll wheel.</string>
+     </property>
+     <property name="text">
+      <string>Disable scroll acceleration</string>
+     </property>
+    </widget>
+   </item>
+   <item row="18" column="2">
+    <spacer name="horizontalSpacer_2">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="sizeType">
+      <enum>QSizePolicy::Fixed</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>30</width>
+       <height>20</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item row="18" column="6">
+    <spacer name="horizontalSpacer">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>40</width>
+       <height>20</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item row="26" column="5">
+    <spacer name="verticalSpacer_2">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>40</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item row="12" column="0" colspan="7">
+    <widget class="Line" name="line_3">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+    </widget>
+   </item>
+   <item row="18" column="0">
+    <spacer name="verticalSpacer_9">
      <property name="orientation">
       <enum>Qt::Vertical</enum>
      </property>
@@ -330,7 +404,23 @@
      </property>
     </spacer>
    </item>
-   <item row="23" column="5" colspan="2">
+   <item row="25" column="0">
+    <spacer name="verticalSpacer_11">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeType">
+      <enum>QSizePolicy::Fixed</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>0</width>
+       <height>28</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item row="25" column="5" colspan="2">
     <widget class="QWidget" name="sSpeedWidget" native="true">
      <property name="sizePolicy">
       <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
@@ -387,34 +477,27 @@
      </layout>
     </widget>
    </item>
-   <item row="10" column="0" colspan="7">
-    <widget class="Line" name="line_3">
+   <item row="22" column="0" colspan="7">
+    <widget class="QLabel" name="osxLabel">
+     <property name="font">
+      <font>
+       <weight>75</weight>
+       <bold>true</bold>
+      </font>
+     </property>
+     <property name="text">
+      <string>OS X tweaks</string>
+     </property>
+    </widget>
+   </item>
+   <item row="16" column="0" colspan="7">
+    <widget class="Line" name="line_2">
      <property name="orientation">
       <enum>Qt::Horizontal</enum>
      </property>
     </widget>
    </item>
-   <item row="17" column="1" colspan="6">
-    <widget class="QCheckBox" name="ditherBox">
-     <property name="toolTip">
-      <string>May improve appearance on some keyboards.</string>
-     </property>
-     <property name="text">
-      <string>Use spatial dithering to simulate extra color resolution</string>
-     </property>
-    </widget>
-   </item>
-   <item row="23" column="1" colspan="4">
-    <widget class="QCheckBox" name="sAccelBox">
-     <property name="toolTip">
-      <string>Try this if you're having problems with the scroll wheel.</string>
-     </property>
-     <property name="text">
-      <string>Disable scroll acceleration</string>
-     </property>
-    </widget>
-   </item>
-   <item row="18" column="1">
+   <item row="20" column="1">
     <spacer name="verticalSpacer_7">
      <property name="orientation">
       <enum>Qt::Vertical</enum>
@@ -430,51 +513,7 @@
      </property>
     </spacer>
    </item>
-   <item row="11" column="3" colspan="4">
-    <layout class="QHBoxLayout" name="horizontalLayout">
-     <item>
-      <widget class="QLabel" name="animPathLabel">
-       <property name="text">
-        <string>/path/to/animations</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QLabel" name="animCountLabel">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="text">
-        <string>0 animations found</string>
-       </property>
-       <property name="alignment">
-        <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QPushButton" name="animScanButton">
-       <property name="text">
-        <string>Re-scan</string>
-       </property>
-      </widget>
-     </item>
-    </layout>
-   </item>
-   <item row="25" column="0" colspan="7">
-    <widget class="QDialogButtonBox" name="buttonBox">
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
-     </property>
-     <property name="standardButtons">
-      <set>QDialogButtonBox::Ok</set>
-     </property>
-    </widget>
-   </item>
-   <item row="13" column="0" colspan="7">
+   <item row="15" column="0" colspan="7">
     <widget class="QLabel" name="label_2">
      <property name="font">
       <font>
@@ -487,23 +526,7 @@
      </property>
     </widget>
    </item>
-   <item row="22" column="0">
-    <spacer name="verticalSpacer_10">
-     <property name="orientation">
-      <enum>Qt::Vertical</enum>
-     </property>
-     <property name="sizeType">
-      <enum>QSizePolicy::Fixed</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>0</width>
-       <height>28</height>
-      </size>
-     </property>
-    </spacer>
-   </item>
-   <item row="22" column="1" colspan="6">
+   <item row="24" column="1" colspan="6">
     <widget class="QCheckBox" name="mAccelBox">
      <property name="toolTip">
       <string>Try this if you're having problems with mouse movement.</string>
@@ -513,26 +536,13 @@
      </property>
     </widget>
    </item>
-   <item row="7" column="1" colspan="6">
-    <widget class="QCheckBox" name="startDelayBox">
+   <item row="9" column="1" colspan="6">
+    <widget class="QCheckBox" name="previewBox">
      <property name="text">
-      <string>Delay application start</string>
+      <string>Disable animated preview when ckb-next is not in focus</string>
      </property>
-    </widget>
-   </item>
-   <item row="4" column="1" colspan="6">
-    <widget class="QLabel" name="scrollWarningLabel">
-     <property name="enabled">
-      <bool>true</bool>
-     </property>
-     <property name="font">
-      <font>
-       <pointsize>8</pointsize>
-       <italic>true</italic>
-      </font>
-     </property>
-     <property name="text">
-      <string>Enabling per-mode brightness will disable scrolling on the tray icon to change the brightness level</string>
+     <property name="checked">
+      <bool>false</bool>
      </property>
     </widget>
    </item>

--- a/src/gui/kblightwidget.cpp
+++ b/src/gui/kblightwidget.cpp
@@ -158,6 +158,8 @@ void KbLightWidget::changeAnimKeys(QStringList keys){
 }
 
 void KbLightWidget::stateChange(Qt::ApplicationState state){
+    if(!CkbSettings::get("Program/DisablePreviewOnFocusLoss", true).toBool())
+        return;
     if (state == Qt::ApplicationActive) {
         if(light && ui->showAnimBox->isChecked())
             startAnimationPreview();

--- a/src/gui/kblightwidget.h
+++ b/src/gui/kblightwidget.h
@@ -42,11 +42,16 @@ private slots:
     void brightnessScroll(bool up);
     void toggleM95Light();
 
+    void stateChange(Qt::ApplicationState state);
+
 private:
     KbLight* light;
     QStringList currentSelection;
 
     Ui::KbLightWidget *ui;
+
+    void startAnimationPreview();
+    void stopAnimationPreview();
 };
 
 #endif // KBLIGHTWIDGET_H

--- a/src/gui/kblightwidget.ui
+++ b/src/gui/kblightwidget.ui
@@ -68,10 +68,10 @@
         </size>
        </property>
        <property name="toolTip">
-        <string>If enabled, the same colors will be displayed here as on the keyboard. If disabled, the base colors will be shown.</string>
+        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If enabled, the same colors will be displayed here as on the keyboard. If disabled, the base colors will be shown.&lt;/p&gt;&lt;p&gt;Note: The animation preview will be disabled when the window loses focus to preserve computation resources.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
        </property>
        <property name="text">
-        <string>Show animated</string>
+        <string>Show animated (if window is in focus)</string>
        </property>
        <property name="checked">
         <bool>true</bool>

--- a/src/gui/kblightwidget.ui
+++ b/src/gui/kblightwidget.ui
@@ -71,7 +71,7 @@
         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If enabled, the same colors will be displayed here as on the keyboard. If disabled, the base colors will be shown.&lt;/p&gt;&lt;p&gt;Note: The animation preview will be disabled when the window loses focus to preserve computation resources.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
        </property>
        <property name="text">
-        <string>Show animated (if window is in focus)</string>
+        <string>Show animated</string>
        </property>
        <property name="checked">
         <bool>true</bool>


### PR DESCRIPTION
This PR amends the GUI to automatically suspend the preview animation:

- Suspend preview animation if window is not active,
- resume the preview animation as soon as the window comes into focus again.
- Additionally the `showAnimBox` element and its `toolTip` property were amended to display the new feature.