### PR TITLE
add K63 Wireless Keyboard IDs. Part Number: CH-9145030-NA

### DIFF
--- a/src/daemon/usb.c
+++ b/src/daemon/usb.c
@@ -38,6 +38,8 @@ device_desc models[] = {
     { V_CORSAIR, P_K63_NRGB, },
     { V_CORSAIR, P_K63_NRGB_WL, },
     { V_CORSAIR, P_K63_NRGB_WL2, },
+    { V_CORSAIR, P_K63_NRGB_WL3, },
+    { V_CORSAIR, P_K63_NRGB_WL4, },
     { V_CORSAIR, P_K65, },
     { V_CORSAIR, P_K65_LEGACY, },
     { V_CORSAIR, P_K65_LUX, },
@@ -158,7 +160,7 @@ const char* product_str(ushort product){
         return "k65";
     if(product == P_K66)
         return "k66";
-    if(product == P_K63_NRGB || product == P_K63_NRGB_WL || product == P_K63_NRGB_WL2)
+    if(product == P_K63_NRGB || product == P_K63_NRGB_WL || product == P_K63_NRGB_WL2 || product == P_K63_NRGB_WL3 || product == P_K63_NRGB_WL4)
         return "k63";
     if(product == P_K55)
         return "k55";

--- a/src/daemon/usb.h
+++ b/src/daemon/usb.h
@@ -49,7 +49,9 @@
 #define P_K63_NRGB           0x1b40
 #define P_K63_NRGB_WL        0x1b45 /* wireless */
 #define P_K63_NRGB_WL2       0x1b50 /* wireless */
-#define IS_K63_WL(kb)        ((kb)->vendor == V_CORSAIR && ((kb)->product == P_K63_NRGB_WL || (kb)->product == P_K63_NRGB_WL2))
+#define P_K63_NRGB_WL3       0x1b8c /* wireless */
+#define P_K63_NRGB_WL4       0x1b8f /* wireless */
+#define IS_K63_WL(kb)        ((kb)->vendor == V_CORSAIR && ((kb)->product == P_K63_NRGB_WL || (kb)->product == P_K63_NRGB_WL2 || (kb)->product == P_K63_NRGB_WL3 || (kb)->product == P_K63_NRGB_WL4))
 #define IS_K63(kb)           (IS_K63_WL(kb) || ((kb)->vendor == V_CORSAIR && ((kb)->product == P_K63_NRGB)))
 
 #define P_K65                0x1b17
@@ -176,7 +178,7 @@ const char* product_str(ushort product);
 /// The difference between non RGB and monochrome is, that monochrome has lights, but just in one color.
 /// nonRGB has no lights.
 /// Change this if new \b monochrome devices are added
-#define IS_MONOCHROME(vendor, product)  ((vendor) == (V_CORSAIR) && ((product) == (P_K63_NRGB) || (product) == (P_K63_NRGB_WL) || (product) == (P_K63_NRGB_WL2) || (product) == (P_K68_NRGB) || (product) == (P_STRAFE_NRGB) || (product) == (P_STRAFE_NRGB_2)))
+#define IS_MONOCHROME(vendor, product)  ((vendor) == (V_CORSAIR) && ((product) == (P_K63_NRGB) || (product) == (P_K63_NRGB_WL) || (product) == (P_K63_NRGB_WL2) || (product) == (P_K63_NRGB_WL3) || (product) == (P_K63_NRGB_WL4) || (product) == (P_K68_NRGB) || (product) == (P_STRAFE_NRGB) || (product) == (P_STRAFE_NRGB_2)))
 
 /// For calling with a usbdevice*, vendor and product are extracted and IS_LEGACY() is returned.
 #define IS_LEGACY_DEV(kb)               IS_LEGACY((kb)->vendor, (kb)->product)


### PR DESCRIPTION
I have tested the K63 Wireless support on my keyboard. I don't know why by my unit has different ID's than the existing defines:
- on usb cable 0x1b8c
- on usb dongle 0x1b8f
