### PR TITLE
Add GitHub Actions to test building and packaging

### DIFF
--- a/.github/actions/cmake/build/action.yml
+++ b/.github/actions/cmake/build/action.yml
@@ -1,0 +1,27 @@
+---
+runs:
+  using: composite
+  steps:
+    - name: Create `cmake` symbolic link
+      run: |
+        if ! command -v cmake &> /dev/null && command -v cmake3 &> /dev/null; then
+          ln --symbolic cmake3 /usr/bin/cmake
+        fi
+      shell: bash --noprofile --norc -euxo pipefail {0}
+
+    - name: Prepare `build` directory
+      run: |
+        cmake -S . -B build \
+          -LA \
+          -DCMAKE_BUILD_TYPE=${BUILD_TYPE:-Debug} \
+          -DFORCE_INIT_SYSTEM=systemd \
+          -DCMAKE_INSTALL_PREFIX=${INSTALL_PREFIX:-/usr} \
+          -DSAFE_INSTALL=ON \
+          -DSAFE_UNINSTALL=ON
+      shell: bash --noprofile --norc -euxo pipefail {0}
+
+    - name: Build
+      run: |
+        export CMAKE_BUILD_PARALLEL_LEVEL=${BUILD_PARALLEL_LEVEL:-$(nproc)}
+        cmake --build build
+      shell: bash --noprofile --norc -euxo pipefail {0}

--- a/.github/actions/cmake/install/action.yml
+++ b/.github/actions/cmake/install/action.yml
@@ -1,0 +1,7 @@
+---
+runs:
+  using: composite
+  steps:
+    - name: Install
+      run: cmake --build build --target install
+      shell: bash --noprofile --norc -euxo pipefail {0}

--- a/.github/actions/cmake/package/action.yml
+++ b/.github/actions/cmake/package/action.yml
@@ -1,0 +1,31 @@
+---
+runs:
+  using: composite
+  steps:
+    - name: Create `cpack` symbolic link
+      run: |
+        if ! command -v cpack &> /dev/null && command -v cpack3 &> /dev/null; then
+          ln --symbolic cpack3 /usr/bin/cpack
+        fi
+      shell: bash --noprofile --norc -euxo pipefail {0}
+
+    - name: Use `TGZ` generator
+      run: |
+        echo "CPACK_OPTIONS=-G TGZ" >> ${GITHUB_ENV}
+      shell: bash --noprofile --norc -euxo pipefail {0}
+      if: startsWith(matrix.image, 'archlinux:')
+
+    - name: Use `RPM` generator
+      run: |
+        echo "CPACK_OPTIONS=-G RPM" >> ${GITHUB_ENV}
+      shell: bash --noprofile --norc -euxo pipefail {0}
+      if: |
+        startsWith(matrix.image, 'almalinux:') ||
+        startsWith(matrix.image, 'amazonlinux:') ||
+        startsWith(matrix.image, 'fedora:') ||
+        startsWith(matrix.image, 'rockylinux:')
+
+    - name: Package
+      run: cpack --config CPackConfig.cmake ${CPACK_OPTIONS:-}
+      shell: bash --noprofile --norc -euxo pipefail {0}
+      working-directory: build

