### PR TITLE
Fixing spelling

### DIFF
--- a/src/gui/animdetailsdialog.ui
+++ b/src/gui/animdetailsdialog.ui
@@ -75,7 +75,7 @@
      </column>
      <column>
       <property name="text">
-       <string>Descripton</string>
+       <string>Description</string>
       </property>
      </column>
     </widget>


### PR DESCRIPTION
Descripton -> Description as noticed by lintian.

```
I: ckb-next: spelling-error-in-binary usr/bin/ckb-next Descripton Description
N: 
N:    Lintian found a spelling error in the given binary. Lintian has a list
N:    of common misspellings that it looks for. It does not have a dictionary
N:    like a spelling checker does.
N:    
N:    If the string containing the spelling error is translated with the help
N:    of gettext or a similar tool, please fix the error in the translations
N:    as well as the English text to avoid making the translations fuzzy. With
N:    gettext, for example, this means you should also fix the spelling
N:    mistake in the corresponding msgids in the *.po files.
N:    
N:    You can often find the word in the source code by running:
N:    
N:     grep -rw <word> <source-tree>
N:    
N:    This tag may produce false positives for words that contain non-ASCII
N:    characters due to limitations in strings.
N:    
N:    Severity: minor, Certainty: wild-guess
N:    
N:    Check: binaries, Type: binary, udeb
```
