### PR TITLE
CKB-355: Sort device tabs

### DIFF
--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -239,19 +239,24 @@ void MainWindow::toggleTrayIcon(bool visible){
 }
 
 void MainWindow::addDevice(Kb* device){
-    // Connected already?
+    int kbIndex = 0;
     for(const KbWidget* w : kbWidgets){
+        // Connected already?
         if(w->device == device)
             return;
+
+        // Determine position of new device based on the serial number of the
+        // device.
+        if (w->device->usbSerial < device->usbSerial)
+            kbIndex += 1;
     }
     // Add the keyboard
     KbWidget* widget = new KbWidget(this, device, windowDetector);
-    kbWidgets.append(widget);
+    kbWidgets.insert(kbIndex, widget);
     // Add to tabber; switch to this device if the user is on the settings screen
-    int count = ui->tabWidget->count();
-    ui->tabWidget->insertTab(count - 1, widget, widget->name());
-    if(ui->tabWidget->currentIndex() == count)
-        ui->tabWidget->setCurrentIndex(count - 1);
+    ui->tabWidget->insertTab(kbIndex, widget, widget->name());
+    if(ui->tabWidget->currentIndex() == ui->tabWidget->count() - 1)
+        ui->tabWidget->setCurrentIndex(kbIndex);
     // Update connected device count
     updateVersion();
 }

--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -240,7 +240,7 @@ void MainWindow::toggleTrayIcon(bool visible){
 
 void MainWindow::addDevice(Kb* device){
     // Connected already?
-    foreach(KbWidget* w, kbWidgets){
+    for(const KbWidget* w : kbWidgets){
         if(w->device == device)
             return;
     }
@@ -257,7 +257,7 @@ void MainWindow::addDevice(Kb* device){
 }
 
 void MainWindow::removeDevice(Kb* device){
-    foreach(KbWidget* w, kbWidgets){
+    for(KbWidget* w : kbWidgets){
         // Remove this device from the UI
         if(w->device == device){
             int i = kbWidgets.indexOf(w);
@@ -317,7 +317,7 @@ void MainWindow::updateVersion(){
 void MainWindow::checkFwUpdates(){
     if(!mainWindow->isVisible())
         return;
-    foreach(KbWidget* w, kbWidgets){
+    for(KbWidget* w : kbWidgets){
         // Display firmware upgrade notification if a new version is available
         CkbVersionNumber version = kbfw->versionForBoard(w->device->productID);
         if(version > w->device->firmware.app){
@@ -374,7 +374,7 @@ void MainWindow::timerTick(){
         snprintf((char*)appShare.data(), appShare.size(), "PID %ld", (long)getpid());
         appShare.unlock();
         // Parse commands
-        foreach(const QString& line, commands){
+        for(const QString& line : commands){
             // Old ckb option line - bring application to foreground
             if(line == "Open")
                 showWindow();
@@ -475,7 +475,7 @@ void MainWindow::setTabsEnabled(bool e){
 }
 
 MainWindow::~MainWindow(){
-    foreach(KbWidget* w, kbWidgets)
+    for(KbWidget* w : kbWidgets)
         delete w;
     kbWidgets.clear();
     KbManager::stop();

--- a/src/gui/mainwindow.h
+++ b/src/gui/mainwindow.h
@@ -40,6 +40,9 @@ public:
 private:
     SettingsWidget* settingsWidget;
     QList<KbWidget*> kbWidgets;
+    // List of device names in order they were added. This is used to re-create
+    // the tab list.
+    QList<QString> kbWidgetNames;
     QAction* restoreAction;
     QAction* closeAction;
     QMenu*              trayIconMenu;
@@ -85,6 +88,8 @@ private slots:
     void appleRequestHidTimer();
 #endif
     void iconClicked(QSystemTrayIcon::ActivationReason reason);
+    // Recreate the device tab order and maintain the active tab if possible.
+    void reorderTabs();
 private:
     Ui::MainWindow *ui;
     QSocketNotifier* sigNotifier;


### PR DESCRIPTION
Should solve #355 

Store list of device names in main window, on device addition/removal recreate the tab order based on the stored device name.

I experimented with using the `QTabWidget::insertTab()` signal and also making the `MainWindow::reorderTabs()` function a slot to be called, but I was unfortunately skill issued. :grimacing: 