### PR TITLE
chore: Improve compilation experience

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -73,6 +73,7 @@ find_package(Sanitizers)
 
 include(CMakeDependentOption)
 
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin" CACHE STRING "Where to put binaries after compilation.")
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib" CACHE STRING "Where to put libraries after compilation.")
 set(UDEV_RULE_DIRECTORY "/lib/udev/rules.d" CACHE STRING "Where to install the udev rule.")

--- a/src/gui/animsettingdialog.cpp
+++ b/src/gui/animsettingdialog.cpp
@@ -22,6 +22,13 @@ AnimSettingDialog::AnimSettingDialog(QWidget* parent, KbAnim* anim) :
     ui(new Ui::AnimSettingDialog), stopCheck(nullptr), kpStopCheck(nullptr),
     _anim(anim), lastDuration(1.0)
 {
+// Re-declare checkStateChanged() signal if Qt Version is below 6.7.0.
+#if QT_VERSION >= QT_VERSION_CHECK(6, 7, 0)
+    void (QCheckBox::*checkStateChanged)(Qt::CheckState) = &QCheckBox::checkStateChanged;
+#else // QT_VERSION < 6.7.0
+    void (QCheckBox::*checkStateChanged)(int) = &QCheckBox::stateChanged;
+#endif
+
     ui->setupUi(this);
     setWindowTitle(anim->scriptName() + tr(" Animation"));
     ui->animName->setText(anim->name());
@@ -58,7 +65,7 @@ AnimSettingDialog::AnimSettingDialog(QWidget* parent, KbAnim* anim) :
             widget = new QCheckBox(param.prefix, this);
             ((QCheckBox*)widget)->setChecked(value.toBool());
             colSpan = 4;
-            connect((QCheckBox*)widget, &QCheckBox::stateChanged, [=] () {
+            connect((QCheckBox*)widget, checkStateChanged, [=] () {
                 emit updateParam(param.name);
             });
             break;
@@ -223,7 +230,7 @@ AnimSettingDialog::AnimSettingDialog(QWidget* parent, KbAnim* anim) :
     check->setChecked(anim->parameter("trigger").toBool());
     ui->settingsGrid->addWidget(check, row, 3, 1, 4);
     settingWidgets["trigger"] = check;
-    connect(check, &QCheckBox::stateChanged, [=] () {
+    connect(check, checkStateChanged, [=] () {
         emit updateParam("trigger");
     });
     row++;
@@ -231,7 +238,7 @@ AnimSettingDialog::AnimSettingDialog(QWidget* parent, KbAnim* anim) :
     check->setChecked(anim->parameter("kptrigger").toBool());
     ui->settingsGrid->addWidget(check, row, 3, 1, 2);
     settingWidgets["kptrigger"] = check;
-    connect(check, &QCheckBox::stateChanged, [=] () {
+    connect(check, checkStateChanged, [=] () {
         emit updateParam("kptrigger");
     });
     // Add an option allowing the user to select keypress mode
@@ -526,6 +533,10 @@ void AnimSettingDialog::on_kpRepeatBox_valueChanged(double arg1){
     updateParam("kprepeat");
 }
 
+#if QT_VERSION >= QT_VERSION_CHECK(6, 7, 0)
+void AnimSettingDialog::on_kpReleaseBox_checkStateChanged(Qt::CheckState arg1){
+#else // QT_VERSION < 6.7.0
 void AnimSettingDialog::on_kpReleaseBox_stateChanged(int arg1){
+#endif
     updateParam("kprelease");
 }

--- a/src/gui/animsettingdialog.h
+++ b/src/gui/animsettingdialog.h
@@ -47,7 +47,11 @@ private slots:
     void on_repeatBox_valueChanged(double arg1);
     void on_kpDelayBox_valueChanged(double arg1);
     void on_kpRepeatBox_valueChanged(double arg1);
+#if QT_VERSION >= QT_VERSION_CHECK(6, 7, 0)
+    void on_kpReleaseBox_checkStateChanged(Qt::CheckState arg1);
+#else // QT_VERSION < 6.7.0
     void on_kpReleaseBox_stateChanged(int arg1);
+#endif
 };
 
 #endif // ANIMSETTINGDIALOG_H

--- a/src/gui/kbfirmware.h
+++ b/src/gui/kbfirmware.h
@@ -41,6 +41,10 @@ private:
         CkbVersionNumber ckbVersion;
         ushort       productID;
         FW();
+
+        // Explicit definition of copy and assignment operators to silence the compilation warnings.
+        FW(const FW& fw) : productID(fw.productID) {};
+        FW& operator=(const FW& other) { return *this; }
     };
     QMap<QString, FW>   fwTable;
     // SHA256 of last downloaded table (redundancy check)

--- a/src/gui/kbwidget.h
+++ b/src/gui/kbwidget.h
@@ -68,7 +68,11 @@ private slots:
     void modeChanged();
     void currentSelectionChanged(const QModelIndex& current, const QModelIndex& previous);
     void on_modesList_customContextMenuRequested(const QPoint &pos);
+#if QT_VERSION >= QT_VERSION_CHECK(6, 7, 0)
+    void batteryTrayBox_checkStateChanged(Qt::CheckState);
+#else // QT_VERSION < 6.7.0
     void batteryTrayBox_stateChanged(int state);
+#endif
 
     void devUpdate();
     void updateBattery(uint battery, BatteryStatus charging);

--- a/src/gui/kperfwidget.cpp
+++ b/src/gui/kperfwidget.cpp
@@ -203,11 +203,10 @@ void KPerfWidget::uiUpdated(int index){
     if(!perf)
         return;
     // Read HW/SW enable state
-    bool software;
-    i_hw hardware;
+    bool software = false;
+    i_hw hardware = KbPerf::NONE;
     if(indicators[index].enable){
         software = indicators[index].enable->isChecked();
-        hardware = KbPerf::NONE;
     } else {
         mode2Raw((HwMode)indicators[index].hwEnable->currentIndex(), software, hardware);
     }

--- a/src/gui/mperfwidget.cpp
+++ b/src/gui/mperfwidget.cpp
@@ -8,6 +8,13 @@ const static QString xyLinkPath = "UI/DPI/UnlinkXY";
 
 MPerfWidget::MPerfWidget(QWidget *parent) :
     QWidget(parent), ui(new Ui::MPerfWidget), perf(nullptr), profile(nullptr), _xyLink(!CkbSettings::get(xyLinkPath).toBool()), colorLink(false), isSetting(false), isDarkCore(false) {
+// Re-declare checkStateChanged() signal if Qt Version is below 6.7.0.
+#if QT_VERSION >= QT_VERSION_CHECK(6, 7, 0)
+    void (QCheckBox::*checkStateChanged)(Qt::CheckState) = &QCheckBox::checkStateChanged;
+#else // QT_VERSION < 6.7.0
+    void (QCheckBox::*checkStateChanged)(int) = &QCheckBox::stateChanged;
+#endif
+
     ui->setupUi(this);
     ui->xyBox->setChecked(!_xyLink);
     // Set up DPI stages
@@ -64,7 +71,7 @@ MPerfWidget::MPerfWidget(QWidget *parent) :
         });
         if(stages[i].enableCheck)
             // Sniper has no enable
-            connect(stages[i].enableCheck, &QCheckBox::stateChanged, [=] () {
+            connect(stages[i].enableCheck, checkStateChanged, [=] () {
                 emit enableChanged(i);
             });
         // Hide indicator arrows

--- a/src/gui/rebindwidget.cpp
+++ b/src/gui/rebindwidget.cpp
@@ -377,7 +377,15 @@ void RebindWidget::setSelection(const QStringList& newSelection, bool applyPrevi
                     // If the daemon macro string contains even a single delay, then the we set the
                     // delay to "as typed" instead of "default"
                     QRegularExpression re("=\\d+");
-                    if(re.match(macroData[0]).hasMatch())
+// Use different match function depending on Qt version, 6.5.0 deprecates
+// QRegularExpression::match() in favor of QRegularExpression::matchView() when
+// using a QStringView parameter.
+#if QT_VERSION >= QT_VERSION_CHECK(6, 5, 0)
+                    bool has_match = re.matchView(macroData[0]).hasMatch();
+#else // QT_VERSION < 6.5.0
+                    bool has_match = re.match(macroData[0]).hasMatch();
+#endif
+                    if(has_match)
                         ui->rb_delay_asTyped->setChecked(true);
                     else
                         ui->rb_delay_default->setChecked(true);


### PR DESCRIPTION
- Resolve QT deprecation warnings, both are guarded by `QT_VERSION >= QT_VERSION_CHECK()`:
  - Qt 6.5 deprecates `QRegularExpression::match()` in favor of `QRegularExpression::matchView()`, and
  - Qt 6.7 deprecates `QCheckBox::stateChanged()` in favor of `QCheckBox::checkStateChanged()`,
- enable compile_commands.json by default.