### PR TITLE
Backend: Select device for mute indicator

### DIFF
--- a/src/gui/kbperf.cpp
+++ b/src/gui/kbperf.cpp
@@ -523,7 +523,7 @@ void KbPerf::applyIndicators(int modeIndex, const bool indicatorState[]){
             lightIndicator("lock", iColor[LOCK][1].rgba());
     }
     if(iEnable[MUTE]){
-        switch(getMuteState()){
+        switch(getMuteState(iMuteDev)){
         case MUTED:
             lightIndicator("mute", iColor[MUTE][0].rgba());
             break;

--- a/src/gui/kbperf.cpp
+++ b/src/gui/kbperf.cpp
@@ -53,6 +53,7 @@ KbPerf::KbPerf(KbMode* parent) :
         // Turn all other indicators on
         iEnable[i] = true;
     }
+    iMuteDev = SINK;
 }
 
 KbPerf::KbPerf(KbMode* parent, const KbPerf& other) :
@@ -65,6 +66,7 @@ KbPerf::KbPerf(KbMode* parent, const KbPerf& other) :
     for(int i = 0; i < DPI_COUNT + 1; i++)
         dpiClr[i] = other.dpiClr[i];
     memcpy(dpiOn, other.dpiOn, sizeof(dpiOn));
+    iMuteDev = other.iMuteDev;
     for(int i = 0; i < I_COUNT; i++){
         iColor[i][0] = other.iColor[i][0];
         iColor[i][1] = other.iColor[i][1];
@@ -85,6 +87,7 @@ const KbPerf& KbPerf::operator= (const KbPerf& other){
     for(int i = 0; i < DPI_COUNT + 1; i++)
         dpiClr[i] = other.dpiClr[i];
     memcpy(dpiOn, other.dpiOn, sizeof(dpiOn));
+    iMuteDev = other.iMuteDev;
     for(int i = 0; i < I_COUNT; i++){
         iColor[i][0] = other.iColor[i][0];
         iColor[i][1] = other.iColor[i][1];
@@ -133,6 +136,10 @@ void KbPerf::load(CkbSettingsBase& settings){
         }
     }
     SGroup group(settings, "Performance");
+
+    QString s_muteDev = settings.value("MuteDevice", "sink").toString();
+    iMuteDev = (s_muteDev == "source") ? SOURCE : SINK;
+
     // Read DPI settings
     {
         SGroup subGroup(settings, "DPI");
@@ -228,6 +235,7 @@ void KbPerf::save(CkbSettingsBase& settings){
     if(typeid(settings) == typeid(CkbSettings))
         _needsSave = false;
     SGroup group(settings, "Performance");
+    settings.setValue("MuteDevice", (iMuteDev == SOURCE) ? "source" : "sink");
     {
         SGroup subGroup(settings, "DPI");
         for(int i = 0; i < DPI_COUNT; i++){
@@ -390,6 +398,15 @@ void KbPerf::setIndicator(indicator index, const QColor& color1, const QColor& c
         hwIType[index] = hardware_enable;
     _needsUpdate = _needsSave = true;
 }
+
+muteDevice KbPerf::getMuteDevice() {
+    return iMuteDev;
+}
+void KbPerf::setMuteDevice(const muteDevice muteDev) {
+    iMuteDev = muteDev;
+    _needsUpdate = _needsSave = true;
+}
+
 
 void KbPerf::liftHeight(height newHeight){
     if(newHeight < LOW || newHeight > HIGH)

--- a/src/gui/kbperf.h
+++ b/src/gui/kbperf.h
@@ -5,6 +5,7 @@
 #include <QPoint>
 #include "ckbsettings.h"
 #include "keymap.h"
+#include "media.h"
 
 class KbMode;
 class KbBind;
@@ -110,6 +111,9 @@ public:
     void getIndicator(indicator index, QColor& color1, QColor& color2, QColor& color3, bool& software_enable, i_hw& hardware_enable);
     void setIndicator(indicator index, const QColor& color1, const QColor& color2, const QColor& color3 = QColor(), bool software_enable = true, i_hw hardware_enable = NORMAL);
 
+    muteDevice getMuteDevice();
+    void setMuteDevice(const muteDevice muteDev);
+
     // Updates settings to the driver. Write "mode %d" first. Disable saveCustomDpi when writing a hardware profile or other permanent storage.
     // By default, nothing will be written unless the settings have changed. Use force = true or call setNeedsUpdate() to override.
     void        update(QFile& cmd, int notifyNumber, bool force, bool saveCustomDpi);
@@ -158,6 +162,7 @@ private:
     QColor iColor[I_COUNT][2];
     QColor light100Color, muteNAColor;
     bool iEnable[I_COUNT];
+    muteDevice iMuteDev;
     i_hw hwIType[HW_I_COUNT];
     bool _dpiIndicator;
 

--- a/src/gui/media.h
+++ b/src/gui/media.h
@@ -15,12 +15,20 @@
 
 #endif
 
+// Mute device selection is supported
+EXTERN_C bool isMuteDeviceSupported();
+// Device class for mute state
+ENUM_C(muteDevice) {
+    SINK,
+    SOURCE
+} ENUM_END_C(muteDevice);
+
 // Gets the default audio device's mute state
 ENUM_C(muteState) {
     UNKNOWN = -1,
     UNMUTED,
     MUTED
 } ENUM_END_C(muteState);
-EXTERN_C muteState getMuteState();
+EXTERN_C muteState getMuteState(const muteDevice muteDev);
 
 #endif

--- a/src/gui/media_mac.m
+++ b/src/gui/media_mac.m
@@ -2,7 +2,11 @@
 #import <Foundation/Foundation.h>
 #include "media.h"
 
-muteState getMuteState(){
+bool isMuteDeviceSupported() {
+    return false;
+}
+
+muteState getMuteState(const muteDevice muteDev){
     // Get the system's default audio device
     AudioObjectPropertyAddress propertyAddress = {
         kAudioHardwarePropertyDefaultOutputDevice,


### PR DESCRIPTION
This is the first half (backend part) for #561, adding the code to store a default mute device in the profile, show the mute state based on this device and mute the correct device when the button is pressed.

I submit this part as a separate PR so that it can be taken into account when making changes (kbperf.cpp seeing those more often).

The UI for selecting the device is an ongoing discussion in #561 