--- a/.github/actions/dependencies/install/action.yml
+++ b/.github/actions/dependencies/install/action.yml
@@ -1,0 +1,155 @@
+---
+inputs:
+  archlinux-build-dependencies:
+    default: >-
+      cmake
+      git
+      libdbusmenu-qt5
+      libpulse
+      libsystemd
+      libxcb
+      make
+      pkgconf
+      qt5-base
+      qt5-tools
+      qt5-x11extras
+      quazip
+      xcb-util-wm
+      zlib
+
+  debian-build-dependencies:
+    default: >-
+      cmake
+      git
+      libdbusmenu-qt5-dev
+      libpulse-dev
+      libqt5x11extras5-dev
+      libquazip5-dev
+      libudev-dev
+      libxcb-ewmh-dev
+      libxcb-screensaver0-dev
+      libxcb1-dev
+      qtbase5-dev
+      qttools5-dev
+      zlib1g-dev
+
+  debian-package-dependencies:
+    default: >-
+      dpkg-dev
+      file
+
+  fedora-build-dependencies:
+    default: >-
+      cmake
+      dbusmenu-qt5-devel
+      git
+      glibc
+      libxcb-devel
+      make
+      pulseaudio-libs-devel
+      qt5-linguist
+      qt5-qtbase-devel
+      qt5-qtx11extras-devel
+      quazip-qt5-devel
+      systemd-devel
+      xcb-util-devel
+      xcb-util-wm-devel
+      zlib-devel
+
+  fedora-package-dependencies:
+    default: >-
+      rpm-build
+
+  rhel-build-dependencies:
+    default: >-
+      cmake3
+      dbusmenu-qt5-devel
+      git
+      glibc
+      libxcb-devel
+      make
+      pulseaudio-libs-devel
+      qt5-linguist
+      qt5-qtbase-devel
+      qt5-qtx11extras-devel
+      quazip-qt5-devel
+      systemd-devel
+      xcb-util-devel
+      xcb-util-wm-devel
+      zlib-devel
+
+  rhel-package-dependencies:
+    default: >-
+      rpm-build
+
+  ubuntu-build-dependencies:
+    default: >-
+      cmake
+      git
+      libdbusmenu-qt5-dev
+      libpulse-dev
+      libqt5x11extras5-dev
+      libquazip5-dev
+      libudev-dev
+      libxcb-ewmh-dev
+      libxcb-screensaver0-dev
+      libxcb1-dev
+      qtbase5-dev
+      qttools5-dev
+      zlib1g-dev
+
+  ubuntu-package-dependencies:
+    default: >-
+      dpkg-dev
+      file
+
+runs:
+  using: composite
+  steps:
+    - name: Install Dependencies (AlmaLinux/Amazon Linux/Rocky Linux)
+      uses: ./.github/actions/dependencies/install/yum
+      with:
+        dependencies: epel-release
+        packages: >-
+          ${{ inputs.rhel-build-dependencies }}
+          ${{ inputs.rhel-package-dependencies }}
+          ${{ matrix.compiler == 'LLVM' && 'clang' || 'gcc gcc-c++' }}
+      if: |
+        startsWith(matrix.image, 'almalinux:') ||
+        startsWith(matrix.image, 'amazonlinux:') ||
+        startsWith(matrix.image, 'rockylinux:')
+
+    - name: Install Dependencies (Arch Linux)
+      uses: ./.github/actions/dependencies/install/pacman
+      with:
+        packages: >-
+          ${{ inputs.archlinux-build-dependencies }}
+          ${{ matrix.compiler == 'LLVM' && 'clang' || 'gcc' }}
+      if: startsWith(matrix.image, 'archlinux:')
+
+    - name: Install Dependencies (Debian)
+      uses: ./.github/actions/dependencies/install/apt-get
+      with:
+        packages: >-
+          ${{ inputs.debian-build-dependencies }}
+          ${{ inputs.debian-package-dependencies }}
+          ${{ matrix.compiler == 'LLVM' && 'clang' || 'g++ gcc' }}
+      if: startsWith(matrix.image, 'debian:')
+
+    - name: Install Dependencies (Fedora)
+      uses: ./.github/actions/dependencies/install/yum
+      with:
+        packages: >-
+          ${{ inputs.fedora-build-dependencies }}
+          ${{ inputs.fedora-package-dependencies }}
+          ${{ matrix.compiler == 'LLVM' && 'clang' || 'gcc gcc-c++' }}
+      if: startsWith(matrix.image, 'fedora:')
+
+    - name: Install Dependencies (Ubuntu)
+      uses: ./.github/actions/dependencies/install/apt-get
+      with:
+        packages: >-
+          ${{ inputs.ubuntu-build-dependencies }}
+          ${{ inputs.ubuntu-package-dependencies }}
+          ${{ matrix.compiler == 'LLVM' && 'clang' || 'g++ gcc' }}
+      if: startsWith(matrix.image, 'ubuntu:')

--- a/.github/actions/dependencies/install/apt-get/action.yml
+++ b/.github/actions/dependencies/install/apt-get/action.yml
@@ -1,0 +1,18 @@
+---
+inputs:
+  packages:
+    description: List of package(s) to install
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Update package information
+      run: apt-get --yes update
+      shell: bash --noprofile --norc -euxo pipefail {0}
+
+    - name: Install package(s)
+      env:
+        DEBIAN_FRONTEND: noninteractive
+      run: apt-get --yes install ${{ inputs.packages }}
+      shell: bash --noprofile --norc -euxo pipefail {0}

--- a/.github/actions/dependencies/install/pacman/action.yml
+++ b/.github/actions/dependencies/install/pacman/action.yml
@@ -1,0 +1,12 @@
+---
+inputs:
+  packages:
+    description: List of package(s) to install
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Install package(s)
+      run: pacman --sync --refresh --sysupgrade --noconfirm ${{ inputs.packages }}
+      shell: bash --noprofile --norc -euxo pipefail {0}

