### PR TITLE
Fix slow power off and reboot for strafe keyboard.

### DIFF
--- a/src/daemon/usb.h
+++ b/src/daemon/usb.h
@@ -201,7 +201,7 @@ const char* product_str(ushort product);
 
 /// Some devices cause usbhid to spend a long time initialising it. To work around this, we intentionally uncleanly
 /// deinitialise the device, skipping the usbhid handover.
-#define NEEDS_UNCLEAN_EXIT(kb)          ((kb)->product == P_K65_RFIRE || (kb)->product == P_K70_RFIRE || (kb)->product == P_K70_RFIRE_NRGB || (kb)->product == P_K95)
+#define NEEDS_UNCLEAN_EXIT(kb)          ((kb)->product == P_K65_RFIRE || (kb)->product == P_K70_RFIRE || (kb)->product == P_K70_RFIRE_NRGB || (kb)->product == P_K95 || (kb)->product == P_STRAFE_NRGB)
 
 /// Used for new devices that come with V3 firmware endpoint configuration out of the factory, but have fwversion < 0x300.
 /// Note: only the RGB variant of the K68 needs a v3 override.


### PR DESCRIPTION
I fixed a bug where power off and reboot was slow because the strafe keyboard will hang.