### PR TITLE
Fix segfault on macOS when quitting

### DIFF
--- a/src/daemon/usb_mac.c
+++ b/src/daemon/usb_mac.c
@@ -9,6 +9,9 @@
 
 #ifdef OS_MAC
 
+// usb.c
+extern _Atomic int reset_stop;
+
 static CFRunLoopRef mainloop = 0;
 static IONotificationPortRef notify = 0;
 
@@ -285,7 +288,9 @@ int os_resetusb(usbdevice* kb, const char* file, int line){
 }
 
 static void intreport(void* context, IOReturn result, void* sender, IOHIDReportType reporttype, uint32_t reportid, uint8_t* data, CFIndex length){
-    process_input_urb(context, data, length, 0);
+    // process input as long as the program isn't shutting down
+    if (!reset_stop)
+        process_input_urb(context, data, length, 0);
 }
 
 typedef struct {


### PR DESCRIPTION
The segfault was based on a race condition between resetting/closing of
one of the attached devices, a subsequent input event that was handled
by another device's CFRunLoop callback, and a mutex lock.

Fix:
- Listen for `reset_stop` - which is set by `quit` when shutting down
  the daemon - to stop processing input urbs.