### PR TITLE
Fix key mapping for plus and equal keys when using all keyboards

### DIFF
--- a/src/gui/macroreader.cpp
+++ b/src/gui/macroreader.cpp
@@ -136,8 +136,8 @@ static inline const char* translateQtKeyCode(int keycode, Qt::KeyboardModifiers 
     SKN(Qt::Key_9, "9", Qt::KeypadModifier, "num9");
     SKN(Qt::Key_0, "0", Qt::KeypadModifier, "num0");
     SKN(Qt::Key_Minus, "minus", Qt::KeypadModifier, "numminus");
-    SKN(Qt::Key_Plus, "equals", Qt::KeypadModifier, "numplus");
-    SK(Qt::Key_Equal, "equals");
+    SKN(Qt::Key_Plus, "equal", Qt::KeypadModifier, "numplus");
+    SK(Qt::Key_Equal, "equal");
     SK(Qt::Key_Backspace, "bspace");
 
     // Shift second row


### PR DESCRIPTION
When creating a macro using "All keyboards" as input rather than ckb-next devices, the macro generated for equals key is incorrectly including "equals" as the string vs "equal" when using ckb-next supported devices which results in an invalid macro.

See #1235 