### PR TITLE
Update 99-ckb-next-daemon.rules

### DIFF
--- a/linux/udev/99-ckb-next-daemon.rules
+++ b/linux/udev/99-ckb-next-daemon.rules
@@ -1,2 +1,2 @@
 # Mark ckb devices as not a joystick and create symlinks to the virtual input devices
-ACTION=="add|change", SUBSYSTEM=="input", ATTRS{name}=="ckb[0-9]: [A-Za-z0-9]*", ENV{ID_INPUT_JOYSTICK}="", PROGRAM="/usr/bin/env sed 's/[0-9]: /-/' /sys/class/input/%k/device/name", ENV{.INPUT_NAME}="%c, "SYMLINK+="input/by-id/%E{.INPUT_NAME}-event"
+ACTION=="add|change", SUBSYSTEM=="input", ATTRS{name}=="ckb[0-9]: [A-Za-z0-9]*", ENV{ID_INPUT_JOYSTICK}="", PROGRAM="/usr/bin/env sed 's/[0-9]: /-/' /sys/class/input/%k/device/name", ENV{.INPUT_NAME}="%c, ", SYMLINK+="input/by-id/%E{.INPUT_NAME}-event"


### PR DESCRIPTION
udev errors due to missing comma and whitespace between tokens