### PR TITLE
Add support for the K70 RGB TKL

### DIFF
--- a/src/daemon/keymap_patch.c
+++ b/src/daemon/keymap_patch.c
@@ -85,6 +85,12 @@ keypatch k100patch[] = {
     {114, "lock", 114, KEY_CORSAIR },
 };
 
+keypatch k70tklpatch[] = {
+    { 1, "logo",    1, KEY_CORSAIR },
+    { 114, "lock",    114, KEY_CORSAIR },
+    { 128, "profswitch",    128, KEY_CORSAIR },
+};
+
 #define ADD_PATCH(vendor, product, patch) \
     { (vendor), (product), (patch), sizeof(patch)/sizeof(*patch) }
 
@@ -105,6 +111,7 @@ static const keypatches mappatches[] = {
     ADD_PATCH(V_CORSAIR, P_DARK_CORE_RGB_PRO_SE,   DCRGBPpatch),
     ADD_PATCH(V_CORSAIR, P_K100_OPTICAL,         k100patch),
     ADD_PATCH(V_CORSAIR, P_K100_MECHANICAL,         k100patch),
+    ADD_PATCH(V_CORSAIR, P_K70_TKL,      k70tklpatch),
 };
 
 #define KEYPATCHES_LEN sizeof(mappatches)/sizeof(*mappatches)

--- a/src/daemon/keymap_patch.c
+++ b/src/daemon/keymap_patch.c
@@ -86,10 +86,10 @@ keypatch k100patch[] = {
 };
 
 keypatch k70tklpatch[] = {
-    { 1, "logo",    1, KEY_CORSAIR },
     { 114, "lock",    114, KEY_CORSAIR },
-    { 128, "profswitch",    128, KEY_CORSAIR },
+    {   1, "logo",      1, KEY_NONE },
 };
+
 
 #define ADD_PATCH(vendor, product, patch) \
     { (vendor), (product), (patch), sizeof(patch)/sizeof(*patch) }

--- a/src/daemon/led_bragi.c
+++ b/src/daemon/led_bragi.c
@@ -44,6 +44,7 @@ static inline size_t bragi_led_count(usbdevice* kb){
     LED_CASE_K(P_K100_OPTICAL, 193);
     LED_CASE_K(P_K100_MECHANICAL, 193);
     LED_CASE_K(P_K65_MINI, 123);
+    LED_CASE_K(P_K70_TKL, 193);
     default:
         ckb_err("Unknown product 0x%hx", kb->product);
         return 0;

--- a/src/daemon/usb.c
+++ b/src/daemon/usb.c
@@ -74,6 +74,7 @@ const device_desc models[] = {
     { V_CORSAIR, P_K70_MK2, },
     { V_CORSAIR, P_K70_MK2SE, },
     { V_CORSAIR, P_K70_MK2LP, },
+    { V_CORSAIR, P_K70_TKL, },
     { V_CORSAIR, P_K90_LEGACY, },
     { V_CORSAIR, P_K95, },
     { V_CORSAIR, P_K95_LEGACY, },
@@ -201,6 +202,8 @@ const char* product_str(ushort product){
         return "k70";
     if(product == P_K70_MK2 || product == P_K70_MK2SE || product == P_K70_MK2LP)
         return "k70mk2";
+    if(product == P_K70_TKL)
+        return "k70tkl";
     if(product == P_K68 || product == P_K68_NRGB)
         return "k68";
     if(product == P_K65 || product == P_K65_LEGACY || product == P_K65_LUX || product == P_K65_RFIRE)

--- a/src/daemon/usb.h
+++ b/src/daemon/usb.h
@@ -89,7 +89,7 @@
 #define P_K70_MK2            0x1b49
 #define P_K70_MK2SE          0x1b6b
 #define P_K70_MK2LP          0x1b55
-#define IS_K70(kb)           ((kb)->vendor == V_CORSAIR && ((kb)->product == P_K70 || (kb)->product == P_K70_LEGACY || (kb)->product == P_K70_RFIRE || (kb)->product == P_K70_RFIRE_NRGB || (kb)->product == P_K70_LUX || (kb)->product == P_K70_LUX_NRGB || (kb)->product == P_K70_MK2 || (kb)->product == P_K70_MK2SE || (kb)->product == P_K70_MK2LP))
+#define P_K70_TKL            0x1b73
 
 // The Legacy K90 behaves like a Legacy K95.
 #define P_K90_LEGACY         0x1b02
@@ -293,10 +293,10 @@ const char* product_str(ushort product);
         clock_nanosleep(CLOCK_MONOTONIC, 0, &(struct timespec) {.tv_nsec = 30000000}, NULL)
 
 // This should be removed in the future when we implement autodetection
-#define USES_BRAGI(vendor, product)                  ((vendor) == (V_CORSAIR) && ((product) == (P_M55_RGB_PRO) || (product) == (P_IRONCLAW_W_U) || (product) == (P_IRONCLAW_W_D) || (product) == (P_K95_PLATINUM_XT) || (product) == (P_DARK_CORE_RGB_PRO_SE) || (product) == (P_DARK_CORE_RGB_PRO_SE_WL) || (product) == P_HARPOON_WL_U || (product) == P_HARPOON_WL_D || (product) == P_K57_U || (product) == P_K57_D || (product) == P_KATAR_PRO_XT || (product) == P_KATAR_PRO || (product) == P_K60_PRO_RGB || (product) == P_K60_PRO_RGB_LP || (product) == P_K60_PRO_RGB_SE || (product) == P_K60_PRO_MONO || (product) == P_K60_PRO_TKL || (product) == P_K55_PRO || (product) == P_K55_PRO_XT || (product) == (P_DARK_CORE_RGB_PRO) || (product) == (P_DARK_CORE_RGB_PRO_WL) || (product) == P_GENERIC_BRAGI_DONGLE || (product) == P_K100_OPTICAL || (product) == P_K100_MECHANICAL || (product) == P_K65_MINI))
+#define USES_BRAGI(vendor, product)                  ((vendor) == (V_CORSAIR) && ((product) == (P_M55_RGB_PRO) || (product) == (P_IRONCLAW_W_U) || (product) == (P_IRONCLAW_W_D) || (product) == (P_K95_PLATINUM_XT) || (product) == (P_DARK_CORE_RGB_PRO_SE) || (product) == (P_DARK_CORE_RGB_PRO_SE_WL) || (product) == P_HARPOON_WL_U || (product) == P_HARPOON_WL_D || (product) == P_K57_U || (product) == P_K57_D || (product) == P_KATAR_PRO_XT || (product) == P_KATAR_PRO || (product) == P_K60_PRO_RGB || (product) == P_K60_PRO_RGB_LP || (product) == P_K60_PRO_RGB_SE || (product) == P_K60_PRO_MONO || (product) == P_K60_PRO_TKL || (product) == P_K55_PRO || (product) == P_K55_PRO_XT || (product) == (P_DARK_CORE_RGB_PRO) || (product) == (P_DARK_CORE_RGB_PRO_WL) || (product) == P_GENERIC_BRAGI_DONGLE || (product) == P_K100_OPTICAL || (product) == P_K100_MECHANICAL || (product) == P_K65_MINI || (product) == P_K70_TKL))
 
 // Devices that use bragi jumbo packets (1024 bytes)
-#define USES_BRAGI_JUMBO(vendor, product)           ((vendor) == (V_CORSAIR) && ((product) == P_K100_OPTICAL || (product) == P_K100_MECHANICAL || (product) == P_K65_MINI))
+#define USES_BRAGI_JUMBO(vendor, product)           ((vendor) == (V_CORSAIR) && ((product) == P_K100_OPTICAL || (product) == P_K100_MECHANICAL || (product) == P_K65_MINI || (product) == P_K70_TKL))
 
 // Used for devices that have the scroll wheel packet in the hardware hid packet only
 #define SW_PKT_HAS_NO_WHEEL(kb)                     ((kb)->vendor == V_CORSAIR && ((kb)->product == P_M55_RGB_PRO || (kb)->product == P_KATAR_PRO_XT || (kb)->product == P_KATAR_PRO))

--- a/src/daemon/usb.h
+++ b/src/daemon/usb.h
@@ -90,6 +90,7 @@
 #define P_K70_MK2SE          0x1b6b
 #define P_K70_MK2LP          0x1b55
 #define P_K70_TKL            0x1b73
+#define IS_K70(kb) ((kb)->vendor == V_CORSAIR && ((kb)->product == P_K70 || (kb)->product == P_K70_LEGACY || (kb)->product == P_K70_RFIRE || (kb)->product == P_K70_RFIRE_NRGB || (kb)->product == P_K70_LUX || (kb)->product == P_K70_LUX_NRGB || (kb)->product == P_K70_MK2 || (kb)->product == P_K70_MK2SE || (kb)->product == P_K70_MK2LP || (kb)->product == P_K70_TKL))
 
 // The Legacy K90 behaves like a Legacy K95.
 #define P_K90_LEGACY         0x1b02

--- a/src/daemon/usb_bragi.c
+++ b/src/daemon/usb_bragi.c
@@ -33,6 +33,7 @@ void bragi_fill_input_eps(usbdevice* kb)
             case P_K100_OPTICAL:
             case P_K100_MECHANICAL:
             case P_K65_MINI:
+            case P_K70_TKL:
                 kb->bragi_out_ep = 0x1;
                 kb->bragi_in_ep = 0x82;
                 break;

--- a/src/gui/kbperf.cpp
+++ b/src/gui/kbperf.cpp
@@ -513,8 +513,7 @@ void KbPerf::applyIndicators(int modeIndex, const bool indicatorState[HW_I_COUNT
     // Disable the M indicators for the K70MK2, the STRAFE_MK2, and the K70_TKL.
     // FIXME: Only enable them for devices that need them instead
     if(iEnable[MODE] && !(this->modeParent()->bind()->map().model() == KeyMap::K70MK2 ||
-                          this->modeParent()->bind()->map().model() == KeyMap::STRAFE_MK2 ||
-                          this->modeParent()->bind()->map().model() == KeyMap::K70_TKL)){
+                          this->modeParent()->bind()->map().model() == KeyMap::STRAFE_MK2)){
         for(uchar i = 0; i < Kb::HWMODE_MAX; i++){
             char name[4];
             snprintf(name, sizeof(name), "m%d", i + 1);

--- a/src/gui/kbperf.cpp
+++ b/src/gui/kbperf.cpp
@@ -510,9 +510,11 @@ void KbPerf::applyIndicators(int modeIndex, const bool indicatorState[HW_I_COUNT
         }
     }
     // KB indicators
-    // Disable the M indicators for the K70MK2 and the STRAFE_MK2.
+    // Disable the M indicators for the K70MK2, the STRAFE_MK2, and the K70_TKL.
     // FIXME: Only enable them for devices that need them instead
-    if(iEnable[MODE] && !(this->modeParent()->bind()->map().model() == KeyMap::K70MK2 || this->modeParent()->bind()->map().model() == KeyMap::STRAFE_MK2)){
+    if(iEnable[MODE] && !(this->modeParent()->bind()->map().model() == KeyMap::K70MK2 ||
+                          this->modeParent()->bind()->map().model() == KeyMap::STRAFE_MK2 ||
+                          this->modeParent()->bind()->map().model() == KeyMap::K70_TKL)){
         for(uchar i = 0; i < Kb::HWMODE_MAX; i++){
             char name[4];
             snprintf(name, sizeof(name), "m%d", i + 1);

--- a/src/gui/keymap.cpp
+++ b/src/gui/keymap.cpp
@@ -876,8 +876,6 @@ static QHash<QString, Key> getMap(KeyMap::Model model, KeyMap::Layout layout){
             map[key->name] = *key;
 
         map.remove("rwin");
-        map.remove("voldn");
-        map.remove("volup");
         map["fn"] = KStrafeKeys[3];
         map["fn"].x -= 12;
         map["light"].x = 190 - K70_X_START;

--- a/src/gui/keymap.cpp
+++ b/src/gui/keymap.cpp
@@ -258,6 +258,17 @@ static inline void patchABNT2(QHash<QString, Key>& map){
 #define K60_TKL_HEIGHT  K60_HEIGHT
 
 
+static const Key K70TklTopRow[] = {
+    {nullptr, "Stop", "stop", K70_X_START - 37, 0, 12, 8, true, true},
+    {nullptr, "Previous", "prev", K70_X_START - 26, 0, 12, 8, true, true},
+    {nullptr, "Play/Pause", "play", K70_X_START - 15, 0, 12, 8, true, true},
+    {nullptr, "Next", "next", K70_X_START - 4, 0, 12, 8, true, true},
+    {nullptr, "Logo", "logo", 140 - K70_X_START, 0, 12, 12, true, false},
+    {nullptr, "Profile Switch", "profswitch", 178 - K70_X_START, 0, 12, 8, true, true},
+    {nullptr, "Mute", "mute", 222 - K70_X_START, 0, 12, 8, true, true},
+};
+#define K70_TKL_TOP_COUNT (sizeof(K70TklTopRow) / sizeof(Key))
+
 static const Key K68TopRow[] = {
     {nullptr,  "Volume Down", "voldn", 285 - K70_X_START, 0, 13, 8, true, true}, {nullptr,  "Volume Up", "volup", 297 - K70_X_START, 0, 13, 8, true, true},
 };
@@ -858,6 +869,29 @@ static QHash<QString, Key> getMap(KeyMap::Model model, KeyMap::Layout layout){
         map["voldn"].x -= 10;
         break;
     }
+    case KeyMap::K70_TKL:{
+        map = getMap(KeyMap::K70, layout);
+        // Very similar to the K63 but with slightly different media button positions
+        QMutableHashIterator<QString, Key> i(map);
+        while(i.hasNext()){
+            i.next();
+            if(i.value().x >= K65_WIDTH)
+                i.remove();
+        }
+        for(const Key* key = K70TklTopRow; key < K70TklTopRow + K70_TKL_TOP_COUNT; key++)
+            map[key->name] = *key;
+
+        map.remove("rwin");
+        map["fn"] = KStrafeKeys[3];
+        map["fn"].x -= 12;
+        map["light"].x = 190 - K70_X_START;
+        map["light"].height = 8;
+        map["lock"].x = 202 - K70_X_START;
+        map["lock"].height = 8;
+
+        // Done!
+        break;
+    }
     case KeyMap::STRAFE_MK2:{
         map = getMap(KeyMap::K70MK2, layout);
         // move everything right to make the space for the left sidelight
@@ -1002,7 +1036,7 @@ static QHash<QString, Key> getMap(KeyMap::Model model, KeyMap::Layout layout){
         map["fn"] = KStrafeKeys[3];
         map["fn"].x = map["rwin"].x;
         map.remove("rwin");
-        
+
         QMutableHashIterator<QString, Key> i(map);
         while(i.hasNext()){
             i.next();
@@ -1592,6 +1626,8 @@ KeyMap::Model KeyMap::getModel(const QString& name){
         return ST100;
     if(lower == "k70mk2")
         return K70MK2;
+    if(lower == "k70tkl")
+        return K70_TKL;
     if(lower == "strafe_mk2")
         return STRAFE_MK2;
     if(lower == "m65e")
@@ -1675,6 +1711,8 @@ QString KeyMap::getModel(KeyMap::Model model){
         return "st100";
     case K70MK2:
         return "k70mk2";
+    case K70_TKL:
+        return "k70tkl";
     case STRAFE_MK2:
         return "strafe_mk2";
     case M65E:
@@ -1717,6 +1755,7 @@ int KeyMap::modelWidth(Model model){
         return K60_TKL_WIDTH;
     case K63:
     case K63_WL:
+    case K70_TKL:
         return K63_WIDTH;
     case K65:
         return K65_WIDTH;
@@ -1780,6 +1819,7 @@ int KeyMap::modelHeight(Model model){
     case K68:
     case K70:
     case K70MK2:
+    case K70_TKL:
     case K95:
     case K95L:
     case STRAFE:

--- a/src/gui/keymap.cpp
+++ b/src/gui/keymap.cpp
@@ -870,26 +870,20 @@ static QHash<QString, Key> getMap(KeyMap::Model model, KeyMap::Layout layout){
         break;
     }
     case KeyMap::K70_TKL:{
-        map = getMap(KeyMap::K70, layout);
-        // Very similar to the K63 but with slightly different media button positions
-        QMutableHashIterator<QString, Key> i(map);
-        while(i.hasNext()){
-            i.next();
-            if(i.value().x >= K65_WIDTH)
-                i.remove();
-        }
+        // Same width as the K63 but with a top row more like the K70
+        map = getMap(KeyMap::K63, layout);
         for(const Key* key = K70TklTopRow; key < K70TklTopRow + K70_TKL_TOP_COUNT; key++)
             map[key->name] = *key;
 
         map.remove("rwin");
+        map.remove("voldn");
+        map.remove("volup");
         map["fn"] = KStrafeKeys[3];
         map["fn"].x -= 12;
         map["light"].x = 190 - K70_X_START;
         map["light"].height = 8;
         map["lock"].x = 202 - K70_X_START;
         map["lock"].height = 8;
-
-        // Done!
         break;
     }
     case KeyMap::STRAFE_MK2:{

--- a/src/gui/keymap.h
+++ b/src/gui/keymap.h
@@ -90,6 +90,7 @@ public:
         BRAGI_DONGLE,
         K100,
         K65_MINI,
+        K70_TKL,
         _MODEL_MAX
     };
     // Key layouts (ordered alphabetically by name)

--- a/src/gui/keywidget.cpp
+++ b/src/gui/keywidget.cpp
@@ -376,7 +376,7 @@ void KeyWidget::paintGL(){
                     painter.setOpacity(0.7);
             }
         }
-        if(((model != KeyMap::STRAFE && model != KeyMap::K95P && model != KeyMap::K100 && model != KeyMap::K70MK2 && model != KeyMap::STRAFE_MK2) && (!strcmp(key.name, "mr") || !strcmp(key.name, "m1") || !strcmp(key.name, "m2") || !strcmp(key.name, "m3")
+        if(((model != KeyMap::STRAFE && model != KeyMap::K95P && model != KeyMap::K100 && model != KeyMap::K70MK2 && model != KeyMap::STRAFE_MK2 && model != KeyMap::K70_TKL) && (!strcmp(key.name, "mr") || !strcmp(key.name, "m1") || !strcmp(key.name, "m2") || !strcmp(key.name, "m3")
                 || !strcmp(key.name, "light") || !strcmp(key.name, "lock") || !strcmp(key.name, "lghtpgm") || (model == KeyMap::K65 && !strcmp(key.name, "mute")))) ||
                 !strcmp(key.name, "ctrlwheelb")){
             // Not all devices have circular buttons
@@ -405,7 +405,7 @@ void KeyWidget::paintGL(){
                 drawTopLeftCorner(&painter, x, y, w, h, drawInfoScale);
             } else
                 painter.drawRect(QRectF(x * drawInfoScale, y * drawInfoScale, w * drawInfoScale, h * drawInfoScale));
-        } else if ((model == KeyMap::K70MK2 || model == KeyMap::STRAFE_MK2) && key.friendlyName().startsWith("Logo")) {
+        } else if ((model == KeyMap::K70MK2 || model == KeyMap::STRAFE_MK2 || model == KeyMap::K70_TKL) && key.friendlyName().startsWith("Logo")) {
             w += 10.f;
             x -= 5.f;
             painter.drawRect(QRectF(x * drawInfoScale, y * drawInfoScale, w * drawInfoScale, h * drawInfoScale));


### PR DESCRIPTION
This adds support for the K70 RGB TKL Champion Series keyboard.  Product page is here: https://www.corsair.com/us/en/Categories/Products/Gaming-Keyboards/RGB-Mechanical-Gaming-Keyboards/K70-RGB-TKL-CHAMPION-SERIES-Mechanical-Gaming-Keyboard/p/CH-9119014-NA

Its interface is fairly similar to the K100, but its key layout is closer to the K63.

I've tested this with my own keyboard, and everything seems fully functional.

Fixes #745 