### PR TITLE
Replace deprecated QString::sprintf with QTextStream

### DIFF
--- a/src/gui/ckbsettings.cpp
+++ b/src/gui/ckbsettings.cpp
@@ -56,7 +56,11 @@ static QSettings* globalSettings(){
 }
 
 bool CkbSettings::isBusy(){
+#if QT_VERSION >= QT_VERSION_CHECK(5, 14, 0)
+    return cacheWritesInProgress.loadRelaxed() > 0;
+#else
     return cacheWritesInProgress.load() > 0;
+#endif
 }
 
 void CkbSettings::migrateSettings(bool macFormat){
@@ -88,7 +92,11 @@ void CkbSettings::cleanUp(){
     if(!_globalSettings)
         return;
     // Wait for all writers to finish
+#if QT_VERSION >= QT_VERSION_CHECK(5, 14, 0)
+    while(cacheWritesInProgress.loadRelaxed() > 0)
+#else
     while(cacheWritesInProgress.load() > 0)
+#endif
         QThread::yieldCurrentThread();
     // Stop thread and delete objects
     globalThread->quit();

--- a/src/gui/gradientbutton.cpp
+++ b/src/gui/gradientbutton.cpp
@@ -1,6 +1,7 @@
 #include <cmath>
 #include <cstdio>
 #include <QPainter>
+#include <QTextStream>
 #include "gradientbutton.h"
 #include "gradientdialog.h"
 
@@ -81,8 +82,12 @@ QString GradientButton::toString() const {
     QStringList result;
     foreach(const QGradientStop& stop, _stops){
         QString string;
+        QTextStream out(&string);
         const QColor& color = stop.second;
-        result << string.sprintf("%d:%02x%02x%02x%02x", (int)round(stop.first * 100.f), color.alpha(), color.red(), color.green(), color.blue());
+        out << static_cast<int>(round(stop.first * 100.f)) << ':'
+            << qSetFieldWidth(2) << qSetPadChar('0') << hex
+            << color.alpha() << color.red() << color.green() << color.blue();
+        result << string;
     }
     return result.join(" ");
 }


### PR DESCRIPTION
I overlooked one of the QString::sprintf() usages remaining in this file. Since QString::asprintf is not recommended either, I decided to use QTextStream to replace the last QString::sprintf in this file.