### PR TITLE
Performance tidying

### DIFF
--- a/src/gui/animscript.cpp
+++ b/src/gui/animscript.cpp
@@ -194,7 +194,7 @@ bool AnimScript::load(){
             QMap<QString, QVariant> preset;
             for(int i = 2; i < count; i++){
                 // Scan name/value setting pairs
-                QString setting = components.at(i);
+                const QString& setting = components.at(i);
                 QStringList sComponents = setting.split("=");
                 if(sComponents.count() != 2)
                     continue;

--- a/src/gui/animsettingdialog.cpp
+++ b/src/gui/animsettingdialog.cpp
@@ -408,19 +408,19 @@ void AnimSettingDialog::updateStops(){
     updateParam("kpstop");
 }
 
-void AnimSettingDialog::angleDialChanged(QString name){
+void AnimSettingDialog::angleDialChanged(const QString& name){
     // Dial changed; update spinner value
     angleSpinners[name]->setValue(angleFlip(((QDial*)settingWidgets[name])->value()));
     updateParam(name);
 }
 
-void AnimSettingDialog::angleSpinnerChanged(QString name){
+void AnimSettingDialog::angleSpinnerChanged(const QString& name){
     // Spinner changed; update dial value
     ((QDial*)settingWidgets[name])->setValue(angleFlip(angleSpinners[name]->value()));
     updateParam(name);
 }
 
-void AnimSettingDialog::updateParam(QString name){
+void AnimSettingDialog::updateParam(const QString& name){
     if(!settingWidgets.contains(name))
         return;
     // stop and kpstop have defeat switches

--- a/src/gui/animsettingdialog.cpp
+++ b/src/gui/animsettingdialog.cpp
@@ -456,7 +456,7 @@ void AnimSettingDialog::updateParam(QString name){
     }
     case AnimScript::Param::RGB:{
         ColorButton* widget = (ColorButton*)settingWidgets[name];
-        QColor color = widget->color();
+        const QColor& color = widget->color();
         char hex[7];
         snprintf(hex, sizeof(hex), "%02x%02x%02x", color.red(), color.green(), color.blue());
         _anim->parameter(name, QString(hex));
@@ -464,7 +464,7 @@ void AnimSettingDialog::updateParam(QString name){
     }
     case AnimScript::Param::ARGB:{
         ColorButton* widget = (ColorButton*)settingWidgets[name];
-        QColor color = widget->color();
+        const QColor& color = widget->color();
         char hex[9];
         snprintf(hex, sizeof(hex), "%02x%02x%02x%02x", color.alpha(), color.red(), color.green(), color.blue());
         _anim->parameter(name, QString(hex));

--- a/src/gui/animsettingdialog.h
+++ b/src/gui/animsettingdialog.h
@@ -40,9 +40,9 @@ private:
 private slots:
     void newDuration(double duration);
     void updateStops();
-    void angleDialChanged(QString name);
-    void angleSpinnerChanged(QString name);
-    void updateParam(QString name);
+    void angleDialChanged(const QString& name);
+    void angleSpinnerChanged(const QString& name);
+    void updateParam(const QString& name);
     void on_delayBox_valueChanged(double arg1);
     void on_repeatBox_valueChanged(double arg1);
     void on_kpDelayBox_valueChanged(double arg1);

--- a/src/gui/ckbupdaterwidget.cpp
+++ b/src/gui/ckbupdaterwidget.cpp
@@ -8,7 +8,7 @@
 #include <QCryptographicHash>
 #include <QMessageBox>
 
-CkbUpdaterDialog::CkbUpdaterDialog(QString ver, QString changelog, QWidget *parent) :
+CkbUpdaterDialog::CkbUpdaterDialog(const QString& ver, const QString& changelog, QWidget *parent) :
     QDialog(parent),
     ui(new Ui::CkbUpdaterWidget), _version(ver), _changelog(changelog), _manager(nullptr), _redirectCount(0), _url(QString("https://github.com/ckb-next/ckb-next/")), _quitApp(false){
     ui->setupUi(this);

--- a/src/gui/ckbupdaterwidget.h
+++ b/src/gui/ckbupdaterwidget.h
@@ -14,7 +14,7 @@ class CkbUpdaterDialog : public QDialog
     Q_OBJECT
 
 public:
-    explicit CkbUpdaterDialog(QString ver,  QString changelog, QWidget *parent = 0);
+    explicit CkbUpdaterDialog(const QString& ver,  const QString& changelog, QWidget *parent = 0);
     ~CkbUpdaterDialog();
 
 private slots:

--- a/src/gui/gradientdialog.cpp
+++ b/src/gui/gradientdialog.cpp
@@ -125,7 +125,7 @@ void GradientDialog::updatePresets(){
     }
 }
 
-void GradientDialog::currentChanged(QColor color, bool spontaneous, int position){
+void GradientDialog::currentChanged(const QColor& color, bool spontaneous, int position){
     int pCount = ui->widget->stopCount();
     if(pCount == 1)
         ui->stopBox->setTitle(tr("1 point"));

--- a/src/gui/gradientdialog.h
+++ b/src/gui/gradientdialog.h
@@ -39,7 +39,7 @@ private:
     Ui::GradientDialog *ui;
 
 private slots:
-    void currentChanged(QColor color, bool spontaneous, int position);
+    void currentChanged(const QColor& color, bool spontaneous, int position);
     void colorChanged(QColor color);
 
     void on_presetList_currentItemChanged(QListWidgetItem *current, QListWidgetItem *previous);

--- a/src/gui/kb.cpp
+++ b/src/gui/kb.cpp
@@ -507,7 +507,7 @@ void Kb::run(){
     notifyPaths.remove(notifyPath);
 }
 
-void Kb::readNotify(QString line){
+void Kb::readNotify(const QString& line){
     QStringList components = line.trimmed().split(" ");
     if(components.count() < 2)
         return;
@@ -837,7 +837,7 @@ KeyMap::Layout Kb::getCurrentLayout(){
     return _layout;
 }
 
-void Kb::setPollRate(QString poll)
+void Kb::setPollRate(const QString& poll)
 {
     cmd.write(QString("\npollrate %1\n").arg(poll).toLatin1());
 }

--- a/src/gui/kb.h
+++ b/src/gui/kb.h
@@ -116,7 +116,7 @@ public:
     inline QString getMacroPath () { return macroPath; }
 
     inline ushort getMaxDpi () {return _maxDpi; }
-    void setPollRate(QString poll);
+    void setPollRate(const QString& poll);
 
     ~Kb();
 
@@ -145,7 +145,7 @@ public slots:
 
 private slots:
     // Processes lines read from the notification node
-    void readNotify(QString line);
+    void readNotify(const QString& line);
 
     void deleteHw();
     void deletePrevious();

--- a/src/gui/kbanim.cpp
+++ b/src/gui/kbanim.cpp
@@ -478,7 +478,7 @@ void KbAnim::blend(ColorMap& animMap, quint64 timestamp){
                 r = r * (1.f - a) + qRed(fg) * a;
                 g = g * (1.f - a) + qGreen(fg) * a;
                 b = b * (1.f - a) + qBlue(fg) * a;
-                bg = qRgb(round(r), round(g), round(b));
+                bg = qRgb(std::round(r), std::round(g), std::round(b));
             }
         } else {
             // Use blend function
@@ -487,7 +487,7 @@ void KbAnim::blend(ColorMap& animMap, quint64 timestamp){
             r = r * (1.f - a) + blend(r, qRed(fg) / 255.f) * a;
             g = g * (1.f - a) + blend(g, qGreen(fg) / 255.f) * a;
             b = b * (1.f - a) + blend(b, qBlue(fg) / 255.f) * a;
-            bg = qRgb(round(r * 255.f), round(g * 255.f), round(b * 255.f));
+            bg = qRgb(std::round(r * 255.f), std::round(g * 255.f), std::round(b * 255.f));
         }
     }
 }

--- a/src/gui/kbbind.cpp
+++ b/src/gui/kbbind.cpp
@@ -144,7 +144,7 @@ QString KbBind::globalRemap(const QString& key){
     return _globalRemap.value(key);
 }
 
-void KbBind::setGlobalRemap(const QHash<QString, QString> keyToActual){
+void KbBind::setGlobalRemap(const QHash<QString, QString>& keyToActual){
     _globalRemap.clear();
     // Ignore any keys with the standard binding
     QHashIterator<QString, QString> i(keyToActual);

--- a/src/gui/kbbind.h
+++ b/src/gui/kbbind.h
@@ -54,7 +54,7 @@ public:
     // Global key remap (changes modifiers per Settings widget)
     // Use only when iterating the map manually; all KbBind functions already take this into account
     static QString  globalRemap(const QString& key);
-    static void     setGlobalRemap(const QHash<QString, QString> keyToActual);
+    static void     setGlobalRemap(const QHash<QString, QString>& keyToActual);
     static void     loadGlobalRemap();
     static void     saveGlobalRemap();
 

--- a/src/gui/kbbindwidget.cpp
+++ b/src/gui/kbbindwidget.cpp
@@ -53,7 +53,7 @@ void KbBindWidget::newLayout(){
     updateSelDisplay();
 }
 
-void KbBindWidget::newSelection(QStringList selection){
+void KbBindWidget::newSelection(const QStringList& selection){
     currentSelection = selection;
     ui->rbWidget->setSelection(selection, true);
     // Throw a warning if the user is trying to bind a win key while winlock is on

--- a/src/gui/kbbindwidget.h
+++ b/src/gui/kbbindwidget.h
@@ -22,7 +22,7 @@ public:
 private slots:
     void updateBind();
     void newLayout();
-    void newSelection(QStringList selection);
+    void newSelection(const QStringList& selection);
     void updateSelDisplay();
 
     void on_resetButton_clicked();

--- a/src/gui/kblight.cpp
+++ b/src/gui/kblight.cpp
@@ -273,13 +273,13 @@ static float sToL(float srgb){
     srgb /= 255.f;
     if(srgb <= 0.04045f)
         return srgb / 12.92f;
-    return pow((srgb + 0.055f) / 1.055f, 2.4f);
+    return std::pow((srgb + 0.055f) / 1.055f, 2.4f);
 }
 
 static float lToS(float linear){
     if(linear <= 0.0031308f)
         return 12.92f * linear * 255.f;
-    return (1.055f * pow(linear, 1.f / 2.4f) - 0.055f) * 255.f;
+    return (1.055f * std::pow(linear, 1.f / 2.4f) - 0.055f) * 255.f;
 }
 
 // Convert RGB to monochrome
@@ -291,7 +291,7 @@ QRgb monoRgb(float r, float g, float b){
     r = sToL(r);
     g = sToL(g);
     b = sToL(b);
-    int value = round(lToS((r + g + b) / 3.f));
+    int value = std::round(lToS((r + g + b) / 3.f));
     return qRgb(value, value, value);
 }
 
@@ -336,9 +336,9 @@ void KbLight::frameUpdate(QFile& cmd, bool monochrome){
                 float g2 = qGreen(rgb2);
                 float b2 = qBlue(rgb2);
                 float a2 = qAlpha(rgb2) / 255.f;
-                r = round(r2 * a2 + r * (1.f - a2));
-                g = round(g2 * a2 + g * (1.f - a2));
-                b = round(b2 * a2 + b * (1.f - a2));
+                r = std::round(r2 * a2 + r * (1.f - a2));
+                g = std::round(g2 * a2 + g * (1.f - a2));
+                b = std::round(b2 * a2 + b * (1.f - a2));
             }
             // If monochrome mode is active, average the channels to get a grayscale image
             if(monochrome)
@@ -372,9 +372,9 @@ void KbLight::frameUpdate(QFile& cmd, bool monochrome){
             r *= light;
             g *= light;
             b *= light;
-            r = round(lToS(r));
-            g = round(lToS(g));
-            b = round(lToS(b));
+            r = std::round(lToS(r));
+            g = std::round(lToS(g));
+            b = std::round(lToS(b));
             rgb = qRgb(r, g, b);
         }
     }

--- a/src/gui/kblightwidget.cpp
+++ b/src/gui/kblightwidget.cpp
@@ -85,7 +85,7 @@ void KbLightWidget::updateLight(){
     ui->brightnessBox->setCurrentIndex(light->dimming());
 }
 
-void KbLightWidget::newSelection(QStringList selection){
+void KbLightWidget::newSelection(const QStringList& selection){
     if(light == nullptr)
         return;
     // Determine selected color (invalid color if no selection or if they're not all the same)
@@ -121,7 +121,7 @@ void KbLightWidget::newSelection(QStringList selection){
     }
 }
 
-void KbLightWidget::changeColor(QColor newColor){
+void KbLightWidget::changeColor(const QColor& newColor){
     if(light){
         foreach(QString key, currentSelection)
             light->color(key, newColor);
@@ -160,7 +160,7 @@ void KbLightWidget::changeAnim(KbAnim *newAnim){
     ui->keyWidget->setAnimationToSelection();
 }
 
-void KbLightWidget::changeAnimKeys(QStringList keys){
+void KbLightWidget::changeAnimKeys(const QStringList& keys){
     ui->keyWidget->setAnimation(keys);
 }
 

--- a/src/gui/kblightwidget.h
+++ b/src/gui/kblightwidget.h
@@ -26,10 +26,10 @@ public:
 
 private slots:
     void updateLight();
-    void newSelection(QStringList selection);
-    void changeColor(QColor newColor);
+    void newSelection(const QStringList& selection);
+    void changeColor(const QColor& newColor);
     void changeAnim(KbAnim* newAnim);
-    void changeAnimKeys(QStringList keys);
+    void changeAnimKeys(const QStringList& keys);
 
     void on_brightnessBox_activated(int index);
     void on_animButton_clicked();

--- a/src/gui/kbmanager.cpp
+++ b/src/gui/kbmanager.cpp
@@ -53,7 +53,7 @@ void KbManager::idleTimerTick(){
 }
 #endif
 
-void KbManager::init(QString guiVersion){
+void KbManager::init(const QString& guiVersion){
     _guiVersion = guiVersion;
     if(_kbManager)
         return;

--- a/src/gui/kbmanager.h
+++ b/src/gui/kbmanager.h
@@ -16,7 +16,7 @@ class KbManager : public QObject
     Q_OBJECT
 public:
     // Call at startup
-    static void init(QString guiVersion);
+    static void init(const QString& guiVersion);
     // Call at shutdown
     static void stop();
     // Singleton instance. Signals are emitted from here. Created when init() is called.

--- a/src/gui/kbperf.cpp
+++ b/src/gui/kbperf.cpp
@@ -552,7 +552,7 @@ void KbPerf::update(QFile& cmd, int notifyNumber, bool force, bool saveCustomDpi
 }
 
 void KbPerf::lightIndicator(const char* name, QRgb rgba){
-    int a = round(qAlpha(rgba) * _iOpacity);
+    int a = std::round(qAlpha(rgba) * _iOpacity);
     if(a <= 0)
         return;
     light()->setIndicator(name, qRgba(qRed(rgba), qGreen(rgba), qBlue(rgba), a));

--- a/src/gui/kbprofiledialog.cpp
+++ b/src/gui/kbprofiledialog.cpp
@@ -340,7 +340,7 @@ void KbProfileDialog::on_importButton_clicked(){
     QStringList filenames = dialog.selectedFiles();
 
     // Pick only the first filename
-    QString filename = filenames.at(0);
+    const QString& filename = filenames.at(0);
     if(!filename.endsWith(".ckb")){
         QMessageBox::warning(this, tr("Error"), tr("Selected file is not a valid profile."), QMessageBox::Ok);
         return;
@@ -421,7 +421,7 @@ void KbProfileDialog::on_importButton_clicked(){
     int pkgVerifiedCount = 0;
 
     for(int i = 0; i < extracted.count(); i++){
-        QString tmpFile = extracted.at(i);
+        const QString& tmpFile = extracted.at(i);
         if(tmpFile.endsWith("ini")){
             pkgProfileCount++;
             if(verifyHash(tmpFile)){
@@ -465,7 +465,7 @@ void KbProfileDialog::on_importButton_clicked(){
         //QUuid current = guid.trimmed();
         QUuid guid = sptr->childGroups().first().trimmed();
         // Messy, shhhh
-        QString profname = profilestr.at(i);
+        const QString& profname = profilestr.at(i);
         KbProfile* profilematch = nullptr;
         foreach(KbProfile* profile, device->profiles()){
 

--- a/src/gui/kbprofiledialog.cpp
+++ b/src/gui/kbprofiledialog.cpp
@@ -189,7 +189,7 @@ void KbProfileDialog::on_profileList_customContextMenuRequested(const QPoint &po
     repopulate();
 }
 
-void KbProfileDialog::extractedFileCleanup(QStringList extracted){
+void KbProfileDialog::extractedFileCleanup(const QStringList& extracted){
     for(int i = 0; i < extracted.count(); i++){
         // Delete extracted files
         QFile fdel(extracted.at(i));
@@ -300,7 +300,7 @@ void KbProfileDialog::on_exportButton_clicked(){
         QMessageBox::information(this, tr("Export Successful"), tr("Selected profiles have been exported successfully."), QMessageBox::Ok);
 }
 
-bool KbProfileDialog::verifyHash(QString file){
+bool KbProfileDialog::verifyHash(const QString& file){
     QFile iniFile(file);
     QFile hashFile(file + ".s256");
     if(iniFile.open(QFile::ReadOnly) && hashFile.open(QFile::ReadOnly)){
@@ -318,7 +318,7 @@ bool KbProfileDialog::verifyHash(QString file){
     return false;
 }
 
-void KbProfileDialog::importCleanup(QStringList extracted, QList<QPair<QSettings*, QString>> profileptrs){
+void KbProfileDialog::importCleanup(const QStringList& extracted, const QList<QPair<QSettings*, QString>>& profileptrs){
     // Destroy the open QSettings objects
     for(int i = 0; i < profileptrs.count(); i++)
         delete profileptrs.at(i).first;

--- a/src/gui/kbprofiledialog.h
+++ b/src/gui/kbprofiledialog.h
@@ -36,9 +36,9 @@ private:
     void repopulate();
     void addNewProfileItem();
 
-    bool verifyHash(QString file);
-    void importCleanup(QStringList extracted, QList<QPair<QSettings*, QString>> profileptrs);
-    void extractedFileCleanup(QStringList extracted);
+    bool verifyHash(const QString& file);
+    void importCleanup(const QStringList& extracted, const QList<QPair<QSettings*, QString>>& profileptrs);
+    void extractedFileCleanup(const QStringList& extracted);
 
 };
 

--- a/src/gui/kbwidget.cpp
+++ b/src/gui/kbwidget.cpp
@@ -384,7 +384,7 @@ void KbWidget::on_modesList_customContextMenuRequested(const QPoint &pos){
     }
 }
 
-inline int KbWidget::getPollRateBoxIdx(QString poll){
+inline int KbWidget::getPollRateBoxIdx(const QString& poll){
     switch(poll.leftRef(1).toInt()){
         case 1:
             return 0;
@@ -499,7 +499,7 @@ void KbWidget::on_layoutBox_activated(int index){
     device->layout(layout, true);
 }
 
-void KbWidget::switchToProfile(QString profile){
+void KbWidget::switchToProfile(const QString& profile){
     int len = device->profiles().length();
     for(int i = 0; i < len; i++){
         KbProfile* loopProfile = device->profiles().at(i);
@@ -515,7 +515,7 @@ void KbWidget::switchToProfile(QString profile){
     }
 }
 
-void KbWidget::switchToMode(QString mode){
+void KbWidget::switchToMode(const QString& mode){
     KbProfile* currentProfile = device->currentProfile();
     int len = currentProfile->modes().length();
 

--- a/src/gui/kbwidget.h
+++ b/src/gui/kbwidget.h
@@ -45,7 +45,7 @@ private:
 
     const static int GUID = Qt::UserRole;
     const static int NEW_FLAG = Qt::UserRole + 1;
-    int getPollRateBoxIdx(QString poll);
+    int getPollRateBoxIdx(const QString& poll);
 
 private slots:
     void updateProfileList();
@@ -68,8 +68,8 @@ private slots:
     void on_tabWidget_currentChanged(int index);
     void on_fwUpdButton_clicked();
     void on_layoutBox_activated(int index);
-    void switchToProfile(QString profile);
-    void switchToMode(QString mode);
+    void switchToProfile(const QString& profile);
+    void switchToMode(const QString& mode);
     void on_pollRateBox_currentIndexChanged(const QString &arg1);
 };
 

--- a/src/gui/keyaction.cpp
+++ b/src/gui/keyaction.cpp
@@ -529,6 +529,6 @@ void KeyAction::adjustDisplay(){
 /// \param macroDef holds the String containing parts 2-5 of a complete macro definition.
 /// \return QString holding the complete G-Key macro definition (parts 1-5)
 ///
-QString KeyAction::macroAction(QString macroDef) {
+QString KeyAction::macroAction(const QString& macroDef) {
     return QString ("$macro:%1").arg(macroDef);
 }

--- a/src/gui/keyaction.h
+++ b/src/gui/keyaction.h
@@ -140,7 +140,7 @@ public:
     static QString  programAction(const QString& onPress, const QString& onRelease, int stop);
     // Key to start an animation
     static QString animAction(const QUuid& guid, bool onlyOnce, bool stopOnRelease);
-    static QString macroAction(QString macroDef);   ///< \brief well documented in cpp file
+    static QString macroAction(const QString& macroDef);   ///< \brief well documented in cpp file
 
     // Action type
     enum Type {

--- a/src/gui/keymap.cpp
+++ b/src/gui/keymap.cpp
@@ -1031,7 +1031,7 @@ QPair<int, QString> KeyMap::addToList(int i, QStringList* list){
     return QPair<int, QString>(i, list->at(i));
 }
 
-QList<QPair<int, QString>> KeyMap::layoutNames(QString layout){
+QList<QPair<int, QString>> KeyMap::layoutNames(const QString& layout){
     QStringList list;
     list << "Danish"
          << "English (ISO/European)"

--- a/src/gui/keymap.h
+++ b/src/gui/keymap.h
@@ -99,7 +99,7 @@ public:
         _LAYOUT_MAX
     };
     // Human-readable names of each layout
-    static QList<QPair<int, QString> > layoutNames(QString layout);
+    static QList<QPair<int, QString> > layoutNames(const QString& layout);
     // ISO (105-key) or ANSI (104-key)?
     inline static bool  isISO(Layout layout)    { return layout != US && layout != US_DVORAK && layout != PL; }
     inline bool         isISO() const           { return isISO(keyLayout); }

--- a/src/gui/keywidget.cpp
+++ b/src/gui/keywidget.cpp
@@ -44,7 +44,7 @@ void KeyWidget::drawInfo(float& scale, float& offsetX, float& offsetY, int ratio
     int w = width() * ratio, h = height() * ratio;
     float xScale = (float)w / (keyMap.width() + KEY_SIZE);
     float yScale = (float)h / (keyMap.height() + KEY_SIZE);
-    scale = fmin(xScale, yScale);
+    scale = std::fmin(xScale, yScale);
     offsetX = (w / scale - keyMap.width()) / 2.f;
     offsetY = (h / scale - keyMap.height()) / 2.f;
 }
@@ -543,7 +543,7 @@ void KeyWidget::mousePressEvent(QMouseEvent* event){
         if((_rgbMode && !key.hasLed)
                 || (!_rgbMode && !key.hasScan))
             continue;
-        if(fabs(key.x - mx) <= key.width / 2.f - 1.f && fabs(key.y - my) <= key.height / 2.f - 1.f){
+        if(std::fabs(key.x - mx) <= key.width / 2.f - 1.f && std::fabs(key.y - my) <= key.height / 2.f - 1.f){
             // Sidelights can't have a color, but they can be toggled
             if(!strcmp(key.name, "lsidel") || !strcmp(key.name, "rsidel")){
                 emit sidelightToggled(); // get the kblightwidget to record it
@@ -602,7 +602,7 @@ void KeyWidget::mouseMoveEvent(QMouseEvent* event){
                 || (!_rgbMode && !key.hasScan))
             continue;
         // Update tooltip with the mouse hover (if any), even if it's not selectable
-        if(fabs(key.x - mx) <= key.width / 2.f - 1.f && fabs(key.y - my) <= key.height / 2.f - 1.f
+        if(std::fabs(key.x - mx) <= key.width / 2.f - 1.f && std::fabs(key.y - my) <= key.height / 2.f - 1.f
                 && tooltip.isEmpty())
             tooltip = key.friendlyName(false);
         // on STRAFE Sidelights and indicators can't be assigned color the way other keys are colored

--- a/src/gui/keywidget.cpp
+++ b/src/gui/keywidget.cpp
@@ -788,7 +788,7 @@ void KeyWidget::drawTopLeftCorner(QPainter* painter, float x, float y, float w, 
     painter->drawPolygon(edgePoints, 6);
 }
 
-void KeyWidget::drawStrafeSidelights(const Key* key, QPainter* decPainter, float offX, float offY, float scale, QColor keyColor, QColor color, QColor bgColor, int ratio){
+void KeyWidget::drawStrafeSidelights(const Key* key, QPainter* decPainter, float offX, float offY, float scale, const QColor& keyColor, const QColor& color, const QColor& bgColor, int ratio){
     float kx = key->x + offX - key->width / 2.f + 1.f;
     float ky = key->y + offY - key->height / 2.f + 1.f;
     float kw = key->width - 2.f;

--- a/src/gui/keywidget.h
+++ b/src/gui/keywidget.h
@@ -87,7 +87,7 @@ private:
     void drawBottomLeftCorner(QPainter* painter, float x, float y, float w, float h, float scale);
     void drawTopRightCorner(QPainter* painter, float x, float y, float w, float h, float scale);
     void drawTopLeftCorner(QPainter* painter, float x, float y, float w, float h, float scale);
-    void drawStrafeSidelights(const Key* key, QPainter* decPainter, float offX, float offY, float scale, QColor keyColor, QColor color, QColor bgColor, int ratio);
+    void drawStrafeSidelights(const Key* key, QPainter* decPainter, float offX, float offY, float scale, const QColor& keyColor, const QColor& color, const QColor& bgColor, int ratio);
 };
 
 #endif // RGBWIDGET_H

--- a/src/gui/kperfwidget.cpp
+++ b/src/gui/kperfwidget.cpp
@@ -131,7 +131,7 @@ void KPerfWidget::setPerf(KbPerf* newPerf, KbProfile* newProfile){
     perf = newPerf;
     profile = newProfile;
     // Set intensity
-    ui->intensityBox->setValue(round(perf->iOpacity() * 100.f));
+    ui->intensityBox->setValue(std::round(perf->iOpacity() * 100.f));
     // Set hardware indicator values
     for(int i = 0; i < HW_I_COUNT; i++){
         QColor c1, c2, c3;

--- a/src/gui/macroreader.cpp
+++ b/src/gui/macroreader.cpp
@@ -6,12 +6,12 @@
 /// \class MacroReader
 ///
 
-MacroReader::MacroReader(int macroNumber, QString macroPath, QPlainTextEdit* macBox, QPlainTextEdit* macText) {
+MacroReader::MacroReader(int macroNumber, const QString& macroPath, QPlainTextEdit* macBox, QPlainTextEdit* macText) {
     startWorkInAThread(macroNumber, macroPath, macBox, macText);
 }
 MacroReader::~MacroReader() {}
 
-void MacroReader::startWorkInAThread(int macroNumber, QString macroPath, QPlainTextEdit* macBox, QPlainTextEdit* macText) {
+void MacroReader::startWorkInAThread(int macroNumber, const QString& macroPath, QPlainTextEdit* macBox, QPlainTextEdit* macText) {
     macroReaderThread = new MacroReaderThread(macroNumber, macroPath, macBox, macText);
     connect(macroReaderThread, &MacroReaderThread::finished, macroReaderThread, &QObject::deleteLater);
     macroReaderThread->start();
@@ -20,7 +20,7 @@ void MacroReader::startWorkInAThread(int macroNumber, QString macroPath, QPlainT
 //////////
 /// \class MacroReaderThread
 ///
-void MacroReaderThread::readMacro(QString line) {
+void MacroReaderThread::readMacro(const QString& line) {
     /// \details We want to see the keys as they appear in the macroText Widget.
     ///
     /// Because it is possible to change the Focus via keyboard,

--- a/src/gui/macroreader.h
+++ b/src/gui/macroreader.h
@@ -52,7 +52,7 @@ public:
     /// \param macBox
     /// \param macText
     ///
-    MacroReaderThread(int macNum, QString macPath, QPlainTextEdit* macBox, QPlainTextEdit* macText) {
+    MacroReaderThread(int macNum, const QString& macPath, QPlainTextEdit* macBox, QPlainTextEdit* macText) {
         macroNumber = macNum;
         macroPath = macPath;
         macroBox = macBox;
@@ -77,7 +77,7 @@ private slots:
     ///
     /// \param line holds the line just got from keyboard
 
-    void readMacro(QString line);
+    void readMacro(const QString& line);
 };
 
 //////////
@@ -97,7 +97,7 @@ public:
     /// \param macBox
     /// \param macText
     ///
-    MacroReader(int macroNumber, QString macroPath, QPlainTextEdit* macBox, QPlainTextEdit* macText);
+    MacroReader(int macroNumber, const QString& macroPath, QPlainTextEdit* macBox, QPlainTextEdit* macText);
     ~MacroReader();
 
     //////////
@@ -107,7 +107,7 @@ public:
     /// \param macBox
     /// \param macText
     ///
-    void startWorkInAThread(int macroNumber, QString macroPath, QPlainTextEdit* macBox, QPlainTextEdit* macText);
+    void startWorkInAThread(int macroNumber, const QString& macroPath, QPlainTextEdit* macBox, QPlainTextEdit* macText);
 
 signals:
 

--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -597,7 +597,7 @@ void MainWindow::PosixSignalHandler(int signal){
         qDebug() << "Error on PosixSignalHandler write";
 }
 
-void MainWindow::checkedForNewVer(QString ver, QString changelog){
+void MainWindow::checkedForNewVer(const QString& ver, const QString& changelog){
 #ifndef DISABLE_UPDATER
     if(!ver.isEmpty()) {
         settingsWidget->setUpdateButtonText(tr("Update to v") + ver);

--- a/src/gui/mainwindow.h
+++ b/src/gui/mainwindow.h
@@ -100,7 +100,7 @@ private slots:
     void cleanup();
     void showFwUpdateNotification(QWidget* widget, float version);
     void QSignalHandler();
-    void checkedForNewVer(QString ver, QString changelog);
+    void checkedForNewVer(const QString& ver, const QString& changelog);
 #if defined(Q_OS_MACOS) && !defined(OS_MAC_LEGACY)
     void appleRequestHidTimer();
 #endif

--- a/src/gui/modeselectdialog.cpp
+++ b/src/gui/modeselectdialog.cpp
@@ -1,7 +1,8 @@
 #include "modeselectdialog.h"
+
 #include "ui_modeselectdialog.h"
 
-ModeSelectDialog::ModeSelectDialog(QWidget* parent, KbMode* currentMode, QList<KbMode*> modeList, const QString& textLabel) :
+ModeSelectDialog::ModeSelectDialog(QWidget* parent, KbMode* currentMode, const QList<KbMode*>& modeList, const QString& textLabel) :
     QDialog(parent), ui(new Ui::ModeSelectDialog),
     _modeList(modeList)
 {

--- a/src/gui/modeselectdialog.h
+++ b/src/gui/modeselectdialog.h
@@ -16,7 +16,7 @@ class ModeSelectDialog : public QDialog
 
 public:
     // Mode dialog with a list of modes and a custom text label. Use exec() to display. currentMode will not be displayed.
-    ModeSelectDialog(QWidget* parent, KbMode* currentMode, QList<KbMode*> modeList, const QString& textLabel);
+    ModeSelectDialog(QWidget* parent, KbMode* currentMode, const QList<KbMode*>& modeList, const QString& textLabel);
     ~ModeSelectDialog();
 
     // Mode(s) selected by the user

--- a/src/gui/mperfwidget.cpp
+++ b/src/gui/mperfwidget.cpp
@@ -69,7 +69,7 @@ MPerfWidget::~MPerfWidget(){
 void MPerfWidget::setPerf(KbPerf *newPerf, KbProfile *newProfile){
     perf = newPerf;
     profile = newProfile;
-    ui->spinBox->setValue(round(perf->iOpacity() * 100.f));
+    ui->spinBox->setValue(std::round(perf->iOpacity() * 100.f));
     for(int i = 0; i < DPI_COUNT; i++){
         stages[i].indicator->color(perf->dpiColor(i));
         bool oldLink = _xyLink;

--- a/src/gui/rebindwidget.cpp
+++ b/src/gui/rebindwidget.cpp
@@ -889,7 +889,7 @@ void RebindWidget::on_rb_delay_default_toggled(bool checked)
 /// If "=" can be found and numbers with more than one digit (means: > 9), it is the "asTyped" button
 /// Otherwise it is the "no" button.
 ///
-void RebindWidget::setCorrectRadioButton (QString macdef) {
+void RebindWidget::setCorrectRadioButton (const QString& macdef) {
     if (!macdef.contains(QRegExp("=\\d+,"))) {
         ui->rb_delay_default->setChecked(true);
         return;

--- a/src/gui/rebindwidget.h
+++ b/src/gui/rebindwidget.h
@@ -89,7 +89,7 @@ private:
     // Show some help info
     void helpStatus(int status);
 
-    void setCorrectRadioButton (QString macdef);
+    void setCorrectRadioButton (const QString& macdef);
 
     KbBind* bind;
     KbProfile* profile;

--- a/src/gui/settingswidget.cpp
+++ b/src/gui/settingswidget.cpp
@@ -263,7 +263,7 @@ void SettingsWidget::enableUpdateButton(){
     ui->pushButton_2->setEnabled(true);
 }
 
-void SettingsWidget::setUpdateButtonText(QString text){
+void SettingsWidget::setUpdateButtonText(const QString& text){
     if(updateRequestedByUser) {
         ui->pushButton_2->setText(text);
         updateRequestedByUser = false;

--- a/src/gui/settingswidget.h
+++ b/src/gui/settingswidget.h
@@ -25,7 +25,7 @@ public:
     void pollUpdates();
 
     void enableUpdateButton();
-    void setUpdateButtonText(QString text);
+    void setUpdateButtonText(const QString& text);
 
 signals:
     void checkForUpdates();


### PR DESCRIPTION
I decided to run some clang-tidy checks on ckb-next's gui directory and let it fix the reported problems. These commits contain fixes for the results of following clang-tidy checks:

- performance-unnecessary-value-param

- performance-unnecessary-copy-initialization

- performance-type-promotion-in-math-fn

