### PR TITLE
experiment with temporal dithering

### DIFF
--- a/src/daemon/CMakeLists.txt
+++ b/src/daemon/CMakeLists.txt
@@ -146,7 +146,8 @@ if (MACOS OR LINUX)
         ckb-next-daemon
             PRIVATE
               Threads::Threads
-              "${ICONV_LIBRARIES}")
+              "${ICONV_LIBRARIES}"
+              m)
 endif ()
 if (MACOS)
     target_link_libraries(

--- a/src/daemon/structures.h
+++ b/src/daemon/structures.h
@@ -74,9 +74,12 @@ typedef struct {
 
 // Lighting structure for a mode
 typedef struct {
-    uchar r[N_KEYS_EXTENDED];
+    uchar r[N_KEYS_EXTENDED]; // the desired value
     uchar g[N_KEYS_EXTENDED];
     uchar b[N_KEYS_EXTENDED];
+    float errorR[N_KEYS_EXTENDED]; // the (accumulated) error
+    float errorG[N_KEYS_EXTENDED];
+    float errorB[N_KEYS_EXTENDED];
     uchar forceupdate;
     uchar sidelight; // strafe sidelight
 } lighting;

--- a/src/gui/extrasettingswidget.cpp
+++ b/src/gui/extrasettingswidget.cpp
@@ -17,7 +17,7 @@ ExtraSettingsWidget::ExtraSettingsWidget(QWidget *parent) :
 
     // Read frame rate from settings
     int rate = settings.value("framerate").toInt();
-    if(rate <= 0 || rate > 60)
+    if(rate <= 0 || rate > 120)
         rate = 30;
     ui->fpsBox->setValue(rate);
     Kb::frameRate(rate);

--- a/src/gui/extrasettingswidget.ui
+++ b/src/gui/extrasettingswidget.ui
@@ -433,7 +433,7 @@
       <number>5</number>
      </property>
      <property name="maximum">
-      <number>60</number>
+      <number>120</number>
      </property>
      <property name="value">
       <number>30</number>


### PR DESCRIPTION
Hi,

First of all, do NOT actually merge this pull request! It breaks existing functionality! I merely want to use this as a starting point for a discussion.

Problem description:
I recently bought a Corsair Ironclaw mouse. I wanted to give the logo-LED a slow/dim glowing animation (black -> dark red -> black, over the course of several seconds). Unfortunately I found that the hardware isn't well suited to display dark colors. There is a too big difference in brightness between black (0,0,0) and the darkest red (1,0,0). Also the next steps are too big (1,0,0)->(2,0,0)->(3,0,0)->... (OTOH there's hardly any noticeable difference between e.g. (250,0,0) and (255,0,0)).

To solve this I experimented with temporal dithering. With the (hacked) code in this PR I am able to get a pretty nice looking animation. The next step is to transform this hack into a more general solution. My question is "are you interested in contributions for such a feature?". In other words: Should I simply change the code so that it's good enough for me? Or should I immediately try to code it in a form that's acceptable to upstream?

There are two main problems that should be overcome:
1) Currently colors are represented by 3x8-bit RGB triplets. But (for dark colors) this representation isn't accurate enough. My first idea is to switch the color components from 'uchar' to 'float'. And only at the end points (QRgb objects for the GUI / the USB data packets for the hardware) convert these back to integers.

2) To avoid flickering the effect needs to be run at a high enough frame rate. For me 120Hz gave an acceptable result. Though currently the software already gives a warning for rates above 30Hz. I'd like to understand the reason for this warning. Is it only about high CPU usage, or is it more serious? At 120Hz I did indeed see a noticeable higher CPU usage (I think there are ways to improve upon this, but let's take one step at a time).

Wouter