### PR TITLE
Resolve syntax error in ckb-next-daemon.in

### DIFF
--- a/linux/sysvinit/ckb-next-daemon.in
+++ b/linux/sysvinit/ckb-next-daemon.in
@@ -36,15 +36,15 @@ do_stop () {
 
 case "$1" in
     start)
-        do_start()
+        do_start
         ;;
     stop)
-        do_stop()
+        do_stop
         ;;
     restart)
         log_daemon_msg "Restarting $DESC" "$NAME"
-        do_stop()
-        do_start()
+        do_stop
+        do_start
         ;;
     reload)
         log_daemon_msg "Reloading $NAME" "$NAME"


### PR DESCRIPTION
Bash functions are called without parenthesis.