### PR TITLE
Fix issues with suspend wakeup on Linux

### DIFF
--- a/src/daemon/includes.h
+++ b/src/daemon/includes.h
@@ -8,6 +8,7 @@
 #include <fcntl.h>
 #include <iconv.h>
 #include <pthread.h>
+#include <stdbool.h>
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>

--- a/src/daemon/input_linux.c
+++ b/src/daemon/input_linux.c
@@ -1,6 +1,7 @@
 #include "command.h"
 #include "device.h"
 #include "input.h"
+#include "usb.h"
 
 #ifdef OS_LINUX
 
@@ -245,6 +246,7 @@ void* _ledthread(void* ctx){
                 ileds &= ~which;
         }
         // Update them if needed
+        wait_until_suspend_processed();
         queued_mutex_lock(dmutex(kb));
 
         if(kb->hw_ileds != ileds){

--- a/src/daemon/usb.c
+++ b/src/daemon/usb.c
@@ -324,6 +324,7 @@ static void* devmain(usbdevice* kb){
         // Read from FIFO
         const char* line;
         int lines = readlines(kbfifo, linectx, &line);
+        wait_until_suspend_processed();
         queued_mutex_lock(dmutex(kb));
         // End thread when the handle is removed
         if(kb->status == DEV_STATUS_DISCONNECTING || kb->status == DEV_STATUS_DISCONNECTED)

--- a/src/daemon/usb.h
+++ b/src/daemon/usb.h
@@ -411,4 +411,12 @@ extern const dpi_list mouse_dpi_list[];
 
 int os_usb_interrupt_out(usbdevice* kb, unsigned int ep, unsigned int len, uchar* data, const char* file, int line);
 
+///
+/// \brief Wait for devices to be reactivated after suspend.
+///
+/// Should be called before communicating with any device.
+///
+/// \warning dmutex may NOT be held by the calling thread.
+void wait_until_suspend_processed();
+
 #endif  // USB_H

--- a/src/daemon/usb_linux.c
+++ b/src/daemon/usb_linux.c
@@ -171,8 +171,8 @@ void* os_inputmain(void* context){
         /// if the ioctl returns something != 0, let's have a deeper look what happened.
         /// Broken devices or shutting down the entire system leads to closing the device and finishing this thread.
         int res = ioctl(fd, USBDEVFS_REAPURB, &urb);
-        wait_until_suspend_processed();
         if (res) {
+            wait_until_suspend_processed();
             if (errno == ENODEV || errno == ENOENT || errno == ESHUTDOWN)
                 // Stop the thread if the handle closes
                 break;
@@ -198,7 +198,9 @@ void* os_inputmain(void* context){
             process_input_urb(kb, urb->buffer, urb->actual_length, urb->endpoint);
 
             /// Re-submit the URB for the next run.
-            ioctl(fd, USBDEVFS_SUBMITURB, urb);
+            if (ioctl(fd, USBDEVFS_SUBMITURB, urb)) {
+                wait_until_suspend_processed();
+            }
             urb = 0;
         }
     }

--- a/src/daemon/usb_mac.c
+++ b/src/daemon/usb_mac.c
@@ -1079,4 +1079,9 @@ void usbkill(){
     CFRunLoopStop(mainloop);
 }
 
+void wait_until_suspend_processed() {
+    // No-op: currently only used on Linux. If adding something here, make sure
+    // the function is called in appropriate places.
+}
+
 #endif


### PR DESCRIPTION
I have a Scimitar Pro, and have been experiencing issues around waking from suspend, similar to what is reported in e.g. #456, #652. It also occasionally completely locks up the daemon, and the system hangs indefinitely when trying to shut down (only SysRq / hard reboot works).

After a couple days of debugging, I isolated two mostly separate issues.

## Kernel race condition, oops, lockup

Sometimes when waking from suspend, I get this in `dmesg`:

<details>
<summary>dmesg output</summary>

```
[  104.480212] BUG: unable to handle page fault for address: 00000000000028a8
[  104.480231] #PF: supervisor write access in kernel mode
[  104.480239] #PF: error_code(0x0002) - not-present page
[  104.480248] PGD 0 P4D 0 
[  104.480260] Oops: 0002 [#1] PREEMPT SMP NOPTI
[  104.480272] CPU: 0 PID: 414 Comm: suspend Tainted: G           OE     5.15.11-arch2-1 #1 03010ffba27108079ccfa4d61c5b01422e5fb7c7
[  104.480286] Hardware name: LENOVO 20N2CTO1WW/20N2CTO1WW, BIOS N2IET90W (1.68 ) 07/06/2020
[  104.480293] RIP: 0010:_raw_spin_lock_irq+0x1a/0x60
[  104.480314] Code: 00 75 05 31 c0 89 c7 c3 e9 73 63 54 ff 0f 1f 00 0f 1f 44 00 00 fa 66 0f 1f 44 00 00 65 ff 05 5d c1 25 6a 31 c0 ba 01 00 00 00 <f0> 0f b1 17 75 17 31 c0 89 c2 89 c1 89 c6 89 c7 41 89 c0 41 89 c1
[  104.480324] RSP: 0018:ffffad5480e07d08 EFLAGS: 00010046
[  104.480335] RAX: 0000000000000000 RBX: 0000000000000000 RCX: 0000000000000000
[  104.480342] RDX: 0000000000000001 RSI: 0000000000000000 RDI: 00000000000028a8
[  104.480349] RBP: 00000000000028a8 R08: 0000000000000000 R09: 0000000000000000
[  104.480355] R10: 0000000000000000 R11: 0000000000000000 R12: ffffa0eb899db318
[  104.480361] R13: ffffa0eb874b2800 R14: 0000000000000000 R15: ffffa0eb93b4b000
[  104.480367] FS:  00007fa0891ec640(0000) GS:ffffa0f0f1e00000(0000) knlGS:0000000000000000
[  104.480374] CS:  0010 DS: 0000 ES: 0000 CR0: 0000000080050033
[  104.480379] CR2: 00000000000028a8 CR3: 0000000106edc004 CR4: 00000000003706f0
[  104.480386] Call Trace:
[  104.480392]  <TASK>
[  104.480400]  hid_pre_reset+0x24/0x70 [usbhid 90776c292c081bf67094cf06e3f68ea13c994907]
[  104.480424]  usb_reset_device+0xba/0x250
[  104.480439]  usbdev_ioctl+0xac3/0x1370
[  104.480448]  ? destroy_async+0x1c/0xa0
[  104.480460]  ? destroy_async_on_interface+0xe4/0x110
[  104.480467]  ? current_time+0x3c/0x100
[  104.480478]  ? __fget_files+0x9c/0xd0
[  104.480492]  __x64_sys_ioctl+0x8b/0xd0
[  104.480502]  do_syscall_64+0x59/0x90
[  104.480517]  ? __audit_syscall_exit+0x255/0x2c0
[  104.480533]  ? syscall_exit_to_user_mode+0x23/0x50
[  104.480545]  ? do_syscall_64+0x69/0x90
[  104.480554]  ? do_syscall_64+0x69/0x90
[  104.480562]  entry_SYSCALL_64_after_hwframe+0x44/0xae
[  104.480577] RIP: 0033:0x7fa08933a59b
[  104.480587] Code: ff ff ff 85 c0 79 9b 49 c7 c4 ff ff ff ff 5b 5d 4c 89 e0 41 5c c3 66 0f 1f 84 00 00 00 00 00 f3 0f 1e fa b8 10 00 00 00 0f 05 <48> 3d 01 f0 ff ff 73 01 c3 48 8b 0d a5 a8 0c 00 f7 d8 64 89 01 48
[  104.480596] RSP: 002b:00007fa0891ebcf8 EFLAGS: 00000206 ORIG_RAX: 0000000000000010
[  104.480608] RAX: ffffffffffffffda RBX: 0000000000000000 RCX: 00007fa08933a59b
[  104.480616] RDX: 0000000000000000 RSI: 0000000000005514 RDI: 0000000000000006
[  104.480622] RBP: 00007fa0891ebd20 R08: 0000000000000000 R09: 00007fa0891eba00
[  104.480629] R10: 0000000000000000 R11: 0000000000000206 R12: 00007ffdc6c227de
[  104.480636] R13: 00007ffdc6c227df R14: 0000000000000000 R15: 00007fa0891ec640
[  104.480650]  </TASK>
[  104.480655] Modules linked in: ccm rfcomm cmac algif_hash algif_skcipher af_alg snd_usb_audio snd_usbmidi_lib snd_rawmidi snd_seq_device bnep uinput uvcvideo videobuf2_vmalloc btusb btrtl videobuf2_memops btbcm videobuf2_v4l2 btintel videobuf2_common videodev bluetooth mc hid_corsair ecdh_generic snd_sof_pci_intel_cnl snd_sof_intel_hda_common soundwire_intel joydev mousedev soundwire_generic_allocation soundwire_cadence snd_sof_intel_hda snd_sof_pci snd_sof_xtensa_dsp intel_tcc_cooling snd_sof x86_pkg_temp_thermal soundwire_bus snd_hda_codec_hdmi snd_soc_skl intel_powerclamp snd_soc_hdac_hda coretemp snd_hda_ext_core think_lmi iTCO_wdt kvm_intel snd_soc_sst_ipc intel_pmc_bxt ee1004 kvm snd_soc_sst_dsp intel_rapl_msr intel_wmi_thunderbolt wmi_bmof firmware_attributes_class iTCO_vendor_support snd_soc_acpi_intel_match mei_hdcp snd_soc_acpi snd_soc_core irqbypass snd_ctl_led snd_compress crct10dif_pclmul snd_hda_codec_realtek ac97_bus crc32_pclmul snd_hda_codec_generic snd_pcm_dmaengine
[  104.480849]  ghash_clmulni_intel aesni_intel snd_hda_intel crypto_simd snd_intel_dspcfg snd_intel_sdw_acpi cryptd iwlmvm rapl snd_hda_codec intel_cstate vfat intel_uncore mac80211 psmouse snd_hda_core fat snd_hwdep processor_thermal_device_pci_legacy libarc4 processor_thermal_device snd_pcm i2c_i801 processor_thermal_rfim e1000e snd_timer i2c_smbus thunderbolt iwlwifi thinkpad_acpi processor_thermal_mbox ucsi_acpi tpm_crb processor_thermal_rapl typec_ucsi intel_lpss_pci typec mei_me ledtrig_audio intel_rapl_common intel_lpss mei idma64 cfg80211 intel_soc_dts_iosf intel_pch_thermal roles platform_profile tpm_tis rfkill tpm_tis_core snd tpm int3403_thermal soundcore int340x_thermal_zone rng_core wmi int3400_thermal acpi_thermal_rel mac_hid acpi_pad vmw_vmci crypto_user fuse acpi_call(OE) bpf_preload ip_tables x_tables ext4 crc32c_generic crc16 mbcache jbd2 usbhid serio_raw atkbd libps2 sdhci_pci crc32c_intel cqhci sdhci xhci_pci mmc_core xhci_pci_renesas i8042 serio i915 intel_gtt video
[  104.481024]  ttm
[  104.481038] CR2: 00000000000028a8
[  104.481046] ---[ end trace 3eae0852d50f0142 ]---
[  104.481053] RIP: 0010:_raw_spin_lock_irq+0x1a/0x60
[  104.481070] Code: 00 75 05 31 c0 89 c7 c3 e9 73 63 54 ff 0f 1f 00 0f 1f 44 00 00 fa 66 0f 1f 44 00 00 65 ff 05 5d c1 25 6a 31 c0 ba 01 00 00 00 <f0> 0f b1 17 75 17 31 c0 89 c2 89 c1 89 c6 89 c7 41 89 c0 41 89 c1
[  104.481078] RSP: 0018:ffffad5480e07d08 EFLAGS: 00010046
[  104.481087] RAX: 0000000000000000 RBX: 0000000000000000 RCX: 0000000000000000
[  104.481093] RDX: 0000000000000001 RSI: 0000000000000000 RDI: 00000000000028a8
[  104.481099] RBP: 00000000000028a8 R08: 0000000000000000 R09: 0000000000000000
[  104.481105] R10: 0000000000000000 R11: 0000000000000000 R12: ffffa0eb899db318
[  104.481112] R13: ffffa0eb874b2800 R14: 0000000000000000 R15: ffffa0eb93b4b000
[  104.481120] FS:  00007fa0891ec640(0000) GS:ffffa0f0f1e00000(0000) knlGS:0000000000000000
[  104.481130] CS:  0010 DS: 0000 ES: 0000 CR0: 0000000080050033
[  104.481138] CR2: 00000000000028a8 CR3: 0000000106edc004 CR4: 00000000003706f0
[  104.481147] note: suspend[414] exited with preempt_count 1
```

</details>

The crashed task leaves the device's (`struct device`) mutex locked forever, and further ioctls to the device from other threads go into uninterruptible sleep trying to lock it.

How I reproduced this consistently (>50%):

1. Have some of the `usbcore.quirks` flags enabled in command line (`b`, `g`, `n`). I guess the delays make the race condition more likely to occur.
2. Insert the device into a USB hub (in my case, a ThinkPad dock).
3. Suspend. While asleep, unplug and replug the USB hub.
4. Resume, boom.

The root cause here is a race condition on the USB interfaces. The kernel tries to reattach drivers while only locking the USB interface. Meanwhile, `ckb-next-daemon` issues an `USBDEVFS_RESET` ioctl to reset the device, which only locks the device itself (that is, these locks are separate and don't exclude each other).

Some pointers are left null during the driver reattach routine, which causes the "oops".

It is also problematic if the kernel reattaches the `usbhid` driver after we finish `reactivate_devices()`, even if an oops does not occur.

There's actually a very old warning in [the documentation](https://www.kernel.org/doc/html/v4.14/driver-api/usb/usb.html#synchronous-i-o-support) for `USBDEVFS_RESET` alluding to this:

> Warning
>
> Avoid using this call until some usbcore bugs get fixed, since it does not fully synchronize device, interface, and driver (not just usbfs) state.

I'll look into bringing up and fixing this in the kernel, but the issue seems quite broad so there's no obvious small fix.

### Mitigation

This approach seems to avoid the race condition:

Call `USBDEVFS_GETDRIVER`. If it returns the error code `ENODATA`, it means there is no driver currently attached to the interface. As such, we should wait before issuing a `USBDEVFS_RESET`.

Once it returns a driver name successfully, if it isn't `"usbfs"` (us), then we should reclaim the interface.

On a cursory read of the kernel source, it seemed like `USBDEVFS_GETDRIVER` can return e.g. `"usbhid"` while the risk for the race condition still exists. In practice this didn't seem to happen, and I hope trying to disconect the native driver first (before `USBDEVFS_RESET`) synchronizes access to the interface correctly.

## Inconsistent operation after suspend

The remaining issue is that some combination of functionality on the device doesn't work after suspend, though it is connected correctly through the daemon. Sometimes this is all functionality, sometimes only the macro buttons and LEDs on my Scimitar Pro. Even a reset of the device doesn't seem to fix it.

I pinned down the cause of this to the fact that some ioctls are issued to the device from other threads, before the suspend thread has had time to finish `reactivate_devices()`. I don't fully understand the underlying mechanism, but the device somehow gets confused.

### Fix

To fix this, all other threads use the same condition as the suspend thread to check if we have recently woken up. If so, they wait until the suspend thread is done with `reactivate_devices()`.

The suspend thread currently detects a wakeup by monitoring `CLOCK_BOOTTIME` and sleeping for two seconds at a time. If more than four seconds have elapsed, we deduce that a suspend happened (`CLOCK_BOOTTIME` advances during suspend). The other threads can look at the timestamp that the suspend thread last wrote, and use the same logic to detect the wakeup and then wait on a `pthread_cond`.

---

I'm only able to test this on my Scimitar Pro, so testing on other devices will be necessary. The only negative effect I can foresee is if an interface is left without a driver indefinitely after suspend (`USBDEVFS_GETDRIVER` gives `ENODATA`). In this case there is extra delay (set to five seconds) before the normal reset procedures run. I assume this scenario is possible at least with some USB quirks enabled?