### PR TITLE
Fix #391 by replacing plain mutexes with FIFO-fair ones.

### DIFF
--- a/src/daemon/device.c
+++ b/src/daemon/device.c
@@ -8,14 +8,49 @@ int hwload_mode = 1;        ///< hwload_mode = 1 means read hardware once. shoul
 
 // Device list
 usbdevice keyboard[DEV_MAX];    ///< remember all usb devices. Needed for closeusb().
-pthread_mutex_t devlistmutex = PTHREAD_MUTEX_INITIALIZER;
-pthread_mutex_t devmutex[DEV_MAX] = { [0 ... DEV_MAX-1] = PTHREAD_MUTEX_INITIALIZER };      ///< Mutex for handling the usbdevice structure
-pthread_mutex_t inputmutex[DEV_MAX] = { [0 ... DEV_MAX-1] = PTHREAD_MUTEX_INITIALIZER };    ///< Mutex for dealing with usb input frames
-pthread_mutex_t macromutex[DEV_MAX] = { [0 ... DEV_MAX-1] = PTHREAD_MUTEX_INITIALIZER };    ///< Protecting macros against lightning: Both use usb_send
+queued_mutex_t devmutex[DEV_MAX] = { [0 ... DEV_MAX-1] = QUEUED_MUTEX_INITIALIZER };        ///< Mutex for handling the usbdevice structure
+queued_mutex_t inputmutex[DEV_MAX] = { [0 ... DEV_MAX-1] = QUEUED_MUTEX_INITIALIZER };      ///< Mutex for dealing with usb input frames
+queued_mutex_t macromutex[DEV_MAX] = { [0 ... DEV_MAX-1] = QUEUED_MUTEX_INITIALIZER };      ///< Protecting macros against lightning: Both use usb_send
 pthread_mutex_t macromutex2[DEV_MAX] = { [0 ... DEV_MAX-1] = PTHREAD_MUTEX_INITIALIZER };   ///< Protecting the single link list of threads and the macrovar
 pthread_cond_t macrovar[DEV_MAX] = { [0 ... DEV_MAX-1] = PTHREAD_COND_INITIALIZER };        ///< This variable is used to stop and wakeup all macro threads which have to wait.
 pthread_mutex_t interruptmutex[DEV_MAX] = { [0 ... DEV_MAX-1] = PTHREAD_MUTEX_INITIALIZER };///< Used for interrupt transfers
 pthread_cond_t interruptcond[DEV_MAX] = { [0 ... DEV_MAX-1] = PTHREAD_COND_INITIALIZER };   ///< Same as above
+
+void queued_mutex_lock(queued_mutex_t* mutex){
+    unsigned long my_turn;
+    pthread_mutex_lock(&mutex->mutex);
+    my_turn = mutex->next_waiting++;
+
+    while(my_turn != mutex->next_in)
+        pthread_cond_wait(&mutex->cond, &mutex->mutex);
+
+    pthread_mutex_unlock(&mutex->mutex);
+}
+
+int queued_mutex_trylock(queued_mutex_t* mutex){
+    unsigned long my_turn;
+    int res = 0;
+    pthread_mutex_lock(&mutex->mutex);
+
+    if(mutex->next_waiting == mutex->next_in){
+        mutex->next_waiting++;
+    }
+    else{
+        res = -1;
+    }
+
+    pthread_mutex_unlock(&mutex->mutex);
+
+    return res;
+}
+
+void queued_mutex_unlock(queued_mutex_t* mutex){
+    pthread_mutex_lock(&mutex->mutex);
+    mutex->next_in++;
+    pthread_mutex_unlock(&mutex->mutex);
+    pthread_cond_broadcast(&mutex->cond);
+}
+
 
 /// \brief .
 ///

--- a/src/daemon/device.c
+++ b/src/daemon/device.c
@@ -28,7 +28,6 @@ void queued_mutex_lock(queued_mutex_t* mutex){
 }
 
 int queued_mutex_trylock(queued_mutex_t* mutex){
-    unsigned long my_turn;
     int res = 0;
     pthread_mutex_lock(&mutex->mutex);
 

--- a/src/daemon/device.h
+++ b/src/daemon/device.h
@@ -14,18 +14,32 @@ extern usbdevice keyboard[DEV_MAX];
 #else
 #define IS_CONNECTED(kb) ((kb) && (kb)->handle && (kb)->event)
 #endif
+
+// A fair queue mutex construct; contenders get to grab the mutex in the order they attempted to acquire it
+typedef struct queued_mutex{
+    pthread_mutex_t mutex;
+    pthread_cond_t cond;
+    unsigned long next_in, next_waiting;
+} queued_mutex_t;
+
+#define QUEUED_MUTEX_INITIALIZER {PTHREAD_MUTEX_INITIALIZER, PTHREAD_COND_INITIALIZER, 0, 0}
+
+void queued_mutex_lock(queued_mutex_t* mutex);   // Lock a queued_mutex
+int queued_mutex_trylock(queued_mutex_t* mutex); // Try to lock a queued_mutex without blocking; returns 0 on success.
+void queued_mutex_unlock(queued_mutex_t* mutex); // Unlock a queued_mutex
+
 //#define MUTEX_DBG(str, kb, mutexarray) (ckb_info(str " %s:%d (%s) at ckb%d, TID 0x%lx, MID %p\n", __FILE__, __LINE__, __func__, INDEX_OF(kb, keyboard), pthread_self(), mutexarray + INDEX_OF(kb, keyboard)) & 0)
 #define MUTEX_DBG(a, b, c) 0
 // A mutex used for USB controls. Needs to be locked before reading or writing the device handle or accessing its profile
-extern pthread_mutex_t devmutex[DEV_MAX];
+extern queued_mutex_t devmutex[DEV_MAX];
 #define dmutex(kb) (devmutex + INDEX_OF(kb, keyboard) + MUTEX_DBG("DMUTEX", kb, devmutex))
 // Similar, but for key input. Also needs to be locked before accessing output FIFOs.
 // When adding or removing a device you must lock BOTH mutexes, dmutex first.
-extern pthread_mutex_t inputmutex[DEV_MAX];
+extern queued_mutex_t inputmutex[DEV_MAX];
 #define imutex(kb) (inputmutex + INDEX_OF(kb, keyboard) + MUTEX_DBG("IMUTEX", kb, inputmutex))
 
 // Needed to synchronize sending macro-keys to the os and sending color info to the device
-extern pthread_mutex_t macromutex[DEV_MAX];
+extern queued_mutex_t macromutex[DEV_MAX];
 #define mmutex(kb) (macromutex + INDEX_OF(kb, keyboard))
 extern pthread_mutex_t macromutex2[DEV_MAX];
 #define mmutex2(kb) (macromutex2 + INDEX_OF(kb, keyboard))

--- a/src/daemon/device.h
+++ b/src/daemon/device.h
@@ -14,13 +14,15 @@ extern usbdevice keyboard[DEV_MAX];
 #else
 #define IS_CONNECTED(kb) ((kb) && (kb)->handle && (kb)->event)
 #endif
+//#define MUTEX_DBG(str, kb, mutexarray) (ckb_info(str " %s:%d (%s) at ckb%d, TID 0x%lx, MID %p\n", __FILE__, __LINE__, __func__, INDEX_OF(kb, keyboard), pthread_self(), mutexarray + INDEX_OF(kb, keyboard)) & 0)
+#define MUTEX_DBG(a, b, c) 0
 // A mutex used for USB controls. Needs to be locked before reading or writing the device handle or accessing its profile
 extern pthread_mutex_t devmutex[DEV_MAX];
-#define dmutex(kb) (devmutex + INDEX_OF(kb, keyboard))
+#define dmutex(kb) (devmutex + INDEX_OF(kb, keyboard) + MUTEX_DBG("DMUTEX", kb, devmutex))
 // Similar, but for key input. Also needs to be locked before accessing output FIFOs.
 // When adding or removing a device you must lock BOTH mutexes, dmutex first.
 extern pthread_mutex_t inputmutex[DEV_MAX];
-#define imutex(kb) (inputmutex + INDEX_OF(kb, keyboard))
+#define imutex(kb) (inputmutex + INDEX_OF(kb, keyboard) + MUTEX_DBG("IMUTEX", kb, inputmutex))
 
 // Needed to synchronize sending macro-keys to the os and sending color info to the device
 extern pthread_mutex_t macromutex[DEV_MAX];

--- a/src/daemon/device_keyboard.c
+++ b/src/daemon/device_keyboard.c
@@ -21,13 +21,13 @@ int setactive_kb(usbdevice* kb, int active){
     if(NEEDS_FW_UPDATE(kb))
         return 0;
 
-    pthread_mutex_lock(imutex(kb));
+    queued_mutex_lock(imutex(kb));
     kb->active = !!active;
     kb->profile->lastlight.forceupdate = 1;
     // Clear input
     memset(&kb->input.keys, 0, sizeof(kb->input.keys));
     inputupdate(kb);
-    pthread_mutex_unlock(imutex(kb));
+    queued_mutex_unlock(imutex(kb));
 
     uchar msg[3][MSG_SIZE] = {
         { CMD_SET, FIELD_SPECIAL, 0 },                // Disables or enables HW control for top row

--- a/src/daemon/device_mouse.c
+++ b/src/daemon/device_mouse.c
@@ -54,13 +54,13 @@ int setactive_mouse(usbdevice* kb, int active){
     else
         // Restore HW mode
         msg[0][2] = MODE_HARDWARE;
-    pthread_mutex_lock(imutex(kb));
+    queued_mutex_lock(imutex(kb));
     kb->active = !!active;
     kb->profile->lastlight.forceupdate = 1;
     // Clear input
     memset(&kb->input.keys, 0, sizeof(kb->input.keys));
     inputupdate(kb);
-    pthread_mutex_unlock(imutex(kb));
+    queued_mutex_unlock(imutex(kb));
     if(!usbsend(kb, msg[0], 1))
         return -1;
     if(active){

--- a/src/daemon/devnode.c
+++ b/src/daemon/devnode.c
@@ -79,13 +79,13 @@ void check_chmod(const char *pathname, mode_t mode){
 /// Because several independent threads may call updateconnected(), protect that procedure with locking/unlocking of \b devmutex.
 ///
 void _updateconnected(usbdevice* kb){
-    pthread_mutex_lock(devmutex);
+    queued_mutex_lock(devmutex);
     char cpath[strlen(devpath) + 12];
     snprintf(cpath, sizeof(cpath), "%s0/connected", devpath);
     FILE* cfile = fopen(cpath, "w");
     if(!cfile){
         ckb_warn("Unable to update %s: %s\n", cpath, strerror(errno));
-        pthread_mutex_unlock(devmutex);
+        queued_mutex_unlock(devmutex);
         return;
     }
     int written = 0;
@@ -93,12 +93,12 @@ void _updateconnected(usbdevice* kb){
     {
         for(int i = 1; i < DEV_MAX; i++){
             ckb_info("Locking ckb%d\n", i);
-            pthread_mutex_lock(devmutex + i);
+            queued_mutex_lock(devmutex + i);
             if(IS_CONNECTED(keyboard + i)){
                 written = 1;
                 fprintf(cfile, "%s%d %s %s\n", devpath, i, keyboard[i].serial, keyboard[i].name);
             }
-            pthread_mutex_unlock(devmutex + i);
+            queued_mutex_unlock(devmutex + i);
         }
     }
     if(!written)
@@ -108,7 +108,7 @@ void _updateconnected(usbdevice* kb){
     check_chmod(cpath, S_GID_READ);
     check_chown(cpath, 0, gid);
 
-    pthread_mutex_unlock(devmutex);
+    queued_mutex_unlock(devmutex);
 }
 
 void updateconnected(usbdevice* kb){

--- a/src/daemon/devnode.c
+++ b/src/daemon/devnode.c
@@ -78,7 +78,7 @@ void check_chmod(const char *pathname, mode_t mode){
 ///
 /// Because several independent threads may call updateconnected(), protect that procedure with locking/unlocking of \b devmutex.
 ///
-void _updateconnected(){
+void _updateconnected(usbdevice* kb){
     pthread_mutex_lock(devmutex);
     char cpath[strlen(devpath) + 12];
     snprintf(cpath, sizeof(cpath), "%s0/connected", devpath);
@@ -89,10 +89,16 @@ void _updateconnected(){
         return;
     }
     int written = 0;
-    for(int i = 1; i < DEV_MAX; i++){
-        if(IS_CONNECTED(keyboard + i)){
-            written = 1;
-            fprintf(cfile, "%s%d %s %s\n", devpath, i, keyboard[i].serial, keyboard[i].name);
+    if(kb != keyboard)
+    {
+        for(int i = 1; i < DEV_MAX; i++){
+            ckb_info("Locking ckb%d\n", i);
+            pthread_mutex_lock(devmutex + i);
+            if(IS_CONNECTED(keyboard + i)){
+                written = 1;
+                fprintf(cfile, "%s%d %s %s\n", devpath, i, keyboard[i].serial, keyboard[i].name);
+            }
+            pthread_mutex_unlock(devmutex + i);
         }
     }
     if(!written)
@@ -105,9 +111,9 @@ void _updateconnected(){
     pthread_mutex_unlock(devmutex);
 }
 
-void updateconnected(){
+void updateconnected(usbdevice* kb){
     euid_guard_start;
-    _updateconnected();
+    _updateconnected(kb);
     euid_guard_stop;
 }
 
@@ -210,7 +216,7 @@ static int _mkdevpath(usbdevice* kb){
 
     if(kb == keyboard + 0){
         // Root keyboard: write a list of devices
-        _updateconnected();
+        _updateconnected(kb);
         // Write version number
         char vpath[sizeof(path) + 8];
         snprintf(vpath, sizeof(vpath), "%s/version", path);

--- a/src/daemon/devnode.h
+++ b/src/daemon/devnode.h
@@ -18,7 +18,7 @@ extern long gid;
 #define S_CUSTOM_R (S_IRUSR | S_IWUSR | S_IRGRP)
 
 /// Update the list of connected devices.
-void updateconnected();
+void updateconnected(usbdevice* kb);
 
 /// Create a dev path for the keyboard at index. Returns 0 on success.
 int mkdevpath(usbdevice* kb);

--- a/src/daemon/input.c
+++ b/src/daemon/input.c
@@ -99,14 +99,14 @@ static void* play_macro(void* param) {
     pthread_mutex_unlock(mmutex2(kb));       ///< Give all new threads the chance to enter the block.
 
     /// Send events for each keypress in the macro
-    pthread_mutex_lock(mmutex(kb)); ///< Synchonization between macro output and color information
+    queued_mutex_lock(mmutex(kb)); ///< Synchonization between macro output and color information
     for (int a = 0; a < macro->actioncount; a++) {
         macroaction* action = macro->actions + a;
         if (action->rel_x != 0 || action->rel_y != 0)
             os_mousemove(kb, action->rel_x, action->rel_y);
         else {
             os_keypress(kb, action->scan, action->down);
-            pthread_mutex_unlock(mmutex(kb));           ///< use this unlock / relock for enablling the parallel running colorization
+            queued_mutex_unlock(mmutex(kb));           ///< use this unlock / relock for enablling the parallel running colorization
             if (action->delay != UINT_MAX && action->delay) {    ///< local delay set
                 clock_nanosleep(CLOCK_MONOTONIC, 0, &(struct timespec) {.tv_nsec = action->delay * 1000}, NULL);
             } else if (kb->delay != UINT_MAX && kb->delay) {     ///< use default global delay
@@ -118,7 +118,7 @@ static void* play_macro(void* param) {
                     clock_nanosleep(CLOCK_MONOTONIC, 0, &(struct timespec) {.tv_nsec = 30000}, NULL);
                 }
             }
-            pthread_mutex_lock(mmutex(kb));
+            queued_mutex_lock(mmutex(kb));
         }
     }
 
@@ -128,7 +128,7 @@ static void* play_macro(void* param) {
     pthread_cond_broadcast(mvar(kb));   ///< Wake up all waiting threads
     pthread_mutex_unlock(mmutex2(kb));  ///< for the linked list and the mvar
 
-    pthread_mutex_unlock(mmutex(kb));   ///< Sync keyboard input/output and colorization
+    queued_mutex_unlock(mmutex(kb));   ///< Sync keyboard input/output and colorization
     return 0;
 }
 
@@ -326,17 +326,17 @@ void cmd_bind(usbdevice* kb, usbmode* mode, int dummy, int keyindex, const char*
     // Find the key to bind to
     uint tocode = 0;
     if(sscanf(to, "#x%ux", &tocode) != 1 && sscanf(to, "#%u", &tocode) == 1 && tocode < N_KEYS_INPUT){
-        pthread_mutex_lock(imutex(kb));
+        queued_mutex_lock(imutex(kb));
         mode->bind.base[keyindex] = tocode;
-        pthread_mutex_unlock(imutex(kb));
+        queued_mutex_unlock(imutex(kb));
         return;
     }
     // If not numeric, look it up
     for(int i = 0; i < N_KEYS_INPUT; i++){
         if(kb->keymap[i].name && !strcmp(to, kb->keymap[i].name)){
-            pthread_mutex_lock(imutex(kb));
+            queued_mutex_lock(imutex(kb));
             mode->bind.base[keyindex] = kb->keymap[i].scan;
-            pthread_mutex_unlock(imutex(kb));
+            queued_mutex_unlock(imutex(kb));
             return;
         }
     }
@@ -348,9 +348,9 @@ void cmd_unbind(usbdevice* kb, usbmode* mode, int dummy, int keyindex, const cha
 
     if(keyindex >= N_KEYS_INPUT)
         return;
-    pthread_mutex_lock(imutex(kb));
+    queued_mutex_lock(imutex(kb));
     mode->bind.base[keyindex] = KEY_UNBOUND;
-    pthread_mutex_unlock(imutex(kb));
+    queued_mutex_unlock(imutex(kb));
 }
 
 void cmd_rebind(usbdevice* kb, usbmode* mode, int dummy, int keyindex, const char* to){
@@ -359,9 +359,9 @@ void cmd_rebind(usbdevice* kb, usbmode* mode, int dummy, int keyindex, const cha
 
     if(keyindex >= N_KEYS_INPUT)
         return;
-    pthread_mutex_lock(imutex(kb));
+    queued_mutex_lock(imutex(kb));
     mode->bind.base[keyindex] = kb->keymap[keyindex].scan;
-    pthread_mutex_unlock(imutex(kb));
+    queued_mutex_unlock(imutex(kb));
 }
 
 static void _cmd_macro(usbmode* mode, const char* keys, const char* assignment, usbdevice* kb){
@@ -489,7 +489,7 @@ static void _cmd_macro(usbmode* mode, const char* keys, const char* assignment, 
 void cmd_macro(usbdevice* kb, usbmode* mode, const int notifynumber, const char* keys, const char* assignment){
     (void)notifynumber;
 
-    pthread_mutex_lock(imutex(kb));
+    queued_mutex_lock(imutex(kb));
     _cmd_macro(mode, keys, assignment, kb);
-    pthread_mutex_unlock(imutex(kb));
+    queued_mutex_unlock(imutex(kb));
 }

--- a/src/daemon/input.c
+++ b/src/daemon/input.c
@@ -284,6 +284,7 @@ void updateindicators_kb(usbdevice* kb, int force){
     kb->hw_ileds_old = hw_new;
     if(old != new || force){
         DELAY_SHORT(kb);
+        ckb_info("updateind");
         os_sendindicators(kb);
     }
     // Print notifications if desired

--- a/src/daemon/input_linux.c
+++ b/src/daemon/input_linux.c
@@ -208,12 +208,12 @@ void* _ledthread(void* ctx){
                 ileds &= ~which;
         }
         // Update them if needed
-        pthread_mutex_lock(dmutex(kb));
+        queued_mutex_lock(dmutex(kb));
         if(kb->hw_ileds != ileds){
             kb->hw_ileds = ileds;
             kb->vtable->updateindicators(kb, 0);
         }
-        pthread_mutex_unlock(dmutex(kb));
+        queued_mutex_unlock(dmutex(kb));
     }
     return 0;
 }

--- a/src/daemon/input_mac.c
+++ b/src/daemon/input_mac.c
@@ -158,19 +158,19 @@ static void* indicator_update(void* context){
     indicthread_name[3] = INDEX_OF(kb, keyboard) + '0';
     pthread_setname_np(indicthread_name);
 
-    pthread_mutex_lock(dmutex(kb));
+    queued_mutex_lock(dmutex(kb));
     {
-        pthread_mutex_lock(imutex(kb));
+        queued_mutex_lock(imutex(kb));
         IOOptionBits modifiers = kb->modifiers;
         // Allow the thread to be spawned again
         kb->indicthread = 0;
-        pthread_mutex_unlock(imutex(kb));
+        queued_mutex_unlock(imutex(kb));
         // Num lock on, Caps dependent on modifier state
         uchar ileds = 1 | !!(modifiers & NX_ALPHASHIFTMASK) << 1;
         kb->hw_ileds = ileds;
         kb->vtable->updateindicators(kb, 0);
     }
-    pthread_mutex_unlock(dmutex(kb));
+    queued_mutex_unlock(dmutex(kb));
     return 0;
 }
 

--- a/src/daemon/input_mac_legacy.c
+++ b/src/daemon/input_mac_legacy.c
@@ -307,19 +307,19 @@ static void* indicator_update(void* context){
     indicthread_name[3] = INDEX_OF(kb, keyboard) + '0';
     pthread_setname_np(indicthread_name);
 
-    pthread_mutex_lock(dmutex(kb));
+    queued_mutex_lock(dmutex(kb));
     {
-        pthread_mutex_lock(imutex(kb));
+        queued_mutex_lock(imutex(kb));
         IOOptionBits modifiers = kb->modifiers;
         // Allow the thread to be spawned again
         kb->indicthread = 0;
-        pthread_mutex_unlock(imutex(kb));
+        queued_mutex_unlock(imutex(kb));
         // Num lock on, Caps dependent on modifier state
         uchar ileds = 1 | !!(modifiers & NX_ALPHASHIFTMASK) << 1;
         kb->hw_ileds = ileds;
         kb->vtable->updateindicators(kb, 0);
     }
-    pthread_mutex_unlock(dmutex(kb));
+    queued_mutex_unlock(dmutex(kb));
     return 0;
 }
 

--- a/src/daemon/keymap.c
+++ b/src/daemon/keymap.c
@@ -342,7 +342,7 @@ void process_input_urb(void* context, unsigned char* buffer, int urblen, ushort 
         if(retval)
             ckb_fatal("Error unlocking interrupt mutex %i\n", retval);
     } else {
-        pthread_mutex_lock(imutex(kb));
+        queued_mutex_lock(imutex(kb));
         if(IS_LEGACY_DEV(kb)) {
             if(IS_MOUSE_DEV(kb))
                 m95_mouse_translate(kb->input.keys, &kb->input.rel_x, &kb->input.rel_y, urblen, buffer);
@@ -377,7 +377,7 @@ void process_input_urb(void* context, unsigned char* buffer, int urblen, ushort 
         ///
         /// The input data is transformed and copied to the kb structure. Now give it to the OS and unlock the imutex afterwards.
         inputupdate(kb);
-        pthread_mutex_unlock(imutex(kb));
+        queued_mutex_unlock(imutex(kb));
     }
 }
 

--- a/src/daemon/main.c
+++ b/src/daemon/main.c
@@ -31,12 +31,12 @@ static void quit() {
     reset_stop = 1;
     for(int i = 1; i < DEV_MAX; i++){
         // Before closing, set all keyboards back to HID input mode so that the stock driver can still talk to them
-        pthread_mutex_lock(devmutex + i);
+        queued_mutex_lock(devmutex + i);
         if(IS_CONNECTED(keyboard + i)){
             revertusb(keyboard + i);
             closeusb(keyboard + i);
         }
-        pthread_mutex_unlock(devmutex + i);
+        queued_mutex_unlock(devmutex + i);
     }
     ckb_info("Closing root controller\n");
     rmdevpath(keyboard);

--- a/src/daemon/notify.c
+++ b/src/daemon/notify.c
@@ -63,12 +63,12 @@ void nprintind(usbdevice* kb, int nnumber, int led, int on){
 void cmd_notify(usbdevice* kb, usbmode* mode, int nnumber, int keyindex, const char* toggle){
     if(keyindex >= N_KEYS_INPUT)
         return;
-    pthread_mutex_lock(imutex(kb));
+    queued_mutex_lock(imutex(kb));
     if(!strcmp(toggle, "on") || *toggle == 0)
         SET_KEYBIT(mode->notify[nnumber], keyindex);
     else if(!strcmp(toggle, "off"))
         CLEAR_KEYBIT(mode->notify[nnumber], keyindex);
-    pthread_mutex_unlock(imutex(kb));
+    queued_mutex_unlock(imutex(kb));
 }
 
 // Check hardware mode, bail out if it doesn't exist
@@ -217,7 +217,7 @@ static void _cmd_get(usbdevice* kb, usbmode* mode, int nnumber, const char* sett
 void cmd_get(usbdevice* kb, usbmode* mode, int nnumber, int dummy, const char* setting){
     (void)dummy;
 
-    pthread_mutex_lock(imutex(kb));
+    queued_mutex_lock(imutex(kb));
     _cmd_get(kb, mode, nnumber, setting);
-    pthread_mutex_unlock(imutex(kb));
+    queued_mutex_unlock(imutex(kb));
 }

--- a/src/daemon/profile.c
+++ b/src/daemon/profile.c
@@ -220,10 +220,10 @@ void cmd_erase(usbdevice* kb, usbmode* mode, int dummy1, int dummy2, const char*
     (void)dummy2;
     (void)dummy3;
 
-    pthread_mutex_lock(imutex(kb));
+    queued_mutex_lock(imutex(kb));
     freemode(mode);
     initmode(mode, kb);
-    pthread_mutex_unlock(imutex(kb));
+    queued_mutex_unlock(imutex(kb));
 }
 
 static void _freeprofile(usbdevice* kb){
@@ -243,10 +243,10 @@ void cmd_eraseprofile(usbdevice* kb, usbmode* dummy1, int dummy2, int dummy3, co
     (void)dummy3;
     (void)dummy4;
 
-    pthread_mutex_lock(imutex(kb));
+    queued_mutex_lock(imutex(kb));
     _freeprofile(kb);
     allocprofile(kb);
-    pthread_mutex_unlock(imutex(kb));
+    queued_mutex_unlock(imutex(kb));
 }
 
 void freeprofile(usbdevice* kb){

--- a/src/daemon/usb_mac.c
+++ b/src/daemon/usb_mac.c
@@ -335,9 +335,9 @@ CGEventRef mouse_event_modifier_callback(CGEventTapProxy proxy, CGEventType type
                 // Only care about the active keyboard for grabbing the modifier keys.
                 // Once found, can move on.
                 if (!IS_MOUSE_DEV(kb) && kb->active == 1) {
-                    pthread_mutex_lock(imutex(kb));
+                    queued_mutex_lock(imutex(kb));
                     CGEventSetFlags(event, (kCGEventFlagMaskNonCoalesced | kb->modifiers | existingFlags));
-                    pthread_mutex_unlock(imutex(kb));
+                    queued_mutex_unlock(imutex(kb));
                     break;
                 }
             }
@@ -493,12 +493,12 @@ void* os_inputmain(void* context){
     while(1){
         CFRunLoopRun();
         // If we get here, the device should be disconnected
-        pthread_mutex_lock(imutex(kb));
+        queued_mutex_lock(imutex(kb));
         if(!IS_CONNECTED(kb)){
-            pthread_mutex_unlock(imutex(kb));
+            queued_mutex_unlock(imutex(kb));
             break;
         }
-        pthread_mutex_unlock(imutex(kb));
+        queued_mutex_unlock(imutex(kb));
     }
 
     // Clean up
@@ -562,9 +562,9 @@ static void remove_device(void* context, io_service_t device, uint32_t message_t
     usbdevice* kb = context;
     if(kb){
         // If the handle is connected to a device, close it
-        pthread_mutex_lock(dmutex(kb));
+        queued_mutex_lock(dmutex(kb));
         closeusb(kb);
-        pthread_mutex_unlock(dmutex(kb));
+        queued_mutex_unlock(dmutex(kb));
     }
     IOObjectRelease(device);
 }
@@ -574,7 +574,7 @@ static void remove_device(void* context, io_service_t device, uint32_t message_t
 static int find_device(uint16_t idvendor, uint16_t idproduct, uint32_t location, int handle_idx){
     // Look for any partially-set up boards matching this device
     for(int i = 1; i < DEV_MAX; i++){
-        if(pthread_mutex_trylock(devmutex + i))
+        if(queued_mutex_trylock(devmutex + i))
             // If the mutex is locked then the device is obviously set up already, keep going
             continue;
         if(keyboard[i].vendor == idvendor && keyboard[i].product == idproduct){
@@ -587,11 +587,11 @@ static int find_device(uint16_t idvendor, uint16_t idproduct, uint32_t location,
                 }
             }
         }
-        pthread_mutex_unlock(devmutex + i);
+        queued_mutex_unlock(devmutex + i);
     }
     // If none was found, grab the first free device
     for(int i = 1; i < DEV_MAX; i++){
-        if(pthread_mutex_trylock(devmutex + i))
+        if(queued_mutex_trylock(devmutex + i))
             continue;
         if(!keyboard[i].handle){
             // Mark the device as in use and print out a message
@@ -602,7 +602,7 @@ static int find_device(uint16_t idvendor, uint16_t idproduct, uint32_t location,
             // Device mutex remains locked
             return i;
         }
-        pthread_mutex_unlock(devmutex + i);
+        queued_mutex_unlock(devmutex + i);
     }
     return -1;
 }
@@ -747,12 +747,12 @@ release:
     if(HAS_ALL_HANDLES(kb))
         setupusb(kb);
     else
-        pthread_mutex_unlock(devmutex + index);
+        queued_mutex_unlock(devmutex + index);
     *rm_notify = kb->rm_notify;
     return kb;
 
 error:
-    pthread_mutex_unlock(devmutex + index);
+    queued_mutex_unlock(devmutex + index);
     return 0;
 }
 
@@ -900,12 +900,12 @@ static usbdevice* add_hid(hid_dev_t handle, io_object_t** rm_notify){
         setupusb(kb);
     else
         // Otherwise, return and keep going
-        pthread_mutex_unlock(devmutex + index);
+        queued_mutex_unlock(devmutex + index);
     *rm_notify = kb->rm_notify + IFACE_MAX + 1 + handle_idx;
     return kb;
 
 error:
-    pthread_mutex_unlock(devmutex + index);
+    queued_mutex_unlock(devmutex + index);
     return 0;
 }
 


### PR DESCRIPTION
This fixes #391 by ensuring the RGB thread doesn't starve indicator updating by hoarding dmutex all the time.

The queued mutexes ensure FIFO locking order so the thread trying to set the indicator LEDs doesn't starve.