### PR TITLE
Replace plain mutexes with queued ticket locks (fixes #391).

### DIFF
--- a/src/daemon/device_keyboard.c
+++ b/src/daemon/device_keyboard.c
@@ -21,13 +21,13 @@ int setactive_kb(usbdevice* kb, int active){
     if(NEEDS_FW_UPDATE(kb))
         return 0;
 
-    pthread_mutex_lock(imutex(kb));
+    ticket_lock(imutex(kb));
     kb->active = !!active;
     kb->profile->lastlight.forceupdate = 1;
     // Clear input
     memset(&kb->input.keys, 0, sizeof(kb->input.keys));
     inputupdate(kb);
-    pthread_mutex_unlock(imutex(kb));
+    ticket_unlock(imutex(kb));
 
     uchar msg[3][MSG_SIZE] = {
         { CMD_SET, FIELD_SPECIAL, 0 },                // Disables or enables HW control for top row

--- a/src/daemon/device_mouse.c
+++ b/src/daemon/device_mouse.c
@@ -54,13 +54,13 @@ int setactive_mouse(usbdevice* kb, int active){
     else
         // Restore HW mode
         msg[0][2] = MODE_HARDWARE;
-    pthread_mutex_lock(imutex(kb));
+    ticket_lock(imutex(kb));
     kb->active = !!active;
     kb->profile->lastlight.forceupdate = 1;
     // Clear input
     memset(&kb->input.keys, 0, sizeof(kb->input.keys));
     inputupdate(kb);
-    pthread_mutex_unlock(imutex(kb));
+    ticket_unlock(imutex(kb));
     if(!usbsend(kb, msg[0], 1))
         return -1;
     if(active){

--- a/src/daemon/devnode.c
+++ b/src/daemon/devnode.c
@@ -79,13 +79,13 @@ void check_chmod(const char *pathname, mode_t mode){
 /// Because several independent threads may call updateconnected(), protect that procedure with locking/unlocking of \b devmutex.
 ///
 void _updateconnected(){
-    pthread_mutex_lock(devmutex);
+    ticket_lock(devmutex);
     char cpath[strlen(devpath) + 12];
     snprintf(cpath, sizeof(cpath), "%s0/connected", devpath);
     FILE* cfile = fopen(cpath, "w");
     if(!cfile){
         ckb_warn("Unable to update %s: %s\n", cpath, strerror(errno));
-        pthread_mutex_unlock(devmutex);
+        ticket_unlock(devmutex);
         return;
     }
     int written = 0;
@@ -102,7 +102,7 @@ void _updateconnected(){
     check_chmod(cpath, S_GID_READ);
     check_chown(cpath, 0, gid);
 
-    pthread_mutex_unlock(devmutex);
+    ticket_unlock(devmutex);
 }
 
 void updateconnected(){

--- a/src/daemon/input.c
+++ b/src/daemon/input.c
@@ -99,14 +99,14 @@ static void* play_macro(void* param) {
     pthread_mutex_unlock(mmutex2(kb));       ///< Give all new threads the chance to enter the block.
 
     /// Send events for each keypress in the macro
-    pthread_mutex_lock(mmutex(kb)); ///< Synchonization between macro output and color information
+    ticket_lock(mmutex(kb)); ///< Synchonization between macro output and color information
     for (int a = 0; a < macro->actioncount; a++) {
         macroaction* action = macro->actions + a;
         if (action->rel_x != 0 || action->rel_y != 0)
             os_mousemove(kb, action->rel_x, action->rel_y);
         else {
             os_keypress(kb, action->scan, action->down);
-            pthread_mutex_unlock(mmutex(kb));           ///< use this unlock / relock for enablling the parallel running colorization
+            ticket_unlock(mmutex(kb));           ///< use this unlock / relock for enablling the parallel running colorization
             if (action->delay != UINT_MAX && action->delay) {    ///< local delay set
                 clock_nanosleep(CLOCK_MONOTONIC, 0, &(struct timespec) {.tv_nsec = action->delay * 1000}, NULL);
             } else if (kb->delay != UINT_MAX && kb->delay) {     ///< use default global delay
@@ -118,7 +118,7 @@ static void* play_macro(void* param) {
                     clock_nanosleep(CLOCK_MONOTONIC, 0, &(struct timespec) {.tv_nsec = 30000}, NULL);
                 }
             }
-            pthread_mutex_lock(mmutex(kb));
+            ticket_lock(mmutex(kb));
         }
     }
 
@@ -128,7 +128,7 @@ static void* play_macro(void* param) {
     pthread_cond_broadcast(mvar(kb));   ///< Wake up all waiting threads
     pthread_mutex_unlock(mmutex2(kb));  ///< for the linked list and the mvar
 
-    pthread_mutex_unlock(mmutex(kb));   ///< Sync keyboard input/output and colorization
+    ticket_unlock(mmutex(kb));   ///< Sync keyboard input/output and colorization
     return 0;
 }
 
@@ -325,17 +325,17 @@ void cmd_bind(usbdevice* kb, usbmode* mode, int dummy, int keyindex, const char*
     // Find the key to bind to
     uint tocode = 0;
     if(sscanf(to, "#x%ux", &tocode) != 1 && sscanf(to, "#%u", &tocode) == 1 && tocode < N_KEYS_INPUT){
-        pthread_mutex_lock(imutex(kb));
+        ticket_lock(imutex(kb));
         mode->bind.base[keyindex] = tocode;
-        pthread_mutex_unlock(imutex(kb));
+        ticket_unlock(imutex(kb));
         return;
     }
     // If not numeric, look it up
     for(int i = 0; i < N_KEYS_INPUT; i++){
         if(kb->keymap[i].name && !strcmp(to, kb->keymap[i].name)){
-            pthread_mutex_lock(imutex(kb));
+            ticket_lock(imutex(kb));
             mode->bind.base[keyindex] = kb->keymap[i].scan;
-            pthread_mutex_unlock(imutex(kb));
+            ticket_unlock(imutex(kb));
             return;
         }
     }
@@ -347,9 +347,9 @@ void cmd_unbind(usbdevice* kb, usbmode* mode, int dummy, int keyindex, const cha
 
     if(keyindex >= N_KEYS_INPUT)
         return;
-    pthread_mutex_lock(imutex(kb));
+    ticket_lock(imutex(kb));
     mode->bind.base[keyindex] = KEY_UNBOUND;
-    pthread_mutex_unlock(imutex(kb));
+    ticket_unlock(imutex(kb));
 }
 
 void cmd_rebind(usbdevice* kb, usbmode* mode, int dummy, int keyindex, const char* to){
@@ -358,9 +358,9 @@ void cmd_rebind(usbdevice* kb, usbmode* mode, int dummy, int keyindex, const cha
 
     if(keyindex >= N_KEYS_INPUT)
         return;
-    pthread_mutex_lock(imutex(kb));
+    ticket_lock(imutex(kb));
     mode->bind.base[keyindex] = kb->keymap[keyindex].scan;
-    pthread_mutex_unlock(imutex(kb));
+    ticket_unlock(imutex(kb));
 }
 
 static void _cmd_macro(usbmode* mode, const char* keys, const char* assignment, usbdevice* kb){
@@ -488,7 +488,7 @@ static void _cmd_macro(usbmode* mode, const char* keys, const char* assignment, 
 void cmd_macro(usbdevice* kb, usbmode* mode, const int notifynumber, const char* keys, const char* assignment){
     (void)notifynumber;
 
-    pthread_mutex_lock(imutex(kb));
+    ticket_lock(imutex(kb));
     _cmd_macro(mode, keys, assignment, kb);
-    pthread_mutex_unlock(imutex(kb));
+    ticket_unlock(imutex(kb));
 }

--- a/src/daemon/input_linux.c
+++ b/src/daemon/input_linux.c
@@ -208,12 +208,12 @@ void* _ledthread(void* ctx){
                 ileds &= ~which;
         }
         // Update them if needed
-        pthread_mutex_lock(dmutex(kb));
+        ticket_lock(dmutex(kb));
         if(kb->hw_ileds != ileds){
             kb->hw_ileds = ileds;
             kb->vtable->updateindicators(kb, 0);
         }
-        pthread_mutex_unlock(dmutex(kb));
+        ticket_unlock(dmutex(kb));
     }
     return 0;
 }

--- a/src/daemon/input_mac.c
+++ b/src/daemon/input_mac.c
@@ -158,19 +158,19 @@ static void* indicator_update(void* context){
     indicthread_name[3] = INDEX_OF(kb, keyboard) + '0';
     pthread_setname_np(indicthread_name);
 
-    pthread_mutex_lock(dmutex(kb));
+    ticket_lock(dmutex(kb));
     {
-        pthread_mutex_lock(imutex(kb));
+        ticket_lock(imutex(kb));
         IOOptionBits modifiers = kb->modifiers;
         // Allow the thread to be spawned again
         kb->indicthread = 0;
-        pthread_mutex_unlock(imutex(kb));
+        ticket_unlock(imutex(kb));
         // Num lock on, Caps dependent on modifier state
         uchar ileds = 1 | !!(modifiers & NX_ALPHASHIFTMASK) << 1;
         kb->hw_ileds = ileds;
         kb->vtable->updateindicators(kb, 0);
     }
-    pthread_mutex_unlock(dmutex(kb));
+    ticket_unlock(dmutex(kb));
     return 0;
 }
 

--- a/src/daemon/input_mac_legacy.c
+++ b/src/daemon/input_mac_legacy.c
@@ -307,19 +307,19 @@ static void* indicator_update(void* context){
     indicthread_name[3] = INDEX_OF(kb, keyboard) + '0';
     pthread_setname_np(indicthread_name);
 
-    pthread_mutex_lock(dmutex(kb));
+    ticket_lock(dmutex(kb));
     {
-        pthread_mutex_lock(imutex(kb));
+        ticket_lock(imutex(kb));
         IOOptionBits modifiers = kb->modifiers;
         // Allow the thread to be spawned again
         kb->indicthread = 0;
-        pthread_mutex_unlock(imutex(kb));
+        ticket_unlock(imutex(kb));
         // Num lock on, Caps dependent on modifier state
         uchar ileds = 1 | !!(modifiers & NX_ALPHASHIFTMASK) << 1;
         kb->hw_ileds = ileds;
         kb->vtable->updateindicators(kb, 0);
     }
-    pthread_mutex_unlock(dmutex(kb));
+    ticket_unlock(dmutex(kb));
     return 0;
 }
 

--- a/src/daemon/keymap.c
+++ b/src/daemon/keymap.c
@@ -342,7 +342,7 @@ void process_input_urb(void* context, unsigned char* buffer, int urblen, ushort 
         if(retval)
             ckb_fatal("Error unlocking interrupt mutex %i\n", retval);
     } else {
-        pthread_mutex_lock(imutex(kb));
+        ticket_lock(imutex(kb));
         if(IS_LEGACY_DEV(kb)) {
             if(IS_MOUSE_DEV(kb))
                 m95_mouse_translate(kb->input.keys, &kb->input.rel_x, &kb->input.rel_y, urblen, buffer);
@@ -377,7 +377,7 @@ void process_input_urb(void* context, unsigned char* buffer, int urblen, ushort 
         ///
         /// The input data is transformed and copied to the kb structure. Now give it to the OS and unlock the imutex afterwards.
         inputupdate(kb);
-        pthread_mutex_unlock(imutex(kb));
+        ticket_unlock(imutex(kb));
     }
 }
 

--- a/src/daemon/main.c
+++ b/src/daemon/main.c
@@ -31,12 +31,12 @@ static void quit() {
     reset_stop = 1;
     for(int i = 1; i < DEV_MAX; i++){
         // Before closing, set all keyboards back to HID input mode so that the stock driver can still talk to them
-        pthread_mutex_lock(devmutex + i);
+        ticket_lock(devmutex + i);
         if(IS_CONNECTED(keyboard + i)){
             revertusb(keyboard + i);
             closeusb(keyboard + i);
         }
-        pthread_mutex_unlock(devmutex + i);
+        ticket_unlock(devmutex + i);
     }
     ckb_info("Closing root controller\n");
     rmdevpath(keyboard);

--- a/src/daemon/notify.c
+++ b/src/daemon/notify.c
@@ -63,12 +63,12 @@ void nprintind(usbdevice* kb, int nnumber, int led, int on){
 void cmd_notify(usbdevice* kb, usbmode* mode, int nnumber, int keyindex, const char* toggle){
     if(keyindex >= N_KEYS_INPUT)
         return;
-    pthread_mutex_lock(imutex(kb));
+    ticket_lock(imutex(kb));
     if(!strcmp(toggle, "on") || *toggle == 0)
         SET_KEYBIT(mode->notify[nnumber], keyindex);
     else if(!strcmp(toggle, "off"))
         CLEAR_KEYBIT(mode->notify[nnumber], keyindex);
-    pthread_mutex_unlock(imutex(kb));
+    ticket_unlock(imutex(kb));
 }
 
 // Check hardware mode, bail out if it doesn't exist
@@ -217,7 +217,7 @@ static void _cmd_get(usbdevice* kb, usbmode* mode, int nnumber, const char* sett
 void cmd_get(usbdevice* kb, usbmode* mode, int nnumber, int dummy, const char* setting){
     (void)dummy;
 
-    pthread_mutex_lock(imutex(kb));
+    ticket_lock(imutex(kb));
     _cmd_get(kb, mode, nnumber, setting);
-    pthread_mutex_unlock(imutex(kb));
+    ticket_unlock(imutex(kb));
 }

--- a/src/daemon/profile.c
+++ b/src/daemon/profile.c
@@ -220,10 +220,10 @@ void cmd_erase(usbdevice* kb, usbmode* mode, int dummy1, int dummy2, const char*
     (void)dummy2;
     (void)dummy3;
 
-    pthread_mutex_lock(imutex(kb));
+    ticket_lock(imutex(kb));
     freemode(mode);
     initmode(mode, kb);
-    pthread_mutex_unlock(imutex(kb));
+    ticket_unlock(imutex(kb));
 }
 
 static void _freeprofile(usbdevice* kb){
@@ -243,10 +243,10 @@ void cmd_eraseprofile(usbdevice* kb, usbmode* dummy1, int dummy2, int dummy3, co
     (void)dummy3;
     (void)dummy4;
 
-    pthread_mutex_lock(imutex(kb));
+    ticket_lock(imutex(kb));
     _freeprofile(kb);
     allocprofile(kb);
-    pthread_mutex_unlock(imutex(kb));
+    ticket_unlock(imutex(kb));
 }
 
 void freeprofile(usbdevice* kb){

--- a/src/daemon/usb.c
+++ b/src/daemon/usb.c
@@ -261,11 +261,11 @@ static void* devmain(usbdevice* kb){
         /// (checked via IS_CONNECTED(kb)).
         /// This is true if the kb-structure has a handle and an event pointer both != Null).
         /// If not, the loop is left (the first exit point).
-        pthread_mutex_unlock(dmutex(kb));
+        ticket_unlock(dmutex(kb));
         // Read from FIFO
         const char* line;
         int lines = readlines(kbfifo, linectx, &line);
-        pthread_mutex_lock(dmutex(kb));
+        ticket_lock(dmutex(kb));
         // End thread when the handle is removed
         if(!IS_CONNECTED(kb))
             break;
@@ -287,7 +287,7 @@ static void* devmain(usbdevice* kb){
             }
         }
     }
-    pthread_mutex_unlock(dmutex(kb));
+    ticket_unlock(dmutex(kb));
     ///
     /// After leaving the endless loop the readlines-ctx structure and its buffers are freed by readlines_ctx_free().
     readlines_ctx_free(linectx);
@@ -336,7 +336,7 @@ static void* _setupusb(void* context){
     /// - the standard delay time is initialized in kb->usbdelay
     ///
     usbdevice* kb = context;
-    pthread_mutex_lock(imutex(kb));
+    ticket_lock(imutex(kb));
     // Set standard fields
     ushort vendor = kb->vendor, product = kb->product;
     const devcmd* vt = kb->vtable = get_vtable(vendor, product);
@@ -444,7 +444,7 @@ static void* _setupusb(void* context){
     /// - From this point - if an error is detected - the error label is addressed by goto statement,
     /// which first performs an unlock on the imutex.
     /// This is interesting because the next statement is exactly this: An unlock on the imutex.
-    pthread_mutex_unlock(imutex(kb));
+    ticket_unlock(imutex(kb));
     ///
     /// - Via vtable the \a kb->start() function is called next.
     /// This is the same for a mouse and an RGB keyboard: start_dev(),
@@ -503,10 +503,10 @@ static void* _setupusb(void* context){
     ///
     /// - The remaining code lines are the two exit labels as described above
     fail:
-    pthread_mutex_unlock(imutex(kb));
+    ticket_unlock(imutex(kb));
     fail_noinput:
     closeusb(kb);
-    pthread_mutex_unlock(dmutex(kb));
+    ticket_unlock(dmutex(kb));
     return 0;
 }
 
@@ -678,9 +678,9 @@ int _usbsend(usbdevice* kb, const uchar* messages, int count, const char* file, 
         // Send each message via the OS function
         while(1){
             DELAY_SHORT(kb);
-            pthread_mutex_lock(mmutex(kb)); ///< Synchonization between macro and color information
+            ticket_lock(mmutex(kb)); ///< Synchonization between macro and color information
             int res = os_usbsend(kb, messages + i * MSG_SIZE, 0, file, line);
-            pthread_mutex_unlock(mmutex(kb));
+            ticket_unlock(mmutex(kb));
             if(res == 0)
                 return 0;
             else if(res != -1){
@@ -700,9 +700,9 @@ int _usbsend(usbdevice* kb, const uchar* messages, int count, const char* file, 
 int _usbsend_control(usbdevice* kb, uchar* data, ushort len, uchar bRequest, ushort wValue, ushort wIndex, const char* file, int line){
     while(1){
         DELAY_SHORT(kb);
-        pthread_mutex_lock(mmutex(kb)); ///< Synchonization between macro and color information
+        ticket_lock(mmutex(kb)); ///< Synchonization between macro and color information
         int res = os_usbsend_control(kb, data, len, bRequest, wValue, wIndex, file, line);
-        pthread_mutex_unlock(mmutex(kb));
+        ticket_unlock(mmutex(kb));
 
         if(res != -1)
             return res;
@@ -764,10 +764,10 @@ int _usbrecv(usbdevice* kb, const uchar* out_msg, uchar* in_msg, const char* fil
     // Try a maximum of 5 times
     for (int try = 0; try < 5; try++) {
         // Send the output message
-        pthread_mutex_lock(mmutex(kb)); ///< Synchonization between macro and color information
+        ticket_lock(mmutex(kb)); ///< Synchonization between macro and color information
         DELAY_SHORT(kb);
         int res = os_usbsend(kb, out_msg, 1, file, line);
-        pthread_mutex_unlock(mmutex(kb));
+        ticket_unlock(mmutex(kb));
         if (res == 0)
             return 0;
         else if (res == -1) {
@@ -837,7 +837,7 @@ int _usbrecv(usbdevice* kb, const uchar* out_msg, uchar* in_msg, const char* fil
 /// and closeusb() always returns zero (success).
 ///
 int closeusb(usbdevice* kb){
-    pthread_mutex_lock(imutex(kb));
+    ticket_lock(imutex(kb));
     if(kb->handle){
         int index = INDEX_OF(kb, keyboard);
         ckb_info("Disconnecting %s%d\n", devpath, index);
@@ -850,10 +850,10 @@ int closeusb(usbdevice* kb){
     rmdevpath(kb);
 
     // Wait for thread to close
-    pthread_mutex_unlock(imutex(kb));
-    pthread_mutex_unlock(dmutex(kb));
+    ticket_unlock(imutex(kb));
+    ticket_unlock(dmutex(kb));
     pthread_join(kb->thread, 0);
-    pthread_mutex_lock(dmutex(kb));
+    ticket_lock(dmutex(kb));
 
     // Free the device-specific keymap
     free(kb->keymap);
@@ -888,13 +888,13 @@ void reactivate_devices()
         if(IS_CONNECTED(keyboard + i)){
             kb = keyboard + i;
             // If the device was active, mark it as disabled and re-enable it
-            pthread_mutex_lock(dmutex(kb));
+            ticket_lock(dmutex(kb));
             if(kb->active){
                 kb->active = 0;
                 const devcmd* vt = kb->vtable;
                 vt->active(kb, 0, 0, 0, 0);
             }
-            pthread_mutex_unlock(dmutex(kb));
+            ticket_unlock(dmutex(kb));
         }
     }
 }

--- a/src/daemon/usb_linux.c
+++ b/src/daemon/usb_linux.c
@@ -273,9 +273,9 @@ void os_sendindicators(usbdevice* kb) {
         ileds = &kb->ileds;
     }
     struct usbdevfs_ctrltransfer transfer = { 0x21, 0x09, 0x0200, 0x00, ((kb->fwversion >= 0x300 || IS_V3_OVERRIDE(kb)) ? 2 : 1), 500, ileds };
-    pthread_mutex_unlock(dmutex(kb));
+    ticket_unlock(dmutex(kb));
     int res = ioctl(kb->handle - 1, USBDEVFS_CONTROL, &transfer);
-    pthread_mutex_lock(dmutex(kb));
+    ticket_lock(dmutex(kb));
     if(res <= 0) {
         ckb_err("%s\n", res ? strerror(errno) : "No data written");
         if (usb_tryreset(kb) == 0 && countForReset++ < 3) {
@@ -661,7 +661,7 @@ int usbadd(struct udev_device* dev, ushort vendor, ushort product) {
     // Find a free USB slot
     for(int index = 1; index < DEV_MAX; index++){
         usbdevice* kb = keyboard + index;
-        if(pthread_mutex_trylock(dmutex(kb))){
+        if(ticket_trylock(dmutex(kb))){
             // If the mutex is locked then the device is obviously in use, so keep going
             if(!strcmp(syspath, kbsyspath[index])){
                 // Make sure this existing keyboard doesn't have the same syspath (this shouldn't happen)
@@ -675,7 +675,7 @@ int usbadd(struct udev_device* dev, ushort vendor, ushort product) {
             if(kb->handle <= 0){
                 ckb_err("Failed to open USB device: %s\n", strerror(errno));
                 kb->handle = 0;
-                pthread_mutex_unlock(dmutex(kb));
+                ticket_unlock(dmutex(kb));
                 return -1;
             } else {
                 // Set up device
@@ -688,7 +688,7 @@ int usbadd(struct udev_device* dev, ushort vendor, ushort product) {
                 return 0;
             }
         }
-        pthread_mutex_unlock(dmutex(kb));
+        ticket_unlock(dmutex(kb));
     }
     ckb_err("No free devices\n");
     return -1;
@@ -748,10 +748,10 @@ static void usb_rm_device(struct udev_device* dev){
     if(!syspath || syspath[0] == 0)
         return;
     for(int i = 1; i < DEV_MAX; i++){
-        pthread_mutex_lock(devmutex + i);
+        ticket_lock(devmutex + i);
         if(!strcmp(syspath, kbsyspath[i]))
             closeusb(keyboard + i);
-        pthread_mutex_unlock(devmutex + i);
+        ticket_unlock(devmutex + i);
     }
 }
 


### PR DESCRIPTION
In order to guarantee fair access to dmutex, imutex and mmutex,
plain mutexes are replaced with a ticket lock structure that
ensures contenders for the lock get queued fairly.

This is enough to remove the delay for indicator leds caused
by contention on dmutex with the RGB update thread.

The solution was taken from this stack overflow question:

https://stackoverflow.com/questions/5385777/implementing-a-fifo-mutex-in-pthreads