### PR TITLE
Add '_' to the regex for the macro string parser

### DIFF
--- a/src/gui/macrotablemodel.cpp
+++ b/src/gui/macrotablemodel.cpp
@@ -333,7 +333,7 @@ QString MacroTableModel::fromString(const QString& input, const bool stopOnError
     QString str = input.simplified();
     str.replace(QChar(' '), QString(""));
     QVector<MacroLine> newMacroLines;
-    QRegularExpression re("(\\+|-)([a-z0-9]+)(=(\\d+)(_(\\d+))?)?(,|$)");
+    QRegularExpression re("(\\+|-)([a-z0-9_]+)(=(\\d+)(_(\\d+))?)?(,|$)");
     QRegularExpressionMatchIterator i = re.globalMatch(str);
     qint64 prevDelay = MacroLine::MACRO_DELAY_DEFAULT, prevMaxDelay = MacroLine::MACRO_DELAY_DEFAULT;
     int previousEnd = 0;


### PR DESCRIPTION
This fixes a bug in the macro functionality when using a backslash on ISO keyboards. Prior to this the string parser would think keys with an underscore were invalid.

Resolves: #905