### PR TITLE
disable led on some keys on K57 and K55 PRO XT

### DIFF
--- a/src/gui/keymap.cpp
+++ b/src/gui/keymap.cpp
@@ -855,8 +855,8 @@ static QHash<QString, Key> getMap(KeyMap::Model model, KeyMap::Layout layout){
         map.remove("rwin");
 
         // Replace volume wheel
-        map["voldn"] = {nullptr,  "Volume Down", "voldn", static_cast<short>(map["mute"].x + 12), 0, map["mute"].width, map["mute"].height, true, true};
-        map["volup"] = {nullptr,  "Volume Up", "volup", static_cast<short>(map["mute"].x + 24), 0, map["mute"].width, map["mute"].height, true, true};
+        map["voldn"] = {nullptr,  "Volume Down", "voldn", static_cast<short>(map["mute"].x + 12), 0, map["mute"].width, map["mute"].height, false, true};
+        map["volup"] = {nullptr,  "Volume Up", "volup", static_cast<short>(map["mute"].x + 24), 0, map["mute"].width, map["mute"].height, false, true};
 
         // Fix up the G keys
         map.remove("g7");
@@ -892,6 +892,16 @@ static QHash<QString, Key> getMap(KeyMap::Model model, KeyMap::Layout layout){
         // Move MR to the left of brightness
         map["mr"].x = map["light"].x - 12;
 
+        // No led on these keys
+        map["mr"].hasLed = false;
+        map["light"].hasLed = false;
+        map["lock"].hasLed = false;
+        map["mute"].hasLed = false;
+        map["stop"].hasLed = false;
+        map["prev"].hasLed = false;
+        map["play"].hasLed = false;
+        map["next"].hasLed = false;
+        
         // Shift all keys down (to make room for the lightbar), and to the left
         QMutableHashIterator<QString, Key> i(map);
         while(i.hasNext()){


### PR DESCRIPTION
K55 PRO XT and also K57 do not have LED on the following keys:
mr, light, lock, mute, voldn, volup, stop, prev, play, next

Tested on K55 PRO XT

Result:
![image](https://user-images.githubusercontent.com/11244067/183367987-1a6f3be9-64c9-447e-8274-48081a0ce445.png)

Find it out while trying to find the reason for #868 (not fixed on this PR)