### PR TITLE
Add support for K100 iWheel rotation events

### DIFF
--- a/src/daemon/keymap.h
+++ b/src/daemon/keymap.h
@@ -45,7 +45,7 @@
 #define MOUSE_BUTTON_FIRST      (N_KEYS_HW + N_KEY_ZONES + N_KEYS_EXTRA + N_GENERIC_ZONES)
 #define MOUSE_EXTRA_FIRST       (MOUSE_BUTTON_FIRST + N_BUTTONS_HW)
 // Number of keys that generate input
-#define N_KEYS_INPUT            (KEY_K100_WHEEL_CCW + 1)
+#define N_KEYS_INPUT            (MOUSE_BUTTON_FIRST + N_BUTTONS_EXTENDED)
 #define N_KEYBYTES_INPUT        ((N_KEYS_INPUT + 7) / 8)
 // Mouse zones
 // LED_MOUSE is an LED index, so technically this is wrong

--- a/src/daemon/keymap.h
+++ b/src/daemon/keymap.h
@@ -52,7 +52,7 @@
 // For example topbar16 with dpi4
 #define LED_MOUSE               N_KEYS_INPUT
 #define N_MOUSE_ZONES           6
-#define N_MOUSE_ZONES_EXTENDED  14
+#define N_MOUSE_ZONES_EXTENDED  16
 // Index of DPI light
 #define LED_DPI                 (LED_MOUSE + 2)
 #define DPI_RGB_START           (LED_MOUSE + 6)

--- a/src/daemon/keymap.h
+++ b/src/daemon/keymap.h
@@ -14,6 +14,10 @@
 #define BTN_WHEELLEFT   0x1f03
 #define BTN_WHEELRIGHT  0x1f04
 
+// Extra input keys for K100 iWheel rotation
+#define KEY_K100_WHEEL_CW     (MOUSE_EXTRA_FIRST + 3)
+#define KEY_K100_WHEEL_CCW    (MOUSE_EXTRA_FIRST + 4)
+
 #ifdef OS_MAC_LEGACY
 // On Linux there's no meaningful distinction between these keys
 // On the OSX legacy build this is used for layout auto-detection (see input_mac_legacy.c)
@@ -41,7 +45,7 @@
 #define MOUSE_BUTTON_FIRST      (N_KEYS_HW + N_KEY_ZONES + N_KEYS_EXTRA + N_GENERIC_ZONES)
 #define MOUSE_EXTRA_FIRST       (MOUSE_BUTTON_FIRST + N_BUTTONS_HW)
 // Number of keys that generate input
-#define N_KEYS_INPUT            (MOUSE_BUTTON_FIRST + N_BUTTONS_EXTENDED)
+#define N_KEYS_INPUT            (KEY_K100_WHEEL_CCW + 1)
 #define N_KEYBYTES_INPUT        ((N_KEYS_INPUT + 7) / 8)
 // Mouse zones
 // LED_MOUSE is an LED index, so technically this is wrong

--- a/src/daemon/keymap.h
+++ b/src/daemon/keymap.h
@@ -14,10 +14,6 @@
 #define BTN_WHEELLEFT   0x1f03
 #define BTN_WHEELRIGHT  0x1f04
 
-// Extra input keys for K100 iWheel rotation
-#define KEY_K100_WHEEL_CW     (MOUSE_EXTRA_FIRST + 3)
-#define KEY_K100_WHEEL_CCW    (MOUSE_EXTRA_FIRST + 4)
-
 #ifdef OS_MAC_LEGACY
 // On Linux there's no meaningful distinction between these keys
 // On the OSX legacy build this is used for layout auto-detection (see input_mac_legacy.c)
@@ -44,8 +40,11 @@
 #define N_BUTTONS_EXTENDED      32
 #define MOUSE_BUTTON_FIRST      (N_KEYS_HW + N_KEY_ZONES + N_KEYS_EXTRA + N_GENERIC_ZONES)
 #define MOUSE_EXTRA_FIRST       (MOUSE_BUTTON_FIRST + N_BUTTONS_HW)
+// Extra input keys for K100 iWheel rotation
+#define KEY_K100_WHEEL_CW     (MOUSE_EXTRA_FIRST + 3)
+#define KEY_K100_WHEEL_CCW    (MOUSE_EXTRA_FIRST + 4)
 // Number of keys that generate input
-#define N_KEYS_INPUT            (MOUSE_BUTTON_FIRST + N_BUTTONS_EXTENDED)
+#define N_KEYS_INPUT            (KEY_K100_WHEEL_CCW + 1)
 #define N_KEYBYTES_INPUT        ((N_KEYS_INPUT + 7) / 8)
 // Mouse zones
 // LED_MOUSE is an LED index, so technically this is wrong
@@ -53,7 +52,7 @@
 // For example topbar16 with dpi4
 #define LED_MOUSE               N_KEYS_INPUT
 #define N_MOUSE_ZONES           6
-#define N_MOUSE_ZONES_EXTENDED  12
+#define N_MOUSE_ZONES_EXTENDED  14
 // Index of DPI light
 #define LED_DPI                 (LED_MOUSE + 2)
 #define DPI_RGB_START           (LED_MOUSE + 6)


### PR DESCRIPTION
This pull request adds support for handling iWheel rotation events on the Corsair K100 RGB Mechanical Gaming Keyboard.

Changes made:
- Introduced two new symbolic key definitions in keymap.h:
  - KEY_K100_WHEEL_CW for clockwise rotation
  - KEY_K100_WHEEL_CCW for counter-clockwise rotation
- In keymap.c, added logic to detect raw input packets with code 0x03 from the K100 and translate:
  - KEY_FASTFORWARD to KEY_K100_WHEEL_CW
  - KEY_REWIND to KEY_K100_WHEEL_CCW
- Clears input state before setting the new wheel input to prevent duplicate or conflicting events

This ensures that iWheel rotation events are treated as distinct and clean inputs, avoiding the spurious key spam previously triggered when the wheel was used.

Tested successfully across a variety of Linux distributions.