### PR TITLE
Update CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -159,9 +159,10 @@ option(PREFER_QT6 "Build with Qt 6 if available." OFF)
 set(CMAKE_FIND_PACKAGE_SORT_ORDER NATURAL)
 set(CMAKE_FIND_PACKAGE_SORT_DIRECTION DEC)
 
-set(QT_LIST Qt5)
 if (PREFER_QT6)
-    list(INSERT QT_LIST 0 Qt6)
+    set(QT_LIST Qt6)
+else()
+    set(QT_LIST Qt5)
 endif ()
 
 if (NOT WITH_GUI)


### PR DESCRIPTION
Fixes building with Qt6 while preserving the Qt5 option as default if PREFER_QT6 configuration option is not set.

The previous `CMakeLists.txt` code was always setting `QT_LIST Qt5` and attempting to locate Qt5 libraries even with `PREFER_QT6=ON` set in the cmake configuration options resulting in a broken configuration run for those intending to build using Qt6:

```console
...
-- Found PulseAudio: /usr/lib64/libpulse.so
-- Found ZLIB: /usr/lib64/libz.so (found version "1.3.1")
CMake Error at /lib64/cmake/Qt5/Qt5Config.cmake:28 (find_package):
  Could not find a package configuration file provided by "Qt5X11Extras" with
  any of the following names:

    Qt5X11ExtrasConfig.cmake
    qt5x11extras-config.cmake

  Add the installation prefix of "Qt5X11Extras" to CMAKE_PREFIX_PATH or set
  "Qt5X11Extras_DIR" to a directory containing one of the above files.  If
  "Qt5X11Extras" provides a separate development package or SDK, be sure it
  has been installed.
Call Stack (most recent call first):
  src/gui/CMakeLists.txt:102 (find_package)


-- Configuring incomplete, errors occurred!
```

As you can see from the log above, the result of the previous `CMakeLists.txt` fails to configure on distributions in the process of removing Qt5 as the Qt6 `PREFER_QT6=ON` configuration option is not working as intended due to `QT_LIST Qt5` always being set.

This patch fixes the Qt6 `PREFER_QT6` configuration option while preserving the Qt5 build configuration as the default for those opting to use Qt5 by leaving `PREFER_QT6` unset.

Log output from patched source using `PREFER_QT6=ON` configuration option confirms Qt6 is selected:
```console
...
-- Found PulseAudio: /usr/lib64/libpulse.so
-- Performing Test HAVE_STDATOMIC
-- Performing Test HAVE_STDATOMIC - Success
-- Found WrapAtomic: TRUE
-- Found OpenGL: /usr/lib64/libOpenGL.so
-- Found WrapOpenGL: TRUE
-- Found WrapVulkanHeaders: /usr/include
-- Found ZLIB: /usr/lib64/libz.so (found version "1.3.1")
-- Using Qt6
-- Found PkgConfig: /usr/bin/pkg-config (found version "2.1.1")
-- Checking for module 'xcb'
--   Found xcb, version 1.17.0
...
```
Following these changes `ckb-next` builds successfully using Qt6, the package installs and runs on KDE Plasma `6.3.4` with Qt `6.9.0`.