### PR TITLE
RGB support for k100 optical variant

### DIFF
--- a/src/daemon/device_bragi.c
+++ b/src/daemon/device_bragi.c
@@ -90,9 +90,9 @@ static int setactive_bragi(usbdevice* kb, int active){
     // Check if the device returned an error
     // Non fatal for now. Should first figure out what the error codes mean.
     // Device returns 0x03 on writes if we haven't opened the handle.
-    if(light == 0x01) {
-        // A K100 has been observed to return 0x01, so it probably means "not supported"
-        // If we get that response, we instead try to open the alt rgb lighting resource
+    if(light == 0x01 || light == 0x06) {
+        // Some K100s have been observed to return either 0x01 or 0x06 which probably means "not supported"
+        // If we get either response, we instead try to open the alt rgb lighting resource
         ckb_warn("ckb%d: Bragi light init returned not supported", ckb_id);
         light = bragi_open_handle(kb, BRAGI_LIGHTING_HANDLE, BRAGI_RES_ALT_LIGHTING);
         if(light < 0)

--- a/src/daemon/keymap_patch.c
+++ b/src/daemon/keymap_patch.c
@@ -111,6 +111,7 @@ static const keypatches mappatches[] = {
     ADD_PATCH(V_CORSAIR, P_DARK_CORE_RGB_PRO_SE,   DCRGBPpatch),
     ADD_PATCH(V_CORSAIR, P_K100_OPTICAL,         k100patch),
     ADD_PATCH(V_CORSAIR, P_K100_MECHANICAL,         k100patch),
+    ADD_PATCH(V_CORSAIR, P_K100_OPTICAL_VARIANT,         k100patch),
     ADD_PATCH(V_CORSAIR, P_K70_TKL,      k70tklpatch),
 };
 

--- a/src/daemon/led_bragi.c
+++ b/src/daemon/led_bragi.c
@@ -43,6 +43,7 @@ static inline size_t bragi_led_count(usbdevice* kb){
     LED_CASE_M(P_DARK_CORE_RGB_PRO_SE, 12);
     LED_CASE_K(P_K100_OPTICAL, 193);
     LED_CASE_K(P_K100_MECHANICAL, 193);
+    LED_CASE_K(P_K100_OPTICAL_VARIANT, 193);
     LED_CASE_K(P_K65_MINI, 123);
     LED_CASE_K(P_K70_TKL, 193);
     default:

--- a/src/daemon/usb.c
+++ b/src/daemon/usb.c
@@ -88,6 +88,7 @@ const device_desc models[] = {
     { V_CORSAIR, P_K57_U, },
     { V_CORSAIR, P_K100_OPTICAL, },
     { V_CORSAIR, P_K100_MECHANICAL, },
+    { V_CORSAIR, P_K100_OPTICAL_VARIANT, },
     { V_CORSAIR, P_K65_MINI, },
     // Mice
     { V_CORSAIR, P_M55_RGB_PRO, },
@@ -190,7 +191,7 @@ const char* vendor_str(ushort vendor){
 /// product_str() needs the \a product \a ID
 ///
 const char* product_str(ushort product){
-    if(product == P_K100_OPTICAL || product == P_K100_MECHANICAL)
+    if(product == P_K100_OPTICAL || product == P_K100_MECHANICAL || product == P_K100_OPTICAL_VARIANT)
         return "k100";
     if(product == P_K95_LEGACY)
         return "k95l";

--- a/src/daemon/usb.h
+++ b/src/daemon/usb.h
@@ -108,6 +108,7 @@
 
 #define P_K100_OPTICAL       0x1b7c
 #define P_K100_MECHANICAL    0x1b7d
+#define P_K100_OPTICAL_VARIANT        0x1bc5
 
 #define P_M55_RGB_PRO        0x1b70
 
@@ -294,10 +295,10 @@ const char* product_str(ushort product);
         clock_nanosleep(CLOCK_MONOTONIC, 0, &(struct timespec) {.tv_nsec = 30000000}, NULL)
 
 // This should be removed in the future when we implement autodetection
-#define USES_BRAGI(vendor, product)                  ((vendor) == (V_CORSAIR) && ((product) == (P_M55_RGB_PRO) || (product) == (P_IRONCLAW_W_U) || (product) == (P_IRONCLAW_W_D) || (product) == (P_K95_PLATINUM_XT) || (product) == (P_DARK_CORE_RGB_PRO_SE) || (product) == (P_DARK_CORE_RGB_PRO_SE_WL) || (product) == P_HARPOON_WL_U || (product) == P_HARPOON_WL_D || (product) == P_K57_U || (product) == P_K57_D || (product) == P_KATAR_PRO_XT || (product) == P_KATAR_PRO || (product) == P_K60_PRO_RGB || (product) == P_K60_PRO_RGB_LP || (product) == P_K60_PRO_RGB_SE || (product) == P_K60_PRO_MONO || (product) == P_K60_PRO_TKL || (product) == P_K55_PRO || (product) == P_K55_PRO_XT || (product) == (P_DARK_CORE_RGB_PRO) || (product) == (P_DARK_CORE_RGB_PRO_WL) || (product) == P_GENERIC_BRAGI_DONGLE || (product) == P_K100_OPTICAL || (product) == P_K100_MECHANICAL || (product) == P_K65_MINI || (product) == P_K70_TKL))
+#define USES_BRAGI(vendor, product)                  ((vendor) == (V_CORSAIR) && ((product) == (P_M55_RGB_PRO) || (product) == (P_IRONCLAW_W_U) || (product) == (P_IRONCLAW_W_D) || (product) == (P_K95_PLATINUM_XT) || (product) == (P_DARK_CORE_RGB_PRO_SE) || (product) == (P_DARK_CORE_RGB_PRO_SE_WL) || (product) == P_HARPOON_WL_U || (product) == P_HARPOON_WL_D || (product) == P_K57_U || (product) == P_K57_D || (product) == P_KATAR_PRO_XT || (product) == P_KATAR_PRO || (product) == P_K60_PRO_RGB || (product) == P_K60_PRO_RGB_LP || (product) == P_K60_PRO_RGB_SE || (product) == P_K60_PRO_MONO || (product) == P_K60_PRO_TKL || (product) == P_K55_PRO || (product) == P_K55_PRO_XT || (product) == (P_DARK_CORE_RGB_PRO) || (product) == (P_DARK_CORE_RGB_PRO_WL) || (product) == P_GENERIC_BRAGI_DONGLE || (product) == P_K100_OPTICAL || (product) == P_K100_MECHANICAL || (product) == P_K100_OPTICAL_VARIANT || (product) == P_K65_MINI || (product) == P_K70_TKL))
 
 // Devices that use bragi jumbo packets (1024 bytes)
-#define USES_BRAGI_JUMBO(vendor, product)           ((vendor) == (V_CORSAIR) && ((product) == P_K100_OPTICAL || (product) == P_K100_MECHANICAL || (product) == P_K65_MINI || (product) == P_K70_TKL))
+#define USES_BRAGI_JUMBO(vendor, product)           ((vendor) == (V_CORSAIR) && ((product) == P_K100_OPTICAL || (product) == P_K100_MECHANICAL || (product) == P_K100_OPTICAL_VARIANT || (product) == P_K65_MINI || (product) == P_K70_TKL))
 
 // Used for devices that have the scroll wheel packet in the hardware hid packet only
 #define SW_PKT_HAS_NO_WHEEL(kb)                     ((kb)->vendor == V_CORSAIR && ((kb)->product == P_M55_RGB_PRO || (kb)->product == P_KATAR_PRO_XT || (kb)->product == P_KATAR_PRO))


### PR DESCRIPTION
Some K100 devices identify on different product IDs. This commit introduces support for a known optical variant.

Key points for this commit are:

- Introduction of a new product ID 0x1bc5 as P_K100_OPTICAL_VARIANT
- This variant uses the more common endpoints 0x4 and 0x84
- This variant returns 0x06 as "not supported" instead of the anticipated 0x01 for switching bragi method.