### PR TITLE
Fix maybe-uninitialized warning

### DIFF
--- a/src/gui/kb.cpp
+++ b/src/gui/kb.cpp
@@ -739,7 +739,7 @@ void Kb::readNotify(const QString& line){
                 if(dpi.length() != 2)
                     continue;
                 QStringList xy = dpi[1].split(',');
-                int x, y;
+                int x = 0, y = 0;
                 bool off = false;
                 if(xy.length() < 2){
                     // If the right side only has one parameter, set both X and Y


### PR DESCRIPTION
Initialize to zero at declaration to remove warnings:

```
/home/eric/src/ckb-next/src/gui/kb.cpp: In member function ‘void Kb::readNotify(const QString&)’:
/home/eric/src/ckb-next/src/gui/kb.cpp:742:24: warning: ‘y’ may be used uninitialized in this function [-Wmaybe-uninitialized]
  742 |                 int x, y;
      |                        ^
/home/eric/src/ckb-next/src/gui/kb.cpp:742:21: warning: ‘x’ may be used uninitialized in this function [-Wmaybe-uninitialized]
  742 |                 int x, y;
      |                     ^
```