### PR TITLE
Replace deprecated QString::sprintf with a string

### DIFF
--- a/src/gui/kblight.cpp
+++ b/src/gui/kblight.cpp
@@ -387,7 +387,7 @@ void KbLight::frameUpdate(QFile& cmd, bool monochrome){
 void KbLight::base(QFile &cmd, bool ignoreDim, bool monochrome){
     close();
     if(_dimming == MAX_DIM && !ignoreDim){
-        cmd.write(QString().sprintf("rgb 000000").toLatin1());
+        cmd.write("rgb 000000");
         return;
     }
     // Set just the background color, ignoring any animation


### PR DESCRIPTION
I was just wondering if usage of QString::sprintf is really needed here. The same file contains a call to cmd.write() function that does not use QString::sprintf, just like in my change.

If I am missing something or toLatin1() is needed, I think cmd.write(QString("rgb 000000").toLatin1()); can be used instead.