### PR TITLE
K63 wireless layout should be the same as K65

### DIFF
--- a/src/daemon/usb.c
+++ b/src/daemon/usb.c
@@ -192,8 +192,10 @@ const char* product_str(ushort product){
         return "k65";
     if(product == P_K66)
         return "k66";
-    if(product == P_K63_NRGB || product == P_K63_NRGB_WL || product == P_K63_NRGB_WL2 || product == P_K63_NRGB_WL3 || product == P_K63_NRGB_WL4)
+    if(product == P_K63_NRGB)
         return "k63";
+    if(product == P_K63_NRGB_WL || product == P_K63_NRGB_WL2 || product == P_K63_NRGB_WL3 || product == P_K63_NRGB_WL4)
+        return "k63_wireless";
     if(product == P_K60_PRO_RGB || product == P_K60_PRO_RGB_LP || product == P_K60_PRO_RGB_SE)
         return "k60";
     if(product == P_K57_U || product == P_K57_D)

--- a/src/gui/keymap.cpp
+++ b/src/gui/keymap.cpp
@@ -801,6 +801,12 @@ static QHash<QString, Key> getMap(KeyMap::Model model, KeyMap::Layout layout){
 
         break;
     }
+    case KeyMap::K63_WL:{
+        // Same as K65
+        map = getMap(KeyMap::K65, layout);
+
+        break;
+    }
     case KeyMap::K60:{
         map = getMap(KeyMap::K70, layout);
         map.remove("light");
@@ -1356,6 +1362,8 @@ KeyMap::Model KeyMap::getModel(const QString& name){
         return K60;
     if(lower == "k63")
         return K63;
+    if(lower == "k63_wireless")
+        return K63_WL;
     if(lower == "k65")
         return K65;
     if(lower == "k66")
@@ -1423,6 +1431,8 @@ QString KeyMap::getModel(KeyMap::Model model){
         return "k60";
     case K63:
         return "k63";
+    case K63_WL:
+        return "k63_wireless";
     case K65:
         return "k65";
     case K68:
@@ -1494,6 +1504,7 @@ int KeyMap::modelWidth(Model model){
     case K60:
         return K60_WIDTH;
     case K63:
+    case K63_WL:
         return K63_WIDTH;
     case K65:
         return K65_WIDTH;
@@ -1542,6 +1553,7 @@ int KeyMap::modelHeight(Model model){
     case K55:
     case K57_WL:
     case K63:
+    case K63_WL:
     case K65:
     case K66:
     case K68:

--- a/src/gui/keymap.h
+++ b/src/gui/keymap.h
@@ -83,6 +83,7 @@ public:
         M55,
         K60,
         K57_WL,
+        K63_WL,
         _MODEL_MAX
     };
     // Key layouts (ordered alphabetically by name)


### PR DESCRIPTION
K63 wireless layout should be the same as K65 including the existence of a JP variant.

Discussed in https://github.com/ckb-next/ckb-next/issues/74. Only the wired K63 does not have the FN key.