### PR TITLE
Fix gcc-10/-fno-common error

### DIFF
--- a/src/daemon/devnode.h
+++ b/src/daemon/devnode.h
@@ -5,7 +5,7 @@
 #include "usb.h"
 
 /// Device path base ("/dev/input/ckb" or "/var/run/ckb")
-const char *const devpath;
+extern const char *const devpath;
 
 /// Group ID for the control nodes. -1 to give read/write access to everybody
 extern long gid;


### PR DESCRIPTION
gcc-10 now defaults to -fno-common and does not automatically add extern
to variables declared in headers.

https://gcc.gnu.org/gcc-10/porting_to.html

Signed-off-by: Erik Zeek <zeekec@gmail.com>