### PR TITLE
Allow for faster repeated macro calls

### DIFF
--- a/src/daemon/command.c
+++ b/src/daemon/command.c
@@ -224,7 +224,12 @@ int readcmd(usbdevice* kb, const char* line){
             continue;
         case SWITCH:
             if(profile->currentmode != mode){
+                queued_mutex_lock(imutex(kb));
+                binding* bind = &profile->currentmode->bind;
+                for (int i = 0; i < bind->macrocount; i++)
+                    bind->macros[i].triggered = 0;
                 profile->currentmode = mode;
+                queued_mutex_unlock(imutex(kb));
                 // Set mode light for non-RGB K95
                 int index = INDEX_OF(mode, profile->mode);
                 vt->setmodeindex(kb, index);

--- a/src/daemon/device.c
+++ b/src/daemon/device.c
@@ -14,7 +14,7 @@ queued_mutex_t macromutex[DEV_MAX] = { [0 ... DEV_MAX-1] = QUEUED_MUTEX_INITIALI
 pthread_mutex_t macromutex2[DEV_MAX] = { [0 ... DEV_MAX-1] = PTHREAD_MUTEX_INITIALIZER };   ///< Protecting the single link list of threads and the macrovar
 pthread_cond_t macrovar[DEV_MAX] = { [0 ... DEV_MAX-1] = PTHREAD_COND_INITIALIZER };        ///< This variable is used to stop and wakeup all macro threads which have to wait.
 pthread_mutex_t interruptmutex[DEV_MAX] = { [0 ... DEV_MAX-1] = PTHREAD_MUTEX_INITIALIZER };///< Used for interrupt transfers
-pthread_cond_t interruptcond[DEV_MAX] = { [0 ... DEV_MAX-1] = PTHREAD_COND_INITIALIZER };   ///< Same as above
+pthread_cond_t interruptcond[DEV_MAX];                                                      ///< Same as above
 
 ///
 /// \brief cond_nanosleep matches semantics of pthread_cond_timedwait, but with a relative wake time
@@ -102,7 +102,8 @@ int init_cond_monotonic(void) {
 
     // pthread_cond_init
     for(int i = 0 ; i < DEV_MAX ; i++) {
-        // add initializers here
+        if(pthread_cond_init(&interruptcond[i], &monotonic_condattr))
+            return 1;
     }
 
     pthread_condattr_destroy(&monotonic_condattr);

--- a/src/daemon/device.c
+++ b/src/daemon/device.c
@@ -13,6 +13,7 @@ queued_mutex_t inputmutex[DEV_MAX] = { [0 ... DEV_MAX-1] = QUEUED_MUTEX_INITIALI
 queued_mutex_t macromutex[DEV_MAX] = { [0 ... DEV_MAX-1] = QUEUED_MUTEX_INITIALIZER };      ///< Protecting macros against lightning: Both use usb_send
 pthread_mutex_t macromutex2[DEV_MAX] = { [0 ... DEV_MAX-1] = PTHREAD_MUTEX_INITIALIZER };   ///< Protecting the single link list of threads and the macrovar
 pthread_cond_t macrovar[DEV_MAX] = { [0 ... DEV_MAX-1] = PTHREAD_COND_INITIALIZER };        ///< This variable is used to stop and wakeup all macro threads which have to wait.
+pthread_cond_t macroint[DEV_MAX];                                                           ///< Should a macro thread's sleep be interrupted, due to repeated key press?
 pthread_mutex_t interruptmutex[DEV_MAX] = { [0 ... DEV_MAX-1] = PTHREAD_MUTEX_INITIALIZER };///< Used for interrupt transfers
 pthread_cond_t interruptcond[DEV_MAX];                                                      ///< Same as above
 
@@ -102,7 +103,8 @@ int init_cond_monotonic(void) {
 
     // pthread_cond_init
     for(int i = 0 ; i < DEV_MAX ; i++) {
-        if(pthread_cond_init(&interruptcond[i], &monotonic_condattr))
+        if(pthread_cond_init(&interruptcond[i], &monotonic_condattr) ||
+           pthread_cond_init(&macroint[i], &monotonic_condattr))
             return 1;
     }
 

--- a/src/daemon/device.c
+++ b/src/daemon/device.c
@@ -16,6 +16,22 @@ pthread_cond_t macrovar[DEV_MAX] = { [0 ... DEV_MAX-1] = PTHREAD_COND_INITIALIZE
 pthread_mutex_t interruptmutex[DEV_MAX] = { [0 ... DEV_MAX-1] = PTHREAD_MUTEX_INITIALIZER };///< Used for interrupt transfers
 pthread_cond_t interruptcond[DEV_MAX] = { [0 ... DEV_MAX-1] = PTHREAD_COND_INITIALIZER };   ///< Same as above
 
+///
+/// \brief cond_nanosleep matches semantics of pthread_cond_timedwait, but with a relative wake time
+/// \param cond     as pthread_cond_timedwait, but must use CLOCK_MONOTONIC
+/// \param mutex    as pthread_cond_timedwait
+/// \param ns       the maximum duration of sleep, in nanoseconds
+/// \return         as pthread_cond_timedwait. returns ENOTSUP if clock_gettime fails
+///
+int cond_nanosleep(pthread_cond_t *restrict cond,
+                   pthread_mutex_t *restrict mutex, uint32_t ns) {
+    struct timespec ts = { 0 };
+    if(clock_gettime(CLOCK_MONOTONIC, &ts))
+        return ENOTSUP;
+    timespec_add(&ts, ns);
+    return pthread_cond_timedwait(cond, mutex, &ts);
+}
+
 void queued_mutex_lock(queued_mutex_t* mutex){
     pthread_mutex_lock(&mutex->mutex);
     unsigned long my_turn = mutex->next_waiting++;
@@ -49,6 +65,50 @@ void queued_mutex_unlock(queued_mutex_t* mutex){
     pthread_cond_broadcast(&mutex->cond);
 }
 
+///
+/// \brief queued_cond_nanosleep matches semantics of cond_nanosleep, but accepts a queued_mutex_t instead of a mutex
+/// \param cond     as cond_nanosleep
+/// \param mutex    as cond_nanosleep, but is a queued_mutex_t
+/// \param ns       as cond_nanosleep
+/// \return         as queued_cond_timedwait
+///
+void queued_cond_nanosleep(pthread_cond_t *restrict cond,
+                           queued_mutex_t *restrict mutex, const uint32_t ns) {
+    pthread_mutex_lock(&mutex->mutex);
+
+    // release mutex
+    mutex->next_in++;
+    pthread_cond_broadcast(&mutex->cond);
+
+    // perform the sleep
+    cond_nanosleep(cond, &mutex->mutex, ns);
+
+    // reacquire mutex
+    unsigned long my_turn = mutex->next_waiting++;
+
+    while(my_turn != mutex->next_in)
+        pthread_cond_wait(&mutex->cond, &mutex->mutex);
+
+    pthread_mutex_unlock(&mutex->mutex);
+}
+
+/// Initialize pthread_cond's with a monotonic clock, if possible
+int init_cond_monotonic(void) {
+    pthread_condattr_t monotonic_condattr;
+
+    if(pthread_condattr_init(&monotonic_condattr) ||
+       pthread_condattr_setclock(&monotonic_condattr, CLOCK_MONOTONIC))
+        return 1;
+
+    // pthread_cond_init
+    for(int i = 0 ; i < DEV_MAX ; i++) {
+        // add initializers here
+    }
+
+    pthread_condattr_destroy(&monotonic_condattr);
+
+    return 0;
+}
 
 /// \brief .
 ///

--- a/src/daemon/device.h
+++ b/src/daemon/device.h
@@ -51,6 +51,8 @@ extern pthread_mutex_t macromutex2[DEV_MAX];
 #define mmutex2(kb) (macromutex2 + INDEX_OF(kb, keyboard))
 extern pthread_cond_t macrovar[DEV_MAX];
 #define mvar(kb) (macrovar + INDEX_OF(kb, keyboard))
+extern pthread_cond_t macroint[DEV_MAX];
+#define mintvar(kb) (macroint + INDEX_OF(kb, keyboard))
 
 // Mutex used for transfering URB Interrupt data between threads
 extern pthread_mutex_t interruptmutex[DEV_MAX];

--- a/src/daemon/device.h
+++ b/src/daemon/device.h
@@ -28,6 +28,8 @@ typedef struct queued_mutex{
 void queued_mutex_lock(queued_mutex_t* mutex);   // Lock a queued_mutex
 int queued_mutex_trylock(queued_mutex_t* mutex); // Try to lock a queued_mutex without blocking; returns 0 on success.
 void queued_mutex_unlock(queued_mutex_t* mutex); // Unlock a queued_mutex
+void queued_cond_nanosleep(pthread_cond_t *restrict cond, queued_mutex_t *restrict mutex, const uint32_t ns);
+int cond_nanosleep(pthread_cond_t *restrict cond, pthread_mutex_t *restrict mutex, uint32_t ns);
 
 #ifdef DEBUG_MUTEX
 #define MUTEX_DBG(str, kb, mutexarray) (ckb_info(str " accessed in %s:%d (%s) at ckb%d, TID 0x%lx, MID %p", __FILE__, __LINE__, __func__, INDEX_OF(kb, keyboard), pthread_self(), mutexarray + INDEX_OF(kb, keyboard)) & 0)
@@ -56,6 +58,8 @@ extern pthread_mutex_t interruptmutex[DEV_MAX];
 // Pthread cond for the above
 extern pthread_cond_t interruptcond[DEV_MAX];
 #define intcond(kb) (interruptcond + INDEX_OF(kb, keyboard))
+
+int init_cond_monotonic(void);
 
 // Sets up device hardware, after software initialization is finished. Also used during resets
 // Should be called only from setupusb/resetusb

--- a/src/daemon/input.c
+++ b/src/daemon/input.c
@@ -409,7 +409,7 @@ void updateindicators_kb(usbdevice* kb, int force){
 /// \brief destroymacro free actions if macro is not currently running
 /// \param macro
 ///
-inline void destroymacro(keymacro* macro) {
+static inline void destroymacro(keymacro* macro) {
     if (macro->running)
         ((parameter_t *)macro->running)->abort = 1;
     else

--- a/src/daemon/input.h
+++ b/src/daemon/input.h
@@ -54,6 +54,9 @@ int os_setupindicators(usbdevice* kb);
 typedef struct parameter {
     usbdevice* kb;
     keymacro* macro;
+    macroaction* actions;
+    int actioncount;
+    char abort;
 } parameter_t;
 
 /// \brief struct ptlist is one element in the single linked list to store  macro_play threads waiting for their execution

--- a/src/daemon/main.c
+++ b/src/daemon/main.c
@@ -290,6 +290,11 @@ int main(int argc, char** argv){
 
     srand(time(NULL));
 
+    if(init_cond_monotonic())  {
+        ckb_fatal("Failed to initialize monotonic clock.");
+        exit(1);
+    }
+
     // Start the USB system
     int result = usbmain();
     quit();

--- a/src/daemon/structures.h
+++ b/src/daemon/structures.h
@@ -52,7 +52,7 @@ typedef struct {
      * thread shuts itself down immediately.
      */
     char triggered;
-    char running;       // is there a thread currently running
+    void* running;      // pointer to the parameter_t of the currently running thread (null if none)
 } keymacro;
 
 // Key bindings for a mode (keyboard + mouse)

--- a/src/daemon/structures.h
+++ b/src/daemon/structures.h
@@ -40,7 +40,19 @@ typedef struct {
     macroaction* actions;
     int actioncount;
     uchar combo[N_KEYBYTES_INPUT];
+
+    /*
+     * The number of times the key has been pressed and released.  It is therefore
+     * even if the key is up, and odd if the key is down.  Whenever the macro execution
+     * completes:
+     *  - The counter is decremented by two, unless it is at 1.
+     *  - If state > 0, the macro is repeated, with a delay if state == 1.
+     *
+     * If the key is released during the delay, the counter is set to 0, and the running
+     * thread shuts itself down immediately.
+     */
     char triggered;
+    char running;       // is there a thread currently running
 } keymacro;
 
 // Key bindings for a mode (keyboard + mouse)

--- a/src/daemon/usb_linux.c
+++ b/src/daemon/usb_linux.c
@@ -169,9 +169,7 @@ int os_usbrecv(usbdevice* kb, uchar* in_msg, const char* file, int line){
     int res;
     if(kb->fwversion >= 0x120 || IS_V2_OVERRIDE(kb)){
         // Wait for 2s
-        struct timespec condwait = {0};
-        condwait.tv_sec = time(NULL) + 2;
-        int condret = pthread_cond_timedwait(intcond(kb), intmutex(kb), &condwait);
+        int condret = cond_nanosleep(intcond(kb), intmutex(kb), 2000000000);
         if(condret != 0){
             if(pthread_mutex_unlock(intmutex(kb)))
                 ckb_fatal("Error unlocking interrupt mutex in os_usbrecv()");

--- a/src/daemon/usb_mac.c
+++ b/src/daemon/usb_mac.c
@@ -189,10 +189,8 @@ int os_usbrecv(usbdevice* kb, uchar* in_msg, const char* file, int line){
 
     // Read the data from the input thread
     if((kb->fwversion >= 0x120 || IS_V2_OVERRIDE(kb))) {
-        struct timespec condwait = {0, 0};
         // Wait for 2s
-        condwait.tv_sec = time(NULL) + 2;
-        int condret = pthread_cond_timedwait(intcond(kb), intmutex(kb), &condwait);
+        int condret = cond_nanosleep(intcond(kb), intmutex(kb), 2000000000);
         if(condret != 0){
             if(pthread_mutex_unlock(intmutex(kb)))
                 ckb_fatal("Error unlocking interrupt mutex in os_usbrecv()");


### PR DESCRIPTION
The current code limits one macro invocation per 500 ms, even if the button the macro is bound to is release and pressed again.  This breaks convention---typically, users expect that releasing and depressing a button will cause the effect to be applied again.  The repeat delay is only expected if the button is held down continuously.

This patch tracks whether the macro trigger is released, and, if so, triggers the macro again, immediately (actually within ~1ms).  During long macro executions, a key release-press cycle can "queue up" up to one immediate additional invocation.

# Testing

I'm currently running this.  I don't use LED animations (I actually use ckb-next to turn them off entirely).