--- a/.github/actions/dependencies/install/yum/action.yml
+++ b/.github/actions/dependencies/install/yum/action.yml
@@ -1,0 +1,44 @@
+---
+inputs:
+  dependencies:
+    description: List of package(s) to pre-install
+    required: false
+  groups:
+    description: List of group(s) to install
+    required: false
+  packages:
+    description: List of package(s) to install
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Enable PowerTools repository (AlmaLinux 8/Rocky Linux 8)
+      run: |
+        dnf --assumeyes --skip-broken install "dnf-command(config-manager)"
+        dnf config-manager --set-enabled powertools
+      shell: bash --noprofile --norc -euxo pipefail {0}
+      if: matrix.image == 'almalinux:8' || matrix.image == 'rockylinux:8'
+
+    - name: Enable EPEL repository (Amazon Linux 2)
+      run: amazon-linux-extras install epel -y
+      shell: bash --noprofile --norc -euxo pipefail {0}
+      if: matrix.image == 'amazonlinux:2' && contains(inputs.dependencies, 'epel-release')
+
+    - name: Install dependency package(s)
+      run: |
+        if [ -n "${{ inputs.dependencies }}" ]; then
+          yum --assumeyes install ${{ inputs.dependencies }}
+        fi
+      shell: bash --noprofile --norc -euxo pipefail {0}
+
+    - name: Install group(s)
+      run: |
+        if [ -n '${{ inputs.groups }}' ]; then
+          yum --assumeyes groups install ${{ inputs.groups }}
+        fi
+      shell: bash --noprofile --norc -euxo pipefail {0}
+
+    - name: Install package(s)
+      run: yum --assumeyes --skip-broken install ${{ inputs.packages }}
+      shell: bash --noprofile --norc -euxo pipefail {0}

--- a/.github/actions/upload-package/action.yml
+++ b/.github/actions/upload-package/action.yml
@@ -1,0 +1,30 @@
+---
+inputs:
+  new_package_name:
+    default: ckb-next.${{ matrix.image }}.${{ matrix.compiler || 'GNU' }}.${{ matrix.build_type || 'Debug' }}
+    description: Name of package file (without suffix)
+    required: false
+
+  old_package_name:
+    default: ckb-next
+    description: Name of package file (without suffix)
+    required: false
+
+runs:
+  using: composite
+  steps:
+    - name: Rename package
+      run: |
+        mkdir -p /tmp/package
+        for OLD_PACKAGE_FILE in ${{ inputs.old_package_name }}.*; do
+          NEW_PACKAGE_FILE=$(echo ${OLD_PACKAGE_FILE} | sed -e 's/${{ inputs.old_package_name }}/${{ inputs.new_package_name }}/' -e 's/:/-/')
+          mv ${OLD_PACKAGE_FILE} /tmp/package/${NEW_PACKAGE_FILE}
+        done
+      shell: bash --noprofile --norc -euxo pipefail {0}
+      working-directory: build
+
+    - name: Upload package
+      uses: actions/upload-artifact@v3
+      with:
+        name: Packages
+        path: /tmp/package/*

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,68 @@
+---
+name: Build
+
+on:
+  - push
+
+jobs:
+  Linux:
+    name: ${{ matrix.image }} (${{ matrix.compiler }})
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        image:
+          - 'amazonlinux:2'
+          - 'archlinux:latest'
+          - 'almalinux:8'
+          - 'rockylinux:8'
+          - 'debian:10'
+          - 'debian:11'
+          - 'fedora:35'
+          - 'fedora:36'
+          - 'ubuntu:20.04'
+          - 'ubuntu:22.04'
+        build_type:
+          - Release
+        compiler:
+          - GNU
+      fail-fast: false
+    container:
+      env:
+        BUILD_TYPE: ${{ matrix.build_type || 'Debug' }}
+        CC: ${{ matrix.compiler == 'LLVM' && 'clang' || 'gcc' }}
+        CXX: ${{ matrix.compiler == 'LLVM' && 'clang++' || 'g++' }}
+      image: ${{ matrix.image }}
+    steps:
+      - name: Install `git`
+        run: |
+          if command -v apt-get &> /dev/null; then
+            apt-get --quiet --quiet update && apt-get --quiet --quiet install git
+          elif command -v pacman &> /dev/null; then
+            pacman --sync --refresh --sysupgrade --noconfirm git
+          elif command -v yum &> /dev/null; then
+            yum --assumeyes install git
+          fi
+
+      - name: Checkout code
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Install dependencies
+        uses: ./.github/actions/dependencies/install
+
+      - name: Build `ckb-next`
+        uses: ./.github/actions/cmake/build
+
+      - name: Install `ckb-next`
+        uses: ./.github/actions/cmake/install
+
+      - name: Run `ckb-next-daemon --help`
+        run: |
+          ckb-next-daemon --help
+
+      - name: Package `ckb-next`
+        uses: ./.github/actions/cmake/package
+
+      - name: Upload `ckb-next` package to workflow artifacts
+        uses: ./.github/actions/upload-package

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 CMakeLists.txt.user
 bin/
 build/
+!.github/actions/cmake/build
 *.app/
 cmake-build*/
 *.pkg


### PR DESCRIPTION
This adds automated building and packaging of `ckb-next` for the following Linux distibutions using GitHub Actions:
  - `almalinux:8`
  - `amazonlinux:2`
  - `archlinux:latest`
  - `debian:10`
  - `debian:11`
  - `fedora:35`
  - `fedora:36`
  - `rockylinux:8`
  - `ubuntu:20.04`
  - `ubuntu:22.04`

This should help in discovering build errors for those distributions.

I didn't see any unit tests or anything to run, so it runs `ckb-next-daemon --help` as at least very basic test.

Here's an example of what a workflow run looks like:
https://github.com/hummeltech/ckb-next/actions/runs/2543736710