### PR TITLE
Fix wayland interface detection

### DIFF
--- a/src/gui/wayland/waylandidletimer.cpp
+++ b/src/gui/wayland/waylandidletimer.cpp
@@ -52,7 +52,7 @@ public:
 };
 
 WaylandIdleTimer::WaylandIdleTimer()
-    : m_supported{WaylandUtils::hasInterface("ext_idle_notifier_v1", 1)}
+    : m_supported{WaylandUtils::hasInterface("ext_idle_notifier_v1")}
 {
     if (m_supported) {
         auto seat = WaylandUtils::seat();

--- a/src/gui/wayland/waylandutils.cpp
+++ b/src/gui/wayland/waylandutils.cpp
@@ -113,7 +113,11 @@ Q_GLOBAL_STATIC(WaylandUtilsHelper, g_helper)
 bool hasInterface(const QString &name, quint32 version)
 {
     auto it = std::find_if(g_helper->m_registerData.constBegin(), g_helper->m_registerData.constEnd(), [&name, &version](const RegistryData& data){
-        return data.interfaceName == name && data.version == version;
+        const bool matched = data.interfaceName == name;
+        if (version == 0) {
+            return matched;
+        }
+        return matched && data.version == version;
     });
     return it != g_helper->m_registerData.constEnd();
 }

--- a/src/gui/wayland/waylandutils.h
+++ b/src/gui/wayland/waylandutils.h
@@ -14,7 +14,7 @@ namespace WaylandUtils
 bool isWayland();
 
 #ifdef USE_WAYLAND
-bool hasInterface(const QString &name, quint32 version);
+bool hasInterface(const QString &name, quint32 version = 0);
 
 wl_display *display();
 wl_seat *seat();


### PR DESCRIPTION
In PR #1142, I made a mistake in understanding how Wayland protocols' version numbers are reported. An issue occurred when Plasma 6.4 was released and [ext_idle_notifier_v1](https://wayland.app/protocols/ext-idle-notify-v1) version 2 support was added (stupid naming scheme 😠). `WaylandUtils::hasInterface` only returned true if the version is exactly match.

This commit now allows checking Wayland interface existence without requiring a version number by specifying `version = 0` in `WaylandUtils::hasInterface`. Ideally, we should also have functions to check version ranges of interfaces, but I don't think that is currently necessary with how little `ckb-next` is using Wayland's specific functions.