### PR TITLE
Implement a configurable Macro Repetition Delay

### DIFF
--- a/src/daemon/input.c
+++ b/src/daemon/input.c
@@ -87,10 +87,6 @@ static pthread_t macro_pt_first() {
 // Default macro keystroke delay
 #define NANOSECONDS_PER_MILLISECONDS 1000000
 const struct timespec macrodelay = { .tv_nsec = 1 * NANOSECONDS_PER_MILLISECONDS };
-// Initial repeat delay
-#define DELAY_REPEAT_INITIAL 500 * NANOSECONDS_PER_MILLISECONDS
-// Delay for every subsequent repeat
-#define DELAY_REPEAT_CATCHUP 500 * NANOSECONDS_PER_MILLISECONDS
 
 static inline void clock_microsleep(uint32_t s) {
     const struct timespec ts = {
@@ -177,7 +173,9 @@ static void* play_macro(void* param) {
 
         queued_mutex_unlock(mmutex(kb));
 
-        int delay_ns = first_keydownloop ? DELAY_REPEAT_INITIAL : DELAY_REPEAT_CATCHUP;
+        int delay_ns = first_keydownloop
+            ? macro->repetition_debounce_ms * NANOSECONDS_PER_MILLISECONDS
+            : macro->repetition_delay_ms * NANOSECONDS_PER_MILLISECONDS;
 
         queued_mutex_lock(imutex(kb));
         // detect if the macro playback has been aborted
@@ -209,7 +207,7 @@ static void* play_macro(void* param) {
             break;
         }
 
-        // if the key released and pressed during the sleep, reset to use DELAY_REPEAT_INITIAL
+        // if the key released and pressed during the sleep, reset to use the default repetition value
         if (macro->triggered == 1)
             first_keydownloop = 0;
 

--- a/src/daemon/input.c
+++ b/src/daemon/input.c
@@ -176,7 +176,7 @@ static void* play_macro(void* param) {
 
         queued_mutex_unlock(mmutex(kb));
 
-        int delay_ns = first_keydownloop
+        uint32_t delay_ns = first_keydownloop
             ? macro->repetition_debounce_ms * NANOSECONDS_PER_MILLISECONDS
             : macro->repetition_delay_ms * NANOSECONDS_PER_MILLISECONDS;
 
@@ -682,10 +682,11 @@ static void _cmd_macro(usbmode* mode, const char* keys, const char* assignment, 
     macro.repetition_delay_ms = REPETITION_DEFAULT_VALUE;
     macro.repetition_debounce_ms = REPETITION_DEFAULT_VALUE;
     if (delay_tok != NULL) {
-        unsigned long debounce_ms = 0;
-        unsigned long delay_ms = 0;
+        static_assert(REPETITION_MAX_VALUE <= UINT32_MAX, "Repetition max value larger than what uint32_t can hold");
+        uint32_t debounce_ms = 0;
+        uint32_t delay_ms = 0;
 
-        if (sscanf(delay_tok, ":%lu;%lu", &debounce_ms, &delay_ms) == 2) {
+        if (sscanf(delay_tok, ":%"SCNu32";%"SCNu32, &debounce_ms, &delay_ms) == 2) {
             if (debounce_ms > 0 && debounce_ms <= REPETITION_MAX_VALUE)
                 macro.repetition_debounce_ms = (uint32_t) debounce_ms;
             if (delay_ms > 0 && delay_ms <= REPETITION_MAX_VALUE)

--- a/src/daemon/input.c
+++ b/src/daemon/input.c
@@ -84,11 +84,12 @@ static pthread_t macro_pt_first() {
 }
 
 // Default macro keystroke delay
-const struct timespec macrodelay = { .tv_nsec = 1000000 };
+#define NANOSECONDS_PER_MILLISECONDS 1000000
+const struct timespec macrodelay = { .tv_nsec = 1 * NANOSECONDS_PER_MILLISECONDS };
 // Initial repeat delay
-#define DELAY_REPEAT_INITIAL 500000000
+#define DELAY_REPEAT_INITIAL 500 * NANOSECONDS_PER_MILLISECONDS
 // Delay for every subsequent repeat
-#define DELAY_REPEAT_CATCHUP 500000000
+#define DELAY_REPEAT_CATCHUP 500 * NANOSECONDS_PER_MILLISECONDS
 
 static inline void clock_microsleep(uint32_t s) {
     const struct timespec ts = {

--- a/src/daemon/input.c
+++ b/src/daemon/input.c
@@ -5,6 +5,7 @@
 #include "input.h"
 #include "notify.h"
 #include <assert.h>
+#include <string.h>
 
 #define IS_SCROLLWHEEL_V(scan)  ((scan) == BTN_WHEELUP   || (scan) == BTN_WHEELDOWN)
 #define IS_SCROLLWHEEL_H(scan)  ((scan) == BTN_WHEELLEFT || (scan) == BTN_WHEELRIGHT)
@@ -673,8 +674,26 @@ static void _cmd_macro(usbmode* mode, const char* keys, const char* assignment, 
     // Scan the actions
     position = 0;
     field = 0;
+
+    // Check if repetition debounce and delay tokens are attached to the assignment.
+    // Validate value to be between 0 and 2000 inclusive. Default to 500ms.
+    const char *delay_tok = strchr(assignment, ':');
+    macro.repetition_debounce_ms = 500;
+    macro.repetition_delay_ms = 500;
+    if (delay_tok != NULL) {
+        unsigned long debounce_ms = 0;
+        unsigned long delay_ms = 0;
+
+        if (sscanf(delay_tok, ":%lu;%lu", &debounce_ms, &delay_ms) == 2) {
+            if (debounce_ms > 0 && debounce_ms <= 2000)
+                macro.repetition_debounce_ms = (uint32_t) debounce_ms;
+            if (delay_ms > 0 && delay_ms <= 2000)
+                macro.repetition_delay_ms = (uint32_t) delay_ms;
+        }
+    }
+
     // max action = old 11 chars plus 12 chars which is the max 32-bit unsigned int 4294967295 size * 2 + 1 for range underscore
-    while(position < right && sscanf(assignment + position, "%"N_SCANF_KEYNAME"[^,]%n", keyname, &field) == 1){
+    while(position < right && sscanf(assignment + position, "%"N_SCANF_KEYNAME"[^,:]%n", keyname, &field) == 1){
         if(!strcmp(keyname, "clear"))
             break;
 

--- a/src/daemon/input.c
+++ b/src/daemon/input.c
@@ -87,6 +87,9 @@ static pthread_t macro_pt_first() {
 // Default macro keystroke delay
 #define NANOSECONDS_PER_MILLISECONDS 1000000
 const struct timespec macrodelay = { .tv_nsec = 1 * NANOSECONDS_PER_MILLISECONDS };
+// Default and max values for macro repetition delays/debounces
+#define REPETITION_DEFAULT_VALUE 500
+#define REPETITION_MAX_VALUE 2000
 
 static inline void clock_microsleep(uint32_t s) {
     const struct timespec ts = {
@@ -676,16 +679,16 @@ static void _cmd_macro(usbmode* mode, const char* keys, const char* assignment, 
     // Check if repetition debounce and delay tokens are attached to the assignment.
     // Validate value to be between 0 and 2000 inclusive. Default to 500ms.
     const char *delay_tok = strchr(assignment, ':');
-    macro.repetition_debounce_ms = 500;
-    macro.repetition_delay_ms = 500;
+    macro.repetition_delay_ms = REPETITION_DEFAULT_VALUE;
+    macro.repetition_debounce_ms = REPETITION_DEFAULT_VALUE;
     if (delay_tok != NULL) {
         unsigned long debounce_ms = 0;
         unsigned long delay_ms = 0;
 
         if (sscanf(delay_tok, ":%lu;%lu", &debounce_ms, &delay_ms) == 2) {
-            if (debounce_ms > 0 && debounce_ms <= 2000)
+            if (debounce_ms > 0 && debounce_ms <= REPETITION_MAX_VALUE)
                 macro.repetition_debounce_ms = (uint32_t) debounce_ms;
-            if (delay_ms > 0 && delay_ms <= 2000)
+            if (delay_ms > 0 && delay_ms <= REPETITION_MAX_VALUE)
                 macro.repetition_delay_ms = (uint32_t) delay_ms;
         }
     }

--- a/src/daemon/structures.h
+++ b/src/daemon/structures.h
@@ -57,6 +57,9 @@ typedef struct {
      */
     char triggered;
     struct _macro_param* param;
+
+    uint32_t repetition_debounce_ms;
+    uint32_t repetition_delay_ms;
 } keymacro;
 
 // Key bindings for a mode (keyboard + mouse)

--- a/src/gui/kbbind.cpp
+++ b/src/gui/kbbind.cpp
@@ -239,8 +239,14 @@ void KbBind::update(QFile& cmd, int notify, bool force){
             cmd.write(keyLatin1);
             // if a macro definiton for the key is given,
             // add the converted string to key-buffer "macro"
-            if (act->isMacro() && act->macroContent().length() > 0) {
-                macros.append("macro " + keyLatin1 + ":" + act->macroContent().toLatin1() + "\n");
+            if (act->isMacro()) {
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+                QList<QStringView> macroContent = QStringView(act->value()).split(':');
+#else // QT_VERSION < 6.0.0
+                QVector<QStringRef> macroContent = act->value().splitRef(':');
+#endif
+                if (macroContent[1].length() > 0)
+                    macros.append("macro " + keyLatin1 + ":" + macroContent[1].toLatin1() + "\n");
             }
         } else {
             // Otherwise, write the binding

--- a/src/gui/kbbind.cpp
+++ b/src/gui/kbbind.cpp
@@ -246,7 +246,10 @@ void KbBind::update(QFile& cmd, int notify, bool force){
                 QVector<QStringRef> macroContent = act->value().splitRef(':');
 #endif
                 if (macroContent[1].length() > 0)
-                    macros.append("macro " + keyLatin1 + ":" + macroContent[1].toLatin1() + "\n");
+                    // Fields used: 1 - daemon string, 5 - repetition delay
+                    macros.append("macro " + keyLatin1
+                            + ":" + macroContent[1].toLatin1()
+                            + ":" + macroContent[5].toLatin1());
             }
         } else {
             // Otherwise, write the binding

--- a/src/gui/keyaction.h
+++ b/src/gui/keyaction.h
@@ -31,11 +31,6 @@ public:
     // Name to send to driver (empty string for unbind)
     QString driverName() const;
 
-    // Returns the string that's passed to the daemon
-    inline QString macroContent() const {
-        return _value.split(":")[1];
-    }
-
     // Mode-switch action.
     // 0 for first mode, 1 for second, etc. Constants below for movement options
     const static int MODE_PREV = -2, MODE_NEXT = -1;

--- a/src/gui/rebindwidget.cpp
+++ b/src/gui/rebindwidget.cpp
@@ -11,6 +11,8 @@
 static const int DPI_OFFSET = -KeyAction::DPI_CYCLE_UP + 1;
 static const int DPI_CUST_IDX = KeyAction::DPI_CUSTOM + DPI_OFFSET;
 
+static const int MACRO_DEFAULT_REPETITION_DEBOUNCE = 500;
+static const int MACRO_DEFAULT_REPETITION_DELAY = 500;
 static const QString MACRO_MAGIC_COLON_REPLACEMENT = QStringLiteral("&das_IST_31N_col0n;");
 
 static inline void setLocalUiElementsEnabled(Ui::RebindWidget* const ui, const bool e){
@@ -360,10 +362,15 @@ void RebindWidget::setSelection(const QStringList& newSelection, bool applyPrevi
                 QStringView valueView(value);
                 QList<QStringView> macroData = valueView.sliced(7).split(QChar(':'));
 #endif
+
                 const int dataCount = macroData.count();
-                // Old format doesn't have the last field, which is the raw macro data
-                // It might not exist at all (count == 3) or it might be set to "x"
-                if(dataCount == 3 || dataCount == 4){
+                // Macro strings have had different number of field depending on
+                // their version:
+                // - Initial version: 3 fields,
+                // - next iteration: 4 fields, appended the raw macro data,
+                //                   which might be "x" in certain situations,
+                // - current iteration: 5 fields, appended repetition debounce & delay.
+                if (3 <= dataCount && dataCount <= 5) {
                     // Colons in the name field are escaped
                     QString macroName = macroData[2].toString();
                     macroName.replace(MACRO_MAGIC_COLON_REPLACEMENT, ":");
@@ -393,6 +400,20 @@ void RebindWidget::setSelection(const QStringList& newSelection, bool applyPrevi
                         ui->rb_delay_asTyped->setChecked(true);
                     else
                         ui->rb_delay_default->setChecked(true);
+
+                    // Set the repetition delay value if it's supplied.
+                    if (dataCount == 5) {
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+                        QVector<QStringRef> repetitionData = macroData[4].split(QChar(';'));
+#else // QT_VERSION >= 6.0.0
+                        QList<QStringView> repetitionData = macroData[4].split(QChar(';'));
+#endif
+                        ui->rep_debounce_input->setValue(repetitionData[0].toInt());
+                        ui->rep_delay_input->setValue(repetitionData[1].toInt());
+                    } else {
+                        ui->rep_debounce_input->setValue(MACRO_DEFAULT_REPETITION_DEBOUNCE);
+                        ui->rep_delay_input->setValue(MACRO_DEFAULT_REPETITION_DELAY);
+                    }
                 }
             }
         } else
@@ -487,7 +508,7 @@ void RebindWidget::applyChanges(const QStringList& keys, bool doUnbind){
             }
         }
         // Generate macro format string
-        // Format is $macro:daemon_string:preview_string:user_specified_macro_name:original_recorded_macro_string
+        // Format is $macro:daemon_string:preview_string:user_specified_macro_name:original_recorded_macro_string:repetition_debounce;repetition_delay
         // $macro: is added by KeyAction::macroAction()
         // daemon_string is the one sent to the daemon, and original_recorded_macro_string is the raw user data
         // preview_string is now unused as it can be generated from the remaining data
@@ -495,7 +516,9 @@ void RebindWidget::applyChanges(const QStringList& keys, bool doUnbind){
         QString escapedMacroName = ui->macroName->text().replace(":", MACRO_MAGIC_COLON_REPLACEMENT);
         QString finalDaemonString = macroLines.toString(false);
         QString originalString = macroLines.toString(true);
-        QString macro = QString("%1::%2:%3").arg(finalDaemonString, escapedMacroName, originalString);
+        QString repDebounceString = ui->rep_debounce_input->cleanText();
+        QString repDelayString = ui->rep_delay_input->cleanText();
+        QString macro = QString("%1::%2:%3:%4;%5").arg(finalDaemonString, escapedMacroName, originalString, repDebounceString, repDelayString);
         bind->setAction(keys, KeyAction::macroAction(macro));
     } else if(doUnbind)
         bind->noAction(keys);
@@ -880,8 +903,8 @@ void RebindWidget::on_btnClearMacro_clicked() {
     macroLines.clear();
     ui->macroName->clear();
     ui->macroPreview->clear();
-    ui->rep_debounce_input->setValue(500);
-    ui->rep_delay_input->setValue(500);
+    ui->rep_debounce_input->setValue(MACRO_DEFAULT_REPETITION_DEBOUNCE);
+    ui->rep_delay_input->setValue(MACRO_DEFAULT_REPETITION_DELAY);
 }
 
 void RebindWidget::on_rb_delay_default_toggled(bool checked){

--- a/src/gui/rebindwidget.cpp
+++ b/src/gui/rebindwidget.cpp
@@ -11,6 +11,8 @@
 static const int DPI_OFFSET = -KeyAction::DPI_CYCLE_UP + 1;
 static const int DPI_CUST_IDX = KeyAction::DPI_CUSTOM + DPI_OFFSET;
 
+static const QString MACRO_MAGIC_COLON_REPLACEMENT = QStringLiteral("&das_IST_31N_col0n;");
+
 static inline void setLocalUiElementsEnabled(Ui::RebindWidget* const ui, const bool e){
     ui->editAsStringBtn->setEnabled(e);
     ui->btnAddEvent->setEnabled(e);
@@ -364,7 +366,7 @@ void RebindWidget::setSelection(const QStringList& newSelection, bool applyPrevi
                 if(dataCount == 3 || dataCount == 4){
                     // Colons in the name field are escaped
                     QString macroName = macroData[2].toString();
-                    macroName.replace("&das_IST_31N_col0n;", ":");
+                    macroName.replace(MACRO_MAGIC_COLON_REPLACEMENT, ":");
                     ui->macroName->setText(macroName);
 
                     // Pick the appropriate string to parse due to legacy formats
@@ -490,7 +492,7 @@ void RebindWidget::applyChanges(const QStringList& keys, bool doUnbind){
         // daemon_string is the one sent to the daemon, and original_recorded_macro_string is the raw user data
         // preview_string is now unused as it can be generated from the remaining data
         // Any colons in user_specified_macro_name are escaped
-        QString escapedMacroName = ui->macroName->text().replace(":", "&das_IST_31N_col0n;");
+        QString escapedMacroName = ui->macroName->text().replace(":", MACRO_MAGIC_COLON_REPLACEMENT);
         QString finalDaemonString = macroLines.toString(false);
         QString originalString = macroLines.toString(true);
         QString macro = QString("%1::%2:%3").arg(finalDaemonString, escapedMacroName, originalString);

--- a/src/gui/rebindwidget.cpp
+++ b/src/gui/rebindwidget.cpp
@@ -24,6 +24,8 @@ static inline void setUiElementsEnabled(Ui::RebindWidget* const ui, const bool e
     ui->unbindButton->setEnabled(e);
     ui->rb_delay_asTyped->setEnabled(e);
     ui->rb_delay_default->setEnabled(e);
+    ui->rep_debounce_input->setEnabled(e);
+    ui->rep_delay_input->setEnabled(e);
     ui->captureTypeBox->setEnabled(e);
     MainWindow::mainWindow->setTabsEnabled(e);
     ui->tabWidget->tabBar()->setEnabled(e);
@@ -876,6 +878,8 @@ void RebindWidget::on_btnClearMacro_clicked() {
     macroLines.clear();
     ui->macroName->clear();
     ui->macroPreview->clear();
+    ui->rep_debounce_input->setValue(500);
+    ui->rep_delay_input->setValue(500);
 }
 
 void RebindWidget::on_rb_delay_default_toggled(bool checked){

--- a/src/gui/rebindwidget.ui
+++ b/src/gui/rebindwidget.ui
@@ -105,10 +105,10 @@
        <item row="1" column="3">
         <spacer name="horizontalSpacer_2">
          <property name="orientation">
-          <enum>Qt::Horizontal</enum>
+          <enum>Qt::Orientation::Horizontal</enum>
          </property>
          <property name="sizeType">
-          <enum>QSizePolicy::Fixed</enum>
+          <enum>QSizePolicy::Policy::Fixed</enum>
          </property>
          <property name="sizeHint" stdset="0">
           <size>
@@ -136,10 +136,10 @@
        <item row="13" column="2">
         <spacer name="verticalSpacer_3">
          <property name="orientation">
-          <enum>Qt::Vertical</enum>
+          <enum>Qt::Orientation::Vertical</enum>
          </property>
          <property name="sizeType">
-          <enum>QSizePolicy::MinimumExpanding</enum>
+          <enum>QSizePolicy::Policy::MinimumExpanding</enum>
          </property>
          <property name="sizeHint" stdset="0">
           <size>
@@ -167,7 +167,7 @@
        <item row="1" column="2">
         <spacer name="horizontalSpacer_4">
          <property name="orientation">
-          <enum>Qt::Horizontal</enum>
+          <enum>Qt::Orientation::Horizontal</enum>
          </property>
          <property name="sizeHint" stdset="0">
           <size>
@@ -225,7 +225,7 @@
        <item row="1" column="5">
         <spacer name="horizontalSpacer_17">
          <property name="orientation">
-          <enum>Qt::Horizontal</enum>
+          <enum>Qt::Orientation::Horizontal</enum>
          </property>
          <property name="sizeHint" stdset="0">
           <size>
@@ -238,10 +238,10 @@
        <item row="1" column="0">
         <spacer name="horizontalSpacer_3">
          <property name="orientation">
-          <enum>Qt::Horizontal</enum>
+          <enum>Qt::Orientation::Horizontal</enum>
          </property>
          <property name="sizeType">
-          <enum>QSizePolicy::Fixed</enum>
+          <enum>QSizePolicy::Policy::Fixed</enum>
          </property>
          <property name="sizeHint" stdset="0">
           <size>
@@ -278,7 +278,7 @@
        <item row="1" column="9">
         <spacer name="horizontalSpacer_21">
          <property name="orientation">
-          <enum>Qt::Horizontal</enum>
+          <enum>Qt::Orientation::Horizontal</enum>
          </property>
          <property name="sizeHint" stdset="0">
           <size>
@@ -361,10 +361,10 @@
        <item row="2" column="1">
         <spacer name="verticalSpacer_8">
          <property name="orientation">
-          <enum>Qt::Vertical</enum>
+          <enum>Qt::Orientation::Vertical</enum>
          </property>
          <property name="sizeType">
-          <enum>QSizePolicy::Fixed</enum>
+          <enum>QSizePolicy::Policy::Fixed</enum>
          </property>
          <property name="sizeHint" stdset="0">
           <size>
@@ -470,10 +470,10 @@
        <item row="1" column="3">
         <spacer name="horizontalSpacer_20">
          <property name="orientation">
-          <enum>Qt::Horizontal</enum>
+          <enum>Qt::Orientation::Horizontal</enum>
          </property>
          <property name="sizeType">
-          <enum>QSizePolicy::Fixed</enum>
+          <enum>QSizePolicy::Policy::Fixed</enum>
          </property>
          <property name="sizeHint" stdset="0">
           <size>
@@ -493,10 +493,10 @@
        <item row="5" column="1">
         <spacer name="verticalSpacer_2">
          <property name="orientation">
-          <enum>Qt::Vertical</enum>
+          <enum>Qt::Orientation::Vertical</enum>
          </property>
          <property name="sizeType">
-          <enum>QSizePolicy::MinimumExpanding</enum>
+          <enum>QSizePolicy::Policy::MinimumExpanding</enum>
          </property>
          <property name="sizeHint" stdset="0">
           <size>
@@ -572,10 +572,10 @@
        <item row="1" column="0">
         <spacer name="horizontalSpacer_18">
          <property name="orientation">
-          <enum>Qt::Horizontal</enum>
+          <enum>Qt::Orientation::Horizontal</enum>
          </property>
          <property name="sizeType">
-          <enum>QSizePolicy::Fixed</enum>
+          <enum>QSizePolicy::Policy::Fixed</enum>
          </property>
          <property name="sizeHint" stdset="0">
           <size>
@@ -588,7 +588,7 @@
        <item row="1" column="2">
         <spacer name="horizontalSpacer_19">
          <property name="orientation">
-          <enum>Qt::Horizontal</enum>
+          <enum>Qt::Orientation::Horizontal</enum>
          </property>
          <property name="sizeHint" stdset="0">
           <size>
@@ -614,10 +614,10 @@
        <item row="1" column="8">
         <spacer name="horizontalSpacer_22">
          <property name="orientation">
-          <enum>Qt::Horizontal</enum>
+          <enum>Qt::Orientation::Horizontal</enum>
          </property>
          <property name="sizeType">
-          <enum>QSizePolicy::Fixed</enum>
+          <enum>QSizePolicy::Policy::Fixed</enum>
          </property>
          <property name="sizeHint" stdset="0">
           <size>
@@ -652,10 +652,10 @@
        <item row="4" column="3">
         <spacer name="horizontalSpacer_24">
          <property name="orientation">
-          <enum>Qt::Horizontal</enum>
+          <enum>Qt::Orientation::Horizontal</enum>
          </property>
          <property name="sizeType">
-          <enum>QSizePolicy::Fixed</enum>
+          <enum>QSizePolicy::Policy::Fixed</enum>
          </property>
          <property name="sizeHint" stdset="0">
           <size>
@@ -668,10 +668,10 @@
        <item row="6" column="2">
         <spacer name="verticalSpacer_11">
          <property name="orientation">
-          <enum>Qt::Vertical</enum>
+          <enum>Qt::Orientation::Vertical</enum>
          </property>
          <property name="sizeType">
-          <enum>QSizePolicy::MinimumExpanding</enum>
+          <enum>QSizePolicy::Policy::MinimumExpanding</enum>
          </property>
          <property name="sizeHint" stdset="0">
           <size>
@@ -684,10 +684,10 @@
        <item row="4" column="5">
         <spacer name="horizontalSpacer_26">
          <property name="orientation">
-          <enum>Qt::Horizontal</enum>
+          <enum>Qt::Orientation::Horizontal</enum>
          </property>
          <property name="sizeType">
-          <enum>QSizePolicy::Fixed</enum>
+          <enum>QSizePolicy::Policy::Fixed</enum>
          </property>
          <property name="sizeHint" stdset="0">
           <size>
@@ -714,10 +714,10 @@
        <item row="4" column="1">
         <spacer name="horizontalSpacer_23">
          <property name="orientation">
-          <enum>Qt::Horizontal</enum>
+          <enum>Qt::Orientation::Horizontal</enum>
          </property>
          <property name="sizeType">
-          <enum>QSizePolicy::Fixed</enum>
+          <enum>QSizePolicy::Policy::Fixed</enum>
          </property>
          <property name="sizeHint" stdset="0">
           <size>
@@ -730,7 +730,7 @@
        <item row="4" column="7">
         <spacer name="horizontalSpacer_25">
          <property name="orientation">
-          <enum>Qt::Horizontal</enum>
+          <enum>Qt::Orientation::Horizontal</enum>
          </property>
          <property name="sizeHint" stdset="0">
           <size>
@@ -772,10 +772,10 @@
        <item row="8" column="1">
         <spacer name="verticalSpacer_5">
          <property name="orientation">
-          <enum>Qt::Vertical</enum>
+          <enum>Qt::Orientation::Vertical</enum>
          </property>
          <property name="sizeType">
-          <enum>QSizePolicy::MinimumExpanding</enum>
+          <enum>QSizePolicy::Policy::MinimumExpanding</enum>
          </property>
          <property name="sizeHint" stdset="0">
           <size>
@@ -813,10 +813,10 @@
        <item row="5" column="1">
         <spacer name="verticalSpacer_6">
          <property name="orientation">
-          <enum>Qt::Vertical</enum>
+          <enum>Qt::Orientation::Vertical</enum>
          </property>
          <property name="sizeType">
-          <enum>QSizePolicy::Fixed</enum>
+          <enum>QSizePolicy::Policy::Fixed</enum>
          </property>
          <property name="sizeHint" stdset="0">
           <size>
@@ -859,10 +859,10 @@
        <item row="2" column="1">
         <spacer name="verticalSpacer_7">
          <property name="orientation">
-          <enum>Qt::Vertical</enum>
+          <enum>Qt::Orientation::Vertical</enum>
          </property>
          <property name="sizeType">
-          <enum>QSizePolicy::Fixed</enum>
+          <enum>QSizePolicy::Policy::Fixed</enum>
          </property>
          <property name="sizeHint" stdset="0">
           <size>
@@ -930,7 +930,7 @@
        <item row="7" column="3">
         <spacer name="horizontalSpacer_10">
          <property name="orientation">
-          <enum>Qt::Horizontal</enum>
+          <enum>Qt::Orientation::Horizontal</enum>
          </property>
          <property name="sizeHint" stdset="0">
           <size>
@@ -953,10 +953,10 @@
        <item row="1" column="2">
         <spacer name="horizontalSpacer_8">
          <property name="orientation">
-          <enum>Qt::Horizontal</enum>
+          <enum>Qt::Orientation::Horizontal</enum>
          </property>
          <property name="sizeType">
-          <enum>QSizePolicy::Fixed</enum>
+          <enum>QSizePolicy::Policy::Fixed</enum>
          </property>
          <property name="sizeHint" stdset="0">
           <size>
@@ -969,10 +969,10 @@
        <item row="1" column="0">
         <spacer name="horizontalSpacer_5">
          <property name="orientation">
-          <enum>Qt::Horizontal</enum>
+          <enum>Qt::Orientation::Horizontal</enum>
          </property>
          <property name="sizeType">
-          <enum>QSizePolicy::Fixed</enum>
+          <enum>QSizePolicy::Policy::Fixed</enum>
          </property>
          <property name="sizeHint" stdset="0">
           <size>
@@ -985,7 +985,7 @@
        <item row="1" column="5">
         <spacer name="horizontalSpacer_6">
          <property name="orientation">
-          <enum>Qt::Horizontal</enum>
+          <enum>Qt::Orientation::Horizontal</enum>
          </property>
          <property name="sizeHint" stdset="0">
           <size>
@@ -1008,7 +1008,7 @@
        <item row="1" column="4">
         <spacer name="horizontalSpacer_7">
          <property name="orientation">
-          <enum>Qt::Horizontal</enum>
+          <enum>Qt::Orientation::Horizontal</enum>
          </property>
          <property name="sizeHint" stdset="0">
           <size>
@@ -1031,10 +1031,10 @@
        <item row="2" column="2">
         <spacer name="horizontalSpacer_13">
          <property name="orientation">
-          <enum>Qt::Horizontal</enum>
+          <enum>Qt::Orientation::Horizontal</enum>
          </property>
          <property name="sizeType">
-          <enum>QSizePolicy::Fixed</enum>
+          <enum>QSizePolicy::Policy::Fixed</enum>
          </property>
          <property name="sizeHint" stdset="0">
           <size>
@@ -1056,17 +1056,17 @@
           <string notr="true">Tip</string>
          </property>
          <property name="textInteractionFlags">
-          <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByMouse</set>
+          <set>Qt::TextInteractionFlag::LinksAccessibleByMouse|Qt::TextInteractionFlag::TextSelectableByMouse</set>
          </property>
         </widget>
        </item>
        <item row="3" column="1">
         <spacer name="verticalSpacer">
          <property name="orientation">
-          <enum>Qt::Vertical</enum>
+          <enum>Qt::Orientation::Vertical</enum>
          </property>
          <property name="sizeType">
-          <enum>QSizePolicy::Fixed</enum>
+          <enum>QSizePolicy::Policy::Fixed</enum>
          </property>
          <property name="sizeHint" stdset="0">
           <size>
@@ -1093,10 +1093,10 @@
        <item row="7" column="1" colspan="4">
         <spacer name="verticalSpacer_9">
          <property name="orientation">
-          <enum>Qt::Vertical</enum>
+          <enum>Qt::Orientation::Vertical</enum>
          </property>
          <property name="sizeType">
-          <enum>QSizePolicy::MinimumExpanding</enum>
+          <enum>QSizePolicy::Policy::MinimumExpanding</enum>
          </property>
          <property name="sizeHint" stdset="0">
           <size>
@@ -1112,10 +1112,10 @@
        <item row="2" column="0">
         <spacer name="horizontalSpacer">
          <property name="orientation">
-          <enum>Qt::Horizontal</enum>
+          <enum>Qt::Orientation::Horizontal</enum>
          </property>
          <property name="sizeType">
-          <enum>QSizePolicy::Fixed</enum>
+          <enum>QSizePolicy::Policy::Fixed</enum>
          </property>
          <property name="sizeHint" stdset="0">
           <size>
@@ -1215,7 +1215,7 @@
           <number>3</number>
          </property>
          <property name="sizeConstraint">
-          <enum>QLayout::SetDefaultConstraint</enum>
+          <enum>QLayout::SizeConstraint::SetDefaultConstraint</enum>
          </property>
          <item>
           <widget class="QLabel" name="label_2">
@@ -1255,19 +1255,19 @@
             </sizepolicy>
            </property>
            <property name="contextMenuPolicy">
-            <enum>Qt::DefaultContextMenu</enum>
+            <enum>Qt::ContextMenuPolicy::DefaultContextMenu</enum>
            </property>
            <property name="acceptDrops">
             <bool>false</bool>
            </property>
            <property name="inputMethodHints">
-            <set>Qt::ImhNoAutoUppercase</set>
+            <set>Qt::InputMethodHint::ImhNoAutoUppercase</set>
            </property>
            <property name="horizontalScrollBarPolicy">
-            <enum>Qt::ScrollBarAlwaysOff</enum>
+            <enum>Qt::ScrollBarPolicy::ScrollBarAlwaysOff</enum>
            </property>
            <property name="sizeAdjustPolicy">
-            <enum>QAbstractScrollArea::AdjustToContents</enum>
+            <enum>QAbstractScrollArea::SizeAdjustPolicy::AdjustToContents</enum>
            </property>
            <property name="documentTitle">
             <string/>
@@ -1282,7 +1282,7 @@
             <string/>
            </property>
            <property name="textInteractionFlags">
-            <set>Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
+            <set>Qt::TextInteractionFlag::TextSelectableByKeyboard|Qt::TextInteractionFlag::TextSelectableByMouse</set>
            </property>
           </widget>
          </item>
@@ -1355,7 +1355,7 @@
            <item row="4" column="2">
             <spacer name="horizontalSpacer_27">
              <property name="orientation">
-              <enum>Qt::Horizontal</enum>
+              <enum>Qt::Orientation::Horizontal</enum>
              </property>
              <property name="sizeHint" stdset="0">
               <size>
@@ -1401,10 +1401,10 @@
          <item>
           <spacer name="horizontalSpacer_29">
            <property name="orientation">
-            <enum>Qt::Horizontal</enum>
+            <enum>Qt::Orientation::Horizontal</enum>
            </property>
            <property name="sizeType">
-            <enum>QSizePolicy::Minimum</enum>
+            <enum>QSizePolicy::Policy::Minimum</enum>
            </property>
            <property name="sizeHint" stdset="0">
             <size>
@@ -1465,7 +1465,7 @@
             </sizepolicy>
            </property>
            <property name="sizeAdjustPolicy">
-            <enum>QAbstractScrollArea::AdjustIgnored</enum>
+            <enum>QAbstractScrollArea::SizeAdjustPolicy::AdjustIgnored</enum>
            </property>
            <property name="dragEnabled">
             <bool>true</bool>
@@ -1474,13 +1474,13 @@
             <bool>false</bool>
            </property>
            <property name="dragDropMode">
-            <enum>QAbstractItemView::InternalMove</enum>
+            <enum>QAbstractItemView::DragDropMode::InternalMove</enum>
            </property>
            <property name="defaultDropAction">
-            <enum>Qt::MoveAction</enum>
+            <enum>Qt::DropAction::MoveAction</enum>
            </property>
            <property name="selectionBehavior">
-            <enum>QAbstractItemView::SelectRows</enum>
+            <enum>QAbstractItemView::SelectionBehavior::SelectRows</enum>
            </property>
            <property name="sortingEnabled">
             <bool>false</bool>
@@ -1605,7 +1605,7 @@
      <item>
       <spacer name="horizontalSpacer_14">
        <property name="orientation">
-        <enum>Qt::Horizontal</enum>
+        <enum>Qt::Orientation::Horizontal</enum>
        </property>
        <property name="sizeHint" stdset="0">
         <size>

--- a/src/gui/rebindwidget.ui
+++ b/src/gui/rebindwidget.ui
@@ -1288,6 +1288,74 @@
          </item>
          <item>
           <layout class="QGridLayout" name="gridLayout_6">
+           <item row="5" column="2">
+            <spacer name="horizontalSpacer_27">
+             <property name="orientation">
+              <enum>Qt::Orientation::Horizontal</enum>
+             </property>
+             <property name="sizeHint" stdset="0">
+              <size>
+               <width>40</width>
+               <height>20</height>
+              </size>
+             </property>
+            </spacer>
+           </item>
+           <item row="5" column="1">
+            <widget class="QComboBox" name="captureTypeBox">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="maximumSize">
+              <size>
+               <width>16777215</width>
+               <height>22</height>
+              </size>
+             </property>
+             <item>
+              <property name="text">
+               <string>This device only</string>
+              </property>
+             </item>
+             <item>
+              <property name="text">
+               <string>All ckb-next devices</string>
+              </property>
+             </item>
+             <item>
+              <property name="text">
+               <string>All keyboards</string>
+              </property>
+             </item>
+            </widget>
+           </item>
+           <item row="2" column="0">
+            <widget class="QLabel" name="label_7">
+             <property name="toolTip">
+              <string>Holding the key will repeat the macro indefinitely. With this value you can define the delay between individual executions of the registered macro.</string>
+             </property>
+             <property name="text">
+              <string>Repetition delay:</string>
+             </property>
+            </widget>
+           </item>
+           <item row="0" column="0">
+            <widget class="QLabel" name="label_5">
+             <property name="text">
+              <string>Keystroke delay:</string>
+             </property>
+            </widget>
+           </item>
+           <item row="5" column="0">
+            <widget class="QLabel" name="label_6">
+             <property name="text">
+              <string>Record from:</string>
+             </property>
+            </widget>
+           </item>
            <item row="0" column="1">
             <layout class="QHBoxLayout" name="horizontalLayout_4">
              <item>
@@ -1321,61 +1389,60 @@
              </item>
             </layout>
            </item>
-           <item row="4" column="1">
-            <widget class="QComboBox" name="captureTypeBox">
-             <property name="sizePolicy">
-              <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
-               <horstretch>0</horstretch>
-               <verstretch>0</verstretch>
-              </sizepolicy>
+           <item row="1" column="0">
+            <widget class="QLabel" name="label_8">
+             <property name="toolTip">
+              <string>Holding the key will repeat the macro indefinitely. With this value you can define the delay before the initial execution of the registered macro.</string>
              </property>
-             <property name="maximumSize">
-              <size>
-               <width>16777215</width>
-               <height>22</height>
-              </size>
-             </property>
-             <item>
-              <property name="text">
-               <string>This device only</string>
-              </property>
-             </item>
-             <item>
-              <property name="text">
-               <string>All ckb-next devices</string>
-              </property>
-             </item>
-             <item>
-              <property name="text">
-               <string>All keyboards</string>
-              </property>
-             </item>
-            </widget>
-           </item>
-           <item row="4" column="2">
-            <spacer name="horizontalSpacer_27">
-             <property name="orientation">
-              <enum>Qt::Orientation::Horizontal</enum>
-             </property>
-             <property name="sizeHint" stdset="0">
-              <size>
-               <width>40</width>
-               <height>20</height>
-              </size>
-             </property>
-            </spacer>
-           </item>
-           <item row="4" column="0">
-            <widget class="QLabel" name="label_6">
              <property name="text">
-              <string>Record from:</string>
+              <string>Initial delay:</string>
              </property>
             </widget>
            </item>
-           <item row="0" column="0">
-            <widget class="QLabel" name="label_5">
-             <property name="text">
-              <string>Keystroke delay:</string>
+           <item row="2" column="1">
+            <widget class="QSpinBox" name="rep_delay_input">
+             <property name="alignment">
+              <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
+             </property>
+             <property name="suffix">
+              <string>ms</string>
+             </property>
+             <property name="maximum">
+              <number>2000</number>
+             </property>
+             <property name="singleStep">
+              <number>25</number>
+             </property>
+             <property name="stepType">
+              <enum>QAbstractSpinBox::StepType::AdaptiveDecimalStepType</enum>
+             </property>
+             <property name="value">
+              <number>500</number>
+             </property>
+            </widget>
+           </item>
+           <item row="1" column="1">
+            <widget class="QSpinBox" name="rep_debounce_input">
+             <property name="alignment">
+              <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
+             </property>
+             <property name="suffix">
+              <string>ms</string>
+             </property>
+             <property name="minimum">
+              <number>50</number>
+             </property>
+             <property name="maximum">
+              <number>2000</number>
+             </property>
+             <property name="singleStep">
+              <number>25</number>
+             </property>
+             <property name="stepType">
+              <enum>QAbstractSpinBox::StepType::AdaptiveDecimalStepType</enum>
+             </property>
+             <property name="value">
+              <number>500</number>
              </property>
             </widget>
            </item>
@@ -1704,6 +1771,23 @@
   <tabstop>resetButton</tabstop>
   <tabstop>cancelButton</tabstop>
   <tabstop>applyButton</tabstop>
+  <tabstop>programKpSIBox</tabstop>
+  <tabstop>programKpModeBox</tabstop>
+  <tabstop>programKrSIBox</tabstop>
+  <tabstop>programKrModeBox</tabstop>
+  <tabstop>macroName</tabstop>
+  <tabstop>macroPreview</tabstop>
+  <tabstop>rb_delay_default</tabstop>
+  <tabstop>rb_delay_asTyped</tabstop>
+  <tabstop>rep_debounce_input</tabstop>
+  <tabstop>rep_delay_input</tabstop>
+  <tabstop>captureTypeBox</tabstop>
+  <tabstop>editAsStringBtn</tabstop>
+  <tabstop>tableView</tabstop>
+  <tabstop>btnStartMacro</tabstop>
+  <tabstop>btnAddEvent</tabstop>
+  <tabstop>btnRemoveEvent</tabstop>
+  <tabstop>btnClearMacro</tabstop>
  </tabstops>
  <resources/>
  <connections/>

--- a/src/gui/resources/translations/de.ts
+++ b/src/gui/resources/translations/de.ts
@@ -2716,17 +2716,17 @@ oder klicken Sie auf &quot;Beenden&quot; in den Einstellungen.</translation>
     <message>
         <location filename="../../rebindwidget.ui" line="1338"/>
         <source>Holding the key will repeat the macro indefinitely. With this value you can define the delay between individual executions of the registered macro.</source>
-        <translation type="unfinished"></translation>
+        <translation>Das Halten der Taste wiederholt das Makro dauerhaft. Mit diesem Wert können Sie einstellen, wie lange die Pause zwischen individuellen Ausführungen des Makros sein soll.</translation>
     </message>
     <message>
         <location filename="../../rebindwidget.ui" line="1341"/>
         <source>Repetition delay:</source>
-        <translation type="unfinished"></translation>
+        <translation>Wiederholungsverzögerung:</translation>
     </message>
     <message>
         <location filename="../../rebindwidget.ui" line="1395"/>
         <source>Holding the key will repeat the macro indefinitely. With this value you can define the delay before the initial execution of the registered macro.</source>
-        <translation type="unfinished"></translation>
+        <translation>Das Halten der Taste wiederholt das Makro dauerhaft. Mit diesem Wert können Sie einstellen, wie lange die Verzögerung vor der ersten Ausführungen des Makros sein soll.</translation>
     </message>
     <message>
         <location filename="../../rebindwidget.ui" line="1398"/>
@@ -2737,7 +2737,7 @@ oder klicken Sie auf &quot;Beenden&quot; in den Einstellungen.</translation>
         <location filename="../../rebindwidget.ui" line="1408"/>
         <location filename="../../rebindwidget.ui" line="1430"/>
         <source>ms</source>
-        <translation type="unfinished"></translation>
+        <translation>ms</translation>
     </message>
     <message>
         <location filename="../../rebindwidget.ui" line="1464"/>

--- a/src/gui/resources/translations/de.ts
+++ b/src/gui/resources/translations/de.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.1" language="de">
+<TS version="2.1" language="de_DE">
 <context>
     <name>AnimAddDialog</name>
     <message>
@@ -99,9 +99,9 @@
         <location filename="../../animsettingdialog.ui" line="169"/>
         <location filename="../../animsettingdialog.ui" line="183"/>
         <location filename="../../animsettingdialog.ui" line="200"/>
-        <location filename="../../animsettingdialog.cpp" line="216"/>
-        <location filename="../../animsettingdialog.cpp" line="342"/>
-        <location filename="../../animsettingdialog.cpp" line="358"/>
+        <location filename="../../animsettingdialog.cpp" line="225"/>
+        <location filename="../../animsettingdialog.cpp" line="352"/>
+        <location filename="../../animsettingdialog.cpp" line="369"/>
         <source>seconds</source>
         <translation>Sekunden</translation>
     </message>
@@ -204,37 +204,37 @@
         <translation>Beschreibung</translation>
     </message>
     <message>
-        <location filename="../../animsettingdialog.cpp" line="26"/>
+        <location filename="../../animsettingdialog.cpp" line="33"/>
         <source> Animation</source>
         <translation> Animation</translation>
     </message>
     <message>
-        <location filename="../../animsettingdialog.cpp" line="33"/>
+        <location filename="../../animsettingdialog.cpp" line="40"/>
         <source>&lt;b&gt;Animation&lt;/b&gt;</source>
         <translation>&lt;b&gt;Animation&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../../animsettingdialog.cpp" line="203"/>
+        <location filename="../../animsettingdialog.cpp" line="211"/>
         <source>&lt;b&gt;Playback&lt;/b&gt;</source>
         <translation>&lt;b&gt;Wiedergabe&lt;</translation>
     </message>
     <message>
-        <location filename="../../animsettingdialog.cpp" line="208"/>
+        <location filename="../../animsettingdialog.cpp" line="216"/>
         <source>Duration:</source>
         <translation>Dauer:</translation>
     </message>
     <message>
-        <location filename="../../animsettingdialog.cpp" line="220"/>
+        <location filename="../../animsettingdialog.cpp" line="229"/>
         <source>Start with mode</source>
         <translation>Mit Modus starten</translation>
     </message>
     <message>
-        <location filename="../../animsettingdialog.cpp" line="228"/>
+        <location filename="../../animsettingdialog.cpp" line="237"/>
         <source>Start with key press</source>
         <translation>Mit Tastendruck starten</translation>
     </message>
     <message>
-        <location filename="../../animsettingdialog.cpp" line="240"/>
+        <location filename="../../animsettingdialog.cpp" line="249"/>
         <source>on pressed key</source>
         <translation variants="yes">
             <lengthvariant>Beim Drücken einer Taste</lengthvariant>
@@ -242,46 +242,46 @@
         </translation>
     </message>
     <message>
-        <location filename="../../animsettingdialog.cpp" line="241"/>
+        <location filename="../../animsettingdialog.cpp" line="250"/>
         <source>on whole keyboard</source>
         <translation>Auf gesamter Tastatur</translation>
     </message>
     <message>
-        <location filename="../../animsettingdialog.cpp" line="242"/>
+        <location filename="../../animsettingdialog.cpp" line="251"/>
         <source>on keyboard (once)</source>
         <translation>Auf Tastatur (einmal)</translation>
     </message>
     <message>
-        <location filename="../../animsettingdialog.cpp" line="246"/>
+        <location filename="../../animsettingdialog.cpp" line="255"/>
         <source>every time</source>
         <translation>jedes Mal</translation>
     </message>
     <message>
-        <location filename="../../animsettingdialog.cpp" line="247"/>
+        <location filename="../../animsettingdialog.cpp" line="256"/>
         <source>only once</source>
         <translation>nur einmal</translation>
     </message>
     <message>
-        <location filename="../../animsettingdialog.cpp" line="285"/>
-        <location filename="../../animsettingdialog.cpp" line="297"/>
+        <location filename="../../animsettingdialog.cpp" line="294"/>
+        <location filename="../../animsettingdialog.cpp" line="306"/>
         <source>Repeat:</source>
         <translation>Wiederholen:</translation>
     </message>
     <message>
-        <location filename="../../animsettingdialog.cpp" line="295"/>
-        <location filename="../../animsettingdialog.cpp" line="307"/>
+        <location filename="../../animsettingdialog.cpp" line="304"/>
+        <location filename="../../animsettingdialog.cpp" line="316"/>
         <source>times</source>
         <translation>mal</translation>
     </message>
     <message>
-        <location filename="../../animsettingdialog.cpp" line="309"/>
-        <location filename="../../animsettingdialog.cpp" line="312"/>
+        <location filename="../../animsettingdialog.cpp" line="318"/>
+        <location filename="../../animsettingdialog.cpp" line="321"/>
         <source>Forever</source>
         <translation>Unendlich</translation>
     </message>
     <message>
-        <location filename="../../animsettingdialog.cpp" line="360"/>
-        <location filename="../../animsettingdialog.cpp" line="364"/>
+        <location filename="../../animsettingdialog.cpp" line="371"/>
+        <location filename="../../animsettingdialog.cpp" line="375"/>
         <source>Stop after:</source>
         <translation>Anhalten nach:</translation>
     </message>
@@ -925,7 +925,7 @@
         <translation>Indikator-Intensität:</translation>
     </message>
     <message>
-        <location filename="../../kperfwidget.cpp" line="237"/>
+        <location filename="../../kperfwidget.cpp" line="236"/>
         <source>Copy performance settings to:</source>
         <translation>Leistungseinstellungen kopieren nach:</translation>
     </message>
@@ -937,40 +937,28 @@
         <translation type="vanished">Beenden</translation>
     </message>
     <message>
-        <location filename="../../kstatusnotifier/kstatusnotifieritem.cpp" line="521"/>
-        <location filename="../../kstatusnotifier/kstatusnotifieritem.cpp" line="1159"/>
+        <location filename="../../kstatusnotifier/kstatusnotifieritem.cpp" line="516"/>
+        <location filename="../../kstatusnotifier/kstatusnotifieritem.cpp" line="1171"/>
         <source>&amp;Minimize</source>
         <comment>@action:inmenu</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../kstatusnotifier/kstatusnotifieritem.cpp" line="876"/>
+        <location filename="../../kstatusnotifier/kstatusnotifieritem.cpp" line="892"/>
         <source>Quit</source>
         <comment>@action:inmenu</comment>
         <translation type="unfinished">Beenden</translation>
     </message>
     <message>
-        <location filename="../../kstatusnotifier/kstatusnotifieritem.cpp" line="1156"/>
+        <location filename="../../kstatusnotifier/kstatusnotifieritem.cpp" line="1168"/>
         <source>&amp;Restore</source>
         <comment>@action:inmenu</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../kstatusnotifier/kstatusnotifieritem.cpp" line="1172"/>
-        <source>Confirm Quit From System Tray</source>
-        <comment>@title:window</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../kstatusnotifier/kstatusnotifieritem.cpp" line="1173"/>
-        <source>&lt;qt&gt;Are you sure you want to quit &lt;b&gt;%1&lt;/b&gt;?&lt;/qt&gt;</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../kstatusnotifier/kstatusnotifieritem.cpp" line="1178"/>
         <source>Quit</source>
         <comment>@action:button</comment>
-        <translation type="unfinished">Beenden</translation>
+        <translation type="obsolete">Beenden</translation>
     </message>
 </context>
 <context>
@@ -1238,6 +1226,14 @@ Die Zuordnung wird nicht funktionieren bis Winlock deaktiviert wird.</translatio
         <location filename="../../kblightwidget.cpp" line="119"/>
         <source>%1 keys selected</source>
         <translation>%1 Tasten ausgewählt</translation>
+    </message>
+</context>
+<context>
+    <name>KbManager</name>
+    <message>
+        <location filename="../../kbmanager.cpp" line="42"/>
+        <source>Please enable &quot;Turn lights off when idle&quot; before using --sleep</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -1581,7 +1577,7 @@ Es wird versucht, so viele wie möglich zu importieren.</translation>
     </message>
     <message>
         <location filename="../../kbwidget.ui" line="552"/>
-        <location filename="../../kbwidget.cpp" line="402"/>
+        <location filename="../../kbwidget.cpp" line="412"/>
         <source>Check for updates</source>
         <translation>Nach Updates suchen</translation>
     </message>
@@ -1596,79 +1592,79 @@ Es wird versucht, so viele wie möglich zu importieren.</translation>
         <translation>Auf Hardware speichern</translation>
     </message>
     <message>
-        <location filename="../../kbwidget.cpp" line="116"/>
+        <location filename="../../kbwidget.cpp" line="120"/>
         <source>Saving to hardware is not supported on this device.</source>
         <translation>Auf diesem Gerät wird das Speichern auf Hardware nicht unterstützt.</translation>
     </message>
     <message>
-        <location filename="../../kbwidget.cpp" line="178"/>
+        <location filename="../../kbwidget.cpp" line="182"/>
         <source>This device does not support setting the poll rate through software.</source>
         <translation>Bei diesem Gerät kann die Abrufrate nicht per Software eingestellt werden.</translation>
     </message>
     <message>
-        <location filename="../../kbwidget.cpp" line="202"/>
+        <location filename="../../kbwidget.cpp" line="206"/>
         <source>Manage profiles...</source>
         <translation>Profile verwalten...</translation>
     </message>
     <message>
-        <location filename="../../kbwidget.cpp" line="272"/>
+        <location filename="../../kbwidget.cpp" line="282"/>
         <source>Rename...</source>
         <translation>Umbenennen...</translation>
     </message>
     <message>
-        <location filename="../../kbwidget.cpp" line="273"/>
+        <location filename="../../kbwidget.cpp" line="283"/>
         <source>Duplicate</source>
         <translation>Duplizieren</translation>
     </message>
     <message>
-        <location filename="../../kbwidget.cpp" line="274"/>
+        <location filename="../../kbwidget.cpp" line="284"/>
         <source>Delete</source>
         <translation>Entfernen</translation>
     </message>
     <message>
-        <location filename="../../kbwidget.cpp" line="279"/>
+        <location filename="../../kbwidget.cpp" line="289"/>
         <source>Move Up</source>
         <translation>Nach oben bewegen</translation>
     </message>
     <message>
-        <location filename="../../kbwidget.cpp" line="281"/>
+        <location filename="../../kbwidget.cpp" line="291"/>
         <source>Manage Events</source>
-        <translation type="unfinished"></translation>
+        <translation>Events verwalten</translation>
     </message>
     <message>
-        <location filename="../../kbwidget.cpp" line="285"/>
+        <location filename="../../kbwidget.cpp" line="295"/>
         <source>Move Down</source>
         <translation>Nach unten bewegen</translation>
     </message>
     <message>
-        <location filename="../../kbwidget.cpp" line="314"/>
+        <location filename="../../kbwidget.cpp" line="324"/>
         <source>Delete mode</source>
         <translation>Modus entfernen</translation>
     </message>
     <message>
-        <location filename="../../kbwidget.cpp" line="314"/>
+        <location filename="../../kbwidget.cpp" line="324"/>
         <source>Are you sure you want to delete this mode?</source>
         <translation>Sind Sie sicher, dass Sie diesen Modus löschen möchten?</translation>
     </message>
     <message>
-        <location filename="../../kbwidget.cpp" line="407"/>
+        <location filename="../../kbwidget.cpp" line="417"/>
         <source>Up to date</source>
         <translation>Aktuell</translation>
     </message>
     <message>
-        <location filename="../../kbwidget.cpp" line="409"/>
+        <location filename="../../kbwidget.cpp" line="419"/>
         <source>Upgrade to v%1</source>
         <translation>Auf v%1 aktualisieren</translation>
     </message>
     <message>
-        <location filename="../../kbwidget.cpp" line="426"/>
+        <location filename="../../kbwidget.cpp" line="436"/>
         <source>Checking...</source>
         <translation>Wird überprüft...</translation>
     </message>
     <message>
-        <location filename="../../kbwidget.cpp" line="434"/>
-        <location filename="../../kbwidget.cpp" line="438"/>
-        <location filename="../../kbwidget.cpp" line="441"/>
+        <location filename="../../kbwidget.cpp" line="444"/>
+        <location filename="../../kbwidget.cpp" line="448"/>
+        <location filename="../../kbwidget.cpp" line="451"/>
         <source>Firmware update</source>
         <translation>Firmware-Update</translation>
     </message>
@@ -1677,37 +1673,37 @@ Es wird versucht, so viele wie möglich zu importieren.</translation>
         <translation type="vanished">&lt;center&gt;Es ist eine neue Firmware für dieses Gerät verfügbar.&lt;br /&gt;Allerdings wird dafür eine neuere Version von ckb-next benötigt.&lt;br /&gt;Bitte aktualisieren Sie ckb-next und versuchen Sie es erneut.&lt;/center&gt;</translation>
     </message>
     <message>
-        <location filename="../../kbwidget.cpp" line="434"/>
+        <location filename="../../kbwidget.cpp" line="444"/>
         <source>&lt;center&gt;There was a problem getting the status for this device.&lt;br /&gt;Would you like to select a file manually?&lt;/center&gt;</source>
         <translation>center&gt;Es gab ein Problem beim Abrufen des Status für dieses Gerät.&lt;br /&gt;Möchten Sie manuell eine Datei auswählen?&lt;/center&gt;</translation>
     </message>
     <message>
-        <location filename="../../kbwidget.cpp" line="438"/>
+        <location filename="../../kbwidget.cpp" line="448"/>
         <source>&lt;center&gt;There is a new firmware available for this device (v%1).&lt;br /&gt;However, it requires a newer version of ckb-next.&lt;br /&gt;Please upgrade ckb-next and try again.&lt;/center&gt;</source>
         <translation>&lt;center&gt;Es ist eine neue Firmware für dieses Gerät verfügbar (v%1).&lt;br /&gt;Allerdings wird dafür eine neuere Version von ckb-next benötigt.&lt;br /&gt;Bitte aktualisieren Sie ckb-next und versuchen Sie es erneut.&lt;/center&gt;</translation>
     </message>
     <message>
-        <location filename="../../kbwidget.cpp" line="441"/>
+        <location filename="../../kbwidget.cpp" line="451"/>
         <source>&lt;center&gt;Your firmware is already up to date.&lt;br /&gt;Would you like to select a file manually?&lt;/center&gt;</source>
         <translation>&lt;center&gt;Die Firmware ist bereits auf dem neuesten Stand.&lt;br /&gt;Möchten Sie manuell eine Datei auswählen?&lt;/center&gt;</translation>
     </message>
     <message>
-        <location filename="../../kbwidget.cpp" line="453"/>
+        <location filename="../../kbwidget.cpp" line="463"/>
         <source>Select firmware file</source>
         <translation>Firmware-Datei auswählen</translation>
     </message>
     <message>
-        <location filename="../../kbwidget.cpp" line="453"/>
+        <location filename="../../kbwidget.cpp" line="463"/>
         <source>Firmware blobs (*.bin)</source>
         <translation>Firmware-Blobs (*.bin)</translation>
     </message>
     <message>
-        <location filename="../../kbwidget.cpp" line="458"/>
+        <location filename="../../kbwidget.cpp" line="468"/>
         <source>Error</source>
         <translation>Fehler</translation>
     </message>
     <message>
-        <location filename="../../kbwidget.cpp" line="458"/>
+        <location filename="../../kbwidget.cpp" line="468"/>
         <source>&lt;center&gt;File could not be read.&lt;/center&gt;</source>
         <translation>&lt;center&gt;Datei konnte nicht gelesen werden.&lt;/center&gt;</translation>
     </message>
@@ -2101,7 +2097,7 @@ Es wird versucht, so viele wie möglich zu importieren.</translation>
         <translation>In Modus kopieren...</translation>
     </message>
     <message>
-        <location filename="../../mperfwidget.cpp" line="350"/>
+        <location filename="../../mperfwidget.cpp" line="357"/>
         <source>Copy performance settings to:</source>
         <translation>Leistungseinstellungen kopieren nach:</translation>
     </message>
@@ -2205,109 +2201,109 @@ Es wird versucht, so viele wie möglich zu importieren.</translation>
         <translation>Über</translation>
     </message>
     <message>
-        <location filename="../../mainwindow.cpp" line="135"/>
+        <location filename="../../mainwindow.cpp" line="136"/>
         <source>Restore</source>
         <translation>Wiederherstellen</translation>
     </message>
     <message>
-        <location filename="../../mainwindow.cpp" line="136"/>
+        <location filename="../../mainwindow.cpp" line="137"/>
         <source>Quit</source>
         <translation>Beenden</translation>
     </message>
     <message>
-        <location filename="../../mainwindow.cpp" line="162"/>
+        <location filename="../../mainwindow.cpp" line="163"/>
         <source>Settings</source>
         <translation>Einstellungen</translation>
     </message>
     <message>
-        <location filename="../../mainwindow.cpp" line="170"/>
+        <location filename="../../mainwindow.cpp" line="171"/>
         <source>The ckb-next daemon is not running. This program will &lt;b&gt;not&lt;/b&gt; work without it!</source>
         <translation>Der ckb-next-Daemon läuft nicht. Das Programm wird ohne &lt;b&gt;nicht&lt;/b&gt; nicht funktionieren!</translation>
     </message>
     <message>
-        <location filename="../../mainwindow.cpp" line="172"/>
+        <location filename="../../mainwindow.cpp" line="173"/>
         <source>Start it once with:</source>
         <translation>Einmalig starten mit:</translation>
     </message>
     <message>
-        <location filename="../../mainwindow.cpp" line="174"/>
+        <location filename="../../mainwindow.cpp" line="175"/>
         <source>Enable it for every boot:</source>
         <translation>Für jeden Systemstart aktivieren:</translation>
     </message>
     <message>
-        <location filename="../../mainwindow.cpp" line="176"/>
+        <location filename="../../mainwindow.cpp" line="177"/>
         <source>If &quot;Unit ckb-next-daemon.service is masked.&quot;, unmask it first and try again:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../mainwindow.cpp" line="179"/>
+        <location filename="../../mainwindow.cpp" line="180"/>
         <source>Start and enable it with:</source>
         <translation>Starten und aktivieren mit:</translation>
     </message>
     <message>
-        <location filename="../../mainwindow.cpp" line="205"/>
+        <location filename="../../mainwindow.cpp" line="206"/>
         <source>The ckb-next daemon is not running.</source>
         <translation>Der ckb-next-Daemon läuft nicht.</translation>
     </message>
     <message>
-        <location filename="../../mainwindow.cpp" line="292"/>
+        <location filename="../../mainwindow.cpp" line="293"/>
         <source>Driver inactive</source>
         <translation>Treiber inaktiv</translation>
     </message>
     <message>
-        <location filename="../../mainwindow.cpp" line="299"/>
+        <location filename="../../mainwindow.cpp" line="300"/>
         <source>&lt;br /&gt;&lt;br /&gt;&lt;b&gt;Warning:&lt;/b&gt; Driver version mismatch (</source>
         <translation>&lt;br /&gt;&lt;br /&gt;&lt;b&gt;Warnung:&lt;/b&gt; Treiber-Version stimmt nicht überein(</translation>
     </message>
     <message>
-        <location filename="../../mainwindow.cpp" line="299"/>
+        <location filename="../../mainwindow.cpp" line="300"/>
         <source>). Please upgrade ckb-next</source>
         <translation>). Bitte aktualisieren Sie ckb-next</translation>
     </message>
     <message>
-        <location filename="../../mainwindow.cpp" line="299"/>
+        <location filename="../../mainwindow.cpp" line="300"/>
         <source>. If the problem persists, try rebooting.</source>
         <translation>. Wenn das Problem weiterhin besteht, versuchen Sie es mit einem Rechner-Neustart.</translation>
     </message>
     <message>
-        <location filename="../../mainwindow.cpp" line="310"/>
+        <location filename="../../mainwindow.cpp" line="311"/>
         <source>&lt;br /&gt;&lt;b&gt;Warning:&lt;/b&gt; System Extension by &quot;Fumihiko Takayama&quot; is not allowed in Security &amp; Privacy. Please allow it and then unplug and replug your devices.</source>
         <translation>&lt;br /&gt;&lt;b&gt;Warnung:&lt;/b&gt; Die Systemerweiterung von &quot;Fumihiko Takayama&quot; ist unter Sicherheit &amp; Datenschutz nicht erlaubt. Bitte lassen Sie sie zu und stecken Sie dann Ihre Geräte ab und wieder an.</translation>
     </message>
     <message>
-        <location filename="../../mainwindow.cpp" line="312"/>
+        <location filename="../../mainwindow.cpp" line="313"/>
         <source>&lt;br /&gt;&lt;b&gt;Warning:&lt;/b&gt; Make sure ckb-next-daemon is allowed in Security &amp; Privacy -&gt; Input monitoring.&lt;br /&gt;Please allow for up to 10 seconds for the daemon restart prompt to show up after allowing input monitoring.</source>
         <translation>&lt;br /&gt;&lt;b&gt;Warnung:&lt;/b&gt; Stellen Sie sicher, dass ckb-next-daemon unter Sicherheit &amp; Datenschutz-&gt; Eingabeüberwachung zugelassen ist. &lt;br /&gt;Bitte warten Sie bis zu 10 Sekunden, bis die Aufforderung zum Neustart des Daemons erscheint, nachdem Sie die Eingabeüberwachung zugelassen haben.</translation>
     </message>
     <message>
-        <location filename="../../mainwindow.cpp" line="322"/>
+        <location filename="../../mainwindow.cpp" line="323"/>
         <source>&lt;br /&gt;&lt;b&gt;Warning:&lt;/b&gt; The uinput module could not be loaded. If this issue persists after rebooting, compile a kernel with CONFIG_INPUT_UINPUT=y.</source>
         <translation>&lt;br /&gt;&lt;b&gt;Warnung:&lt;/b&gt; Das uinput-Modul konnte nicht geladen werden. Wenn dieses Problem nach einem Neustart weiterhin besteht, kompilieren Sie einen Kernel mit CONFIG_INPUT_UINPUT=y.</translation>
     </message>
     <message>
-        <location filename="../../mainwindow.cpp" line="325"/>
+        <location filename="../../mainwindow.cpp" line="326"/>
         <source>No devices connected</source>
         <translation>Keine Geräte verbunden</translation>
     </message>
     <message>
-        <location filename="../../mainwindow.cpp" line="328"/>
+        <location filename="../../mainwindow.cpp" line="329"/>
         <source>1 device connected</source>
         <translation>1 Gerät verbunden</translation>
     </message>
     <message>
-        <location filename="../../mainwindow.cpp" line="330"/>
+        <location filename="../../mainwindow.cpp" line="331"/>
         <source>%1 devices connected</source>
         <translation>%1 Geräte verbunden</translation>
     </message>
     <message>
-        <location filename="../../mainwindow.cpp" line="361"/>
+        <location filename="../../mainwindow.cpp" line="362"/>
         <source>A new firmware is available for your %1 (v%2)
 Would you like to install it now?</source>
         <translation>Eine neue Firmware ist für Ihr(e) %1 (v%2) verfübar
 Möchten Sie sie installieren?</translation>
     </message>
     <message>
-        <location filename="../../mainwindow.cpp" line="377"/>
+        <location filename="../../mainwindow.cpp" line="378"/>
         <source>ckb-next will still run in the background.
 To close it, choose Quit from the tray menu
 or click &quot;Quit&quot; on the Settings screen.</source>
@@ -2316,12 +2312,12 @@ Um es zu beenden, wählen Sie Beenden aus dem Tray-Menü
 oder klicken Sie auf &quot;Beenden&quot; in den Einstellungen.</translation>
     </message>
     <message>
-        <location filename="../../mainwindow.cpp" line="536"/>
+        <location filename="../../mainwindow.cpp" line="539"/>
         <source>Update to v</source>
         <translation>Aktualisieren auf v</translation>
     </message>
     <message>
-        <location filename="../../mainwindow.cpp" line="541"/>
+        <location filename="../../mainwindow.cpp" line="544"/>
         <source>Up to date</source>
         <translation>Aktuell</translation>
     </message>
@@ -2355,47 +2351,52 @@ oder klicken Sie auf &quot;Beenden&quot; in den Einstellungen.</translation>
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../../main.cpp" line="68"/>
+        <location filename="../../main.cpp" line="69"/>
         <source>Starts in background, without displaying the main window.</source>
         <translation>Startet im Hintergrund, ohne das Hauptfenster anzuzeigen.</translation>
     </message>
     <message>
-        <location filename="../../main.cpp" line="73"/>
+        <location filename="../../main.cpp" line="74"/>
         <source>Causes already running instance (if any) to exit.</source>
         <translation>Bewirkt, dass bereits laufende Instanzen (falls vorhanden) beendet werden.</translation>
     </message>
     <message>
-        <location filename="../../main.cpp" line="76"/>
+        <location filename="../../main.cpp" line="77"/>
         <source>Switches to the profile with the specified name on all devices.</source>
         <translation>Wechselt auf allen Geräten zu dem Profil mit dem angegebenen Namen.</translation>
     </message>
     <message>
-        <location filename="../../main.cpp" line="79"/>
+        <location filename="../../main.cpp" line="80"/>
         <source>Switches to the mode either in the current profile, or in the one specified by --profile</source>
         <translation>Wechselt entweder in den Modus des aktuellen Profils oder in den mit --profile angegebenen Modus</translation>
     </message>
     <message>
-        <location filename="../../main.cpp" line="82"/>
+        <location filename="../../main.cpp" line="83"/>
+        <source>Turns the lights off as if the system was idling.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../main.cpp" line="86"/>
         <source>Delays application start for 5 seconds</source>
         <translation>Verzögert den Programmstart um 5 Sekunden</translation>
     </message>
     <message>
-        <location filename="../../main.cpp" line="83"/>
+        <location filename="../../main.cpp" line="87"/>
         <source>Disables the daemon not running popup</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../main.cpp" line="97"/>
+        <location filename="../../main.cpp" line="101"/>
         <source>Enables the KeyWidget debug window</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../main.cpp" line="299"/>
+        <location filename="../../main.cpp" line="320"/>
         <source>Downgrade Warning</source>
         <translation>Downgrade-Warnung</translation>
     </message>
     <message>
-        <location filename="../../main.cpp" line="300"/>
+        <location filename="../../main.cpp" line="321"/>
         <source>Downgrading ckb-next will lead to profile data loss. It is recommended to click Cancel and update to the latest version.&lt;br&gt;&lt;br&gt;If you wish to continue, back up the settings file located at&lt;blockquote&gt;%1&lt;/blockquote&gt;and click OK.</source>
         <translation>Ein Downgrade von ckb-next führt zum Verlust von Profildaten. Es wird empfohlen, auf Abbrechen zu klicken und auf die neueste Version zu aktualisieren.&lt;br&gt;&lt;br&gt;Wenn Sie fortfahren möchten, sichern Sie die Einstellungsdatei, die sich unter&lt;blockquote&gt;%1&lt;/blockquote&gt; befindet, und klicken Sie auf OK.</translation>
     </message>
@@ -2405,22 +2406,22 @@ oder klicken Sie auf &quot;Beenden&quot; in den Einstellungen.</translation>
         <translation>n. a.</translation>
     </message>
     <message>
-        <location filename="../../keymap.cpp" line="1974"/>
+        <location filename="../../keymap.cpp" line="2005"/>
         <source>Eject</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../keymap.cpp" line="1976"/>
+        <location filename="../../keymap.cpp" line="2007"/>
         <source>Power</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../keymap.cpp" line="1978"/>
+        <location filename="../../keymap.cpp" line="2009"/>
         <source>Wheel Left</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../keymap.cpp" line="1980"/>
+        <location filename="../../keymap.cpp" line="2011"/>
         <source>Wheel Right</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2688,37 +2689,63 @@ oder klicken Sie auf &quot;Beenden&quot; in den Einstellungen.</translation>
         <translation>Vorschau</translation>
     </message>
     <message>
-        <location filename="../../rebindwidget.ui" line="1340"/>
+        <location filename="../../rebindwidget.ui" line="1320"/>
         <source>This device only</source>
         <translation>Nur dieses Gerät</translation>
     </message>
     <message>
-        <location filename="../../rebindwidget.ui" line="1345"/>
+        <location filename="../../rebindwidget.ui" line="1325"/>
         <source>All ckb-next devices</source>
         <translation>Alle ckb-next Geräte</translation>
     </message>
     <message>
-        <location filename="../../rebindwidget.ui" line="1350"/>
+        <location filename="../../rebindwidget.ui" line="1330"/>
         <source>All keyboards</source>
         <translation>Alle Tastaturen</translation>
     </message>
     <message>
-        <location filename="../../rebindwidget.ui" line="1371"/>
+        <location filename="../../rebindwidget.ui" line="1355"/>
         <source>Record from:</source>
         <translation>Aufzeichnen von:</translation>
     </message>
     <message>
-        <location filename="../../rebindwidget.ui" line="1378"/>
+        <location filename="../../rebindwidget.ui" line="1348"/>
         <source>Keystroke delay:</source>
         <translation>Tastenverzögerung:</translation>
     </message>
     <message>
-        <location filename="../../rebindwidget.ui" line="1397"/>
+        <location filename="../../rebindwidget.ui" line="1338"/>
+        <source>Holding the key will repeat the macro indefinitely. With this value you can define the delay between individual executions of the registered macro.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../rebindwidget.ui" line="1341"/>
+        <source>Repetition delay:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../rebindwidget.ui" line="1395"/>
+        <source>Holding the key will repeat the macro indefinitely. With this value you can define the delay before the initial execution of the registered macro.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../rebindwidget.ui" line="1398"/>
+        <source>Initial delay:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../rebindwidget.ui" line="1408"/>
+        <location filename="../../rebindwidget.ui" line="1430"/>
+        <source>ms</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../rebindwidget.ui" line="1464"/>
         <source>Events</source>
         <translation>Ereignisse</translation>
     </message>
     <message>
-        <location filename="../../rebindwidget.ui" line="1432"/>
+        <location filename="../../rebindwidget.ui" line="1499"/>
         <source>Edit as string</source>
         <translatorcomment>“Zeichenkette” is too long for the button, I think</translatorcomment>
         <translation variants="yes">
@@ -2727,28 +2754,28 @@ oder klicken Sie auf &quot;Beenden&quot; in den Einstellungen.</translation>
         </translation>
     </message>
     <message>
-        <location filename="../../rebindwidget.ui" line="1522"/>
-        <location filename="../../rebindwidget.cpp" line="810"/>
+        <location filename="../../rebindwidget.ui" line="1589"/>
+        <location filename="../../rebindwidget.cpp" line="845"/>
         <source>Start Recording</source>
         <translation>Aufzeichnung starten</translation>
     </message>
     <message>
-        <location filename="../../rebindwidget.ui" line="1547"/>
+        <location filename="../../rebindwidget.ui" line="1614"/>
         <source>Add</source>
         <translation>Hinzufügen</translation>
     </message>
     <message>
-        <location filename="../../rebindwidget.ui" line="1572"/>
+        <location filename="../../rebindwidget.ui" line="1639"/>
         <source>Remove</source>
         <translation>Entfernen</translation>
     </message>
     <message>
-        <location filename="../../rebindwidget.ui" line="1296"/>
+        <location filename="../../rebindwidget.ui" line="1364"/>
         <source>Set delay to default values: 20us up to 15 chars, 200us above</source>
         <translation>Verzögerung auf Standardwerte setzen: 20us bis zu 15 Zeichen, 200us darüber</translation>
     </message>
     <message>
-        <location filename="../../rebindwidget.ui" line="1312"/>
+        <location filename="../../rebindwidget.ui" line="1380"/>
         <source>Delay will be the same as it was recorded</source>
         <translation variants="yes">
             <lengthvariant>Die Verzögerung ist dieselbe wie bei der Aufnahme</lengthvariant>
@@ -2756,48 +2783,48 @@ oder klicken Sie auf &quot;Beenden&quot; in den Einstellungen.</translation>
         </translation>
     </message>
     <message>
-        <location filename="../../rebindwidget.ui" line="1299"/>
+        <location filename="../../rebindwidget.ui" line="1367"/>
         <source>de&amp;fault</source>
         <translation>&amp;Standard</translation>
     </message>
     <message>
-        <location filename="../../rebindwidget.ui" line="1315"/>
+        <location filename="../../rebindwidget.ui" line="1383"/>
         <source>as t&amp;yped</source>
         <translation>&amp;Wie eingegeben</translation>
     </message>
     <message>
-        <location filename="../../rebindwidget.ui" line="1591"/>
+        <location filename="../../rebindwidget.ui" line="1658"/>
         <source>Clear</source>
         <translation>Leeren</translation>
     </message>
     <message>
-        <location filename="../../rebindwidget.ui" line="1621"/>
+        <location filename="../../rebindwidget.ui" line="1688"/>
         <source>Unbind</source>
         <translation>Zuordnung aufheben</translation>
     </message>
     <message>
-        <location filename="../../rebindwidget.ui" line="1628"/>
+        <location filename="../../rebindwidget.ui" line="1695"/>
         <source>Reset to Default</source>
         <translation>Auf Standard zurücksetzen</translation>
     </message>
     <message>
-        <location filename="../../rebindwidget.ui" line="1635"/>
+        <location filename="../../rebindwidget.ui" line="1702"/>
         <source>Cancel</source>
         <translation>Abbrechen</translation>
     </message>
     <message>
-        <location filename="../../rebindwidget.ui" line="1642"/>
+        <location filename="../../rebindwidget.ui" line="1709"/>
         <source>Apply</source>
         <translation>Anwenden</translation>
     </message>
     <message>
-        <location filename="../../rebindwidget.cpp" line="84"/>
+        <location filename="../../rebindwidget.cpp" line="90"/>
         <source>Tip: use xdg-open to launch a file or directory. For instance, to open your home folder:
   xdg-open </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../rebindwidget.cpp" line="463"/>
+        <location filename="../../rebindwidget.cpp" line="496"/>
         <source>Key %1 (%2) is pressed but never released.
 This will result in the key being pressed by the macro until you manually press the key itself and release it.
 
@@ -2808,7 +2835,7 @@ Dies führt dazu, dass die Taste vom Makro gedrückt wird, bis Sie die Taste sel
 Sind Sie sicher, dass Sie fortfahren möchten?</translation>
     </message>
     <message>
-        <location filename="../../rebindwidget.cpp" line="466"/>
+        <location filename="../../rebindwidget.cpp" line="499"/>
         <source>Key %1 (%2) is released but never pressed.
 This will have no observable effect unless the key is held down manually or by another macro.
 
@@ -2819,45 +2846,45 @@ Dies hat keine erkennbaren Auswirkungen, es sei denn, die Taste wird manuell ode
 Sind Sie sicher, dass Sie fortfahren möchten?</translation>
     </message>
     <message>
-        <location filename="../../rebindwidget.cpp" line="469"/>
+        <location filename="../../rebindwidget.cpp" line="502"/>
         <source>Macro warning</source>
         <translation>Makro-Warnung</translation>
     </message>
     <message>
-        <location filename="../../rebindwidget.cpp" line="811"/>
+        <location filename="../../rebindwidget.cpp" line="846"/>
         <source>Click Apply or manually edit the events.</source>
         <translation>Auf Anwenden klicken oder Ereignisse manuell bearbeiten.</translation>
     </message>
     <message>
-        <location filename="../../rebindwidget.cpp" line="849"/>
+        <location filename="../../rebindwidget.cpp" line="884"/>
         <source>Unknown key combination pressed</source>
         <translation>Unbekannte Tastenkombination gedrückt</translation>
     </message>
     <message>
-        <location filename="../../rebindwidget.cpp" line="849"/>
+        <location filename="../../rebindwidget.cpp" line="884"/>
         <source>An unknown key combination (%1, %2) has been pressed.
 Make sure your keyboard layout is set to English - United States while recording macros.</source>
         <translation>Es wurde eine unbekannte Tastenkombination (%1, %2) gedrückt.
 Vergewissern Sie sich, dass Ihre Tastaturbelegung auf Englisch - Vereinigte Staaten eingestellt ist, während Sie Makros aufzeichnen.</translation>
     </message>
     <message>
-        <location filename="../../rebindwidget.cpp" line="859"/>
+        <location filename="../../rebindwidget.cpp" line="894"/>
         <source>Stop Recording</source>
         <translatorcomment>Alternative: stoppen</translatorcomment>
         <translation>Aufzeichnung anhalten</translation>
     </message>
     <message>
-        <location filename="../../rebindwidget.cpp" line="860"/>
+        <location filename="../../rebindwidget.cpp" line="895"/>
         <source>Type your macro and press Stop Recording when finished.</source>
         <translation>Makro eingeben und danach auf &quot;Aufzeichnung anhalten&quot; klicken.</translation>
     </message>
     <message>
-        <location filename="../../rebindwidget.cpp" line="867"/>
+        <location filename="../../rebindwidget.cpp" line="902"/>
         <source>Click Start Recording or manually edit the events.</source>
         <translation>Auf &quot;Aufzeichnung starten&quot; klicken oder manuell Ereignisse manuell bearbeiten.</translation>
     </message>
     <message>
-        <location filename="../../rebindwidget.cpp" line="935"/>
+        <location filename="../../rebindwidget.cpp" line="972"/>
         <source>&quot;Record from all keyboards&quot; is only recommended if you do not have a keyboard managed by ckb-next.
 It currently only functions with an English - United States keyboard layout.
 Make sure your keyboard is switched to it before recording.</source>
@@ -2866,7 +2893,7 @@ Es funktioniert derzeit nur mit der Tastaturbelegung Englisch - Vereinigte Staat
 Vergewissern Sie sich, dass Ihre Tastatur vor der Aufnahme auf diese Belegung umgestellt ist.</translation>
     </message>
     <message>
-        <location filename="../../rebindwidget.cpp" line="938"/>
+        <location filename="../../rebindwidget.cpp" line="975"/>
         <source>Record from all keyboards</source>
         <translation>Von allen Tastaturen aufnehmen</translation>
     </message>
@@ -2874,100 +2901,98 @@ Vergewissern Sie sich, dass Ihre Tastatur vor der Aufnahme auf diese Belegung um
 <context>
     <name>SettingsWidget</name>
     <message>
-        <location filename="../../settingswidget.ui" line="61"/>
+        <location filename="../../settingswidget.ui" line="60"/>
         <source>No devices connected</source>
         <translation>Keine Geräte verbunden</translation>
     </message>
     <message>
-        <location filename="../../settingswidget.ui" line="143"/>
+        <location filename="../../settingswidget.ui" line="141"/>
         <source>Modifier keys</source>
         <translatorcomment>“Zusatztasten” is used by Windows</translatorcomment>
         <translation>Zusatztasten</translation>
     </message>
     <message>
-        <location filename="../../settingswidget.ui" line="334"/>
+        <location filename="../../settingswidget.ui" line="332"/>
         <source>These will override the keyboard profile. See &quot;Binding&quot; tab for more settings.</source>
         <translation>Damit wird das Tastaturprofil überschrieben. Siehe Zuordnung-Tab für weitere Einstellungen.</translation>
     </message>
     <message>
-        <location filename="../../settingswidget.ui" line="375"/>
+        <location filename="../../settingswidget.ui" line="372"/>
         <source>Application</source>
         <translation>Programm</translation>
     </message>
     <message>
-        <location filename="../../settingswidget.ui" line="389"/>
         <source>ckb-next will be started when you log in to your computer.</source>
-        <translation>ckb-next wird automatisch gestartet, wenn sie sich an diesem Computer anmelden.</translation>
+        <translation type="vanished">ckb-next wird automatisch gestartet, wenn sie sich an diesem Computer anmelden.</translation>
     </message>
     <message>
-        <location filename="../../settingswidget.ui" line="392"/>
         <source>Start ckb-next at login</source>
-        <translation>ckb-next mit Anmeldung starten</translation>
+        <translation type="vanished">ckb-next mit Anmeldung starten</translation>
     </message>
     <message>
-        <location filename="../../settingswidget.ui" line="399"/>
+        <location filename="../../settingswidget.ui" line="386"/>
         <source>You will be notified when new firmware versions are available. You&apos;ll have the option to install them immediately or wait until later.</source>
         <translation>Sie werden benachrichtigt, wenn neue Firmware-Versionen verfügbar sind. Sie haben dann die Möglichkeit, diese sofort zu installieren oder bis zu einem späteren Zeitpunkt zu warten.</translation>
     </message>
     <message>
-        <location filename="../../settingswidget.ui" line="402"/>
+        <location filename="../../settingswidget.ui" line="389"/>
         <source>Check for new firmware automatically</source>
         <translation>Automatisch nach Firmware-Updates suchen</translation>
     </message>
     <message>
-        <location filename="../../settingswidget.ui" line="412"/>
+        <location filename="../../settingswidget.ui" line="399"/>
         <source>Check for ckb-next updates on startup</source>
         <translation>Beim Starten nach ckb-next-Updates suchen</translation>
     </message>
     <message>
-        <location filename="../../settingswidget.ui" line="422"/>
+        <location filename="../../settingswidget.ui" line="409"/>
         <source>Enable this only if you have a high DPI monitor and the ckb-next window shows up too small.</source>
         <translation>Aktivieren Sie diese Option nur, wenn Sie einen Monitor mit hohem DPI-Wert haben und das ckb-next-Fenster zu klein dargestellt wird.</translation>
     </message>
     <message>
-        <location filename="../../settingswidget.ui" line="425"/>
+        <location filename="../../settingswidget.ui" line="412"/>
         <source>Enable HiDPI Scaling</source>
         <translation>HiDPI-Skalierung aktivieren</translation>
     </message>
     <message>
-        <location filename="../../settingswidget.ui" line="439"/>
-        <location filename="../../settingswidget.cpp" line="197"/>
+        <location filename="../../settingswidget.ui" line="426"/>
+        <location filename="../../settingswidget.cpp" line="208"/>
         <source>Generate report</source>
         <translation>Bericht erzeugen</translation>
     </message>
     <message>
-        <location filename="../../settingswidget.ui" line="464"/>
+        <location filename="../../settingswidget.ui" line="451"/>
         <source>Check for updates</source>
         <translation>Nach Updates suchen</translation>
     </message>
     <message>
-        <location filename="../../settingswidget.ui" line="471"/>
-        <location filename="../../settingswidget.cpp" line="286"/>
+        <location filename="../../settingswidget.ui" line="458"/>
+        <location filename="../../settingswidget.cpp" line="297"/>
         <source>Uninstall ckb-next</source>
         <translation>ckb-next deinstallieren</translation>
     </message>
     <message>
-        <location filename="../../settingswidget.ui" line="589"/>
+        <location filename="../../settingswidget.ui" line="576"/>
         <source>About Qt</source>
         <translation>Über Qt</translation>
     </message>
     <message>
-        <location filename="../../settingswidget.ui" line="596"/>
+        <location filename="../../settingswidget.ui" line="583"/>
         <source>Quit</source>
         <translation>Beenden</translation>
     </message>
     <message>
-        <location filename="../../settingswidget.cpp" line="92"/>
+        <location filename="../../settingswidget.cpp" line="110"/>
         <source>The ckb-next development team</source>
         <translation>Das ckb-next Entwickler-Team</translation>
     </message>
     <message>
-        <location filename="../../settingswidget.cpp" line="96"/>
+        <location filename="../../settingswidget.cpp" line="114"/>
         <source>&lt;br/&gt;Special thanks to &lt;a href=&quot;https://github.com/tekezo&quot; style=&quot;text-decoration:none;&quot;&gt;tekezo&lt;/a&gt; for &lt;a href=&quot;https://github.com/tekezo/Karabiner-VirtualHIDDevice&quot; style=&quot;text-decoration:none;&quot;&gt;VirtualHIDDevice&lt;/a&gt;.</source>
         <translation>&lt;br/&gt;Besonderer Dank an &lt;a href=&quot;https://github.com/tekezo&quot; style=&quot;text-decoration:none;&quot;&gt;tekezo&lt;/a&gt; für &lt;a href=&quot;https://github.com/tekezo/Karabiner-VirtualHIDDevice&quot; style=&quot;text-decoration:none;&quot;&gt;VirtualHIDDevice&lt;/a&gt;.</translation>
     </message>
     <message>
-        <location filename="../../settingswidget.cpp" line="197"/>
+        <location filename="../../settingswidget.cpp" line="208"/>
         <source>This will collect software logs, as well as information about the Corsair devices in your system.
 
 Make sure they are plugged in and click OK.</source>
@@ -2976,25 +3001,25 @@ Make sure they are plugged in and click OK.</source>
 Vergewissern Sie sich, dass die Geräte angeschlossen sind, und klicken Sie auf OK.</translation>
     </message>
     <message>
-        <location filename="../../settingswidget.cpp" line="211"/>
-        <location filename="../../settingswidget.cpp" line="231"/>
+        <location filename="../../settingswidget.cpp" line="222"/>
+        <location filename="../../settingswidget.cpp" line="242"/>
         <source>Error executing ckb-next-dev-detect</source>
         <translation>Fehler beim Ausführen von ckb-next-dev-detect</translation>
     </message>
     <message>
-        <location filename="../../settingswidget.cpp" line="211"/>
+        <location filename="../../settingswidget.cpp" line="222"/>
         <source>An error occurred while trying to execute ckb-next-dev-detect.
 File not found or not executable.</source>
         <translation>Beim Versuch, ckb-next-dev-detect auszuführen, ist ein Fehler aufgetreten.
 Datei nicht gefunden oder nicht ausführbar.</translation>
     </message>
     <message>
-        <location filename="../../settingswidget.cpp" line="216"/>
+        <location filename="../../settingswidget.cpp" line="227"/>
         <source>Generating Report</source>
         <translation>Bericht wird erzeugt</translation>
     </message>
     <message>
-        <location filename="../../settingswidget.cpp" line="227"/>
+        <location filename="../../settingswidget.cpp" line="238"/>
         <source>An error occurred while trying to execute ckb-next-dev-detect.
 
 </source>
@@ -3003,44 +3028,44 @@ Datei nicht gefunden oder nicht ausführbar.</translation>
 </translation>
     </message>
     <message>
-        <location filename="../../settingswidget.cpp" line="230"/>
+        <location filename="../../settingswidget.cpp" line="241"/>
         <source>Return code %1</source>
         <translation>Rückgabecode %1</translation>
     </message>
     <message>
-        <location filename="../../settingswidget.cpp" line="236"/>
+        <location filename="../../settingswidget.cpp" line="247"/>
         <source>Select output directory</source>
         <translation>Ausgabe-Ordner wählen</translation>
     </message>
     <message>
-        <location filename="../../settingswidget.cpp" line="239"/>
+        <location filename="../../settingswidget.cpp" line="250"/>
         <source>Report generated successfully</source>
         <translation>Bericht erfolgreich erzeugt</translation>
     </message>
     <message>
-        <location filename="../../settingswidget.cpp" line="239"/>
+        <location filename="../../settingswidget.cpp" line="250"/>
         <source>The report has been generated successfully.</source>
         <translation>Der Bericht wurde erfolgreich erzeugt.</translation>
     </message>
     <message>
-        <location filename="../../settingswidget.cpp" line="249"/>
+        <location filename="../../settingswidget.cpp" line="260"/>
         <source>Error writing report</source>
         <translation>Fehler beim Speichern des Berichts</translation>
     </message>
     <message>
-        <location filename="../../settingswidget.cpp" line="249"/>
+        <location filename="../../settingswidget.cpp" line="260"/>
         <source>Could not write report to the selected directory.
 Please pick a different one and try again.</source>
         <translation>Der Bericht konnte nicht in das ausgewählte Verzeichnis gespeichert werden.
 Bitte wählen Sie ein anderes Verzeichnis und versuchen Sie es erneut.</translation>
     </message>
     <message>
-        <location filename="../../settingswidget.cpp" line="268"/>
+        <location filename="../../settingswidget.cpp" line="279"/>
         <source>Checking...</source>
         <translation>Wird überprüft...</translation>
     </message>
     <message>
-        <location filename="../../settingswidget.cpp" line="286"/>
+        <location filename="../../settingswidget.cpp" line="297"/>
         <source>WARNING: Clicking OK will uninstall ckb-next and any older versions of the software from your system.
 
 Your settings and lighting profiles will be preserved.</source>
@@ -3049,12 +3074,12 @@ Your settings and lighting profiles will be preserved.</source>
 Ihre Einstellungen und Beleuchtungsprofile bleiben erhalten.</translation>
     </message>
     <message>
-        <location filename="../../settingswidget.cpp" line="298"/>
+        <location filename="../../settingswidget.cpp" line="309"/>
         <source>Please restart ckb-next</source>
         <translation>Bitte starten Sie ckb-next neu</translation>
     </message>
     <message>
-        <location filename="../../settingswidget.cpp" line="298"/>
+        <location filename="../../settingswidget.cpp" line="309"/>
         <source>Please click the Quit button and restart ckb-next for the changes to take effect.</source>
         <translation>Bitte auf Beenden klicken und ckb-next neu starten, damit die Änderungen wirksam werden.</translation>
     </message>

--- a/src/gui/resources/translations/el.ts
+++ b/src/gui/resources/translations/el.ts
@@ -95,9 +95,9 @@
         <location filename="../../animsettingdialog.ui" line="169"/>
         <location filename="../../animsettingdialog.ui" line="183"/>
         <location filename="../../animsettingdialog.ui" line="200"/>
-        <location filename="../../animsettingdialog.cpp" line="216"/>
-        <location filename="../../animsettingdialog.cpp" line="342"/>
-        <location filename="../../animsettingdialog.cpp" line="358"/>
+        <location filename="../../animsettingdialog.cpp" line="225"/>
+        <location filename="../../animsettingdialog.cpp" line="352"/>
+        <location filename="../../animsettingdialog.cpp" line="369"/>
         <source>seconds</source>
         <translation>δευτερόλεπτα</translation>
     </message>
@@ -193,81 +193,81 @@
         <translation>Περιγραφή</translation>
     </message>
     <message>
-        <location filename="../../animsettingdialog.cpp" line="26"/>
+        <location filename="../../animsettingdialog.cpp" line="33"/>
         <source> Animation</source>
         <translation> Animation</translation>
     </message>
     <message>
-        <location filename="../../animsettingdialog.cpp" line="33"/>
+        <location filename="../../animsettingdialog.cpp" line="40"/>
         <source>&lt;b&gt;Animation&lt;/b&gt;</source>
         <translation>&lt;b&gt;Animation&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../../animsettingdialog.cpp" line="203"/>
+        <location filename="../../animsettingdialog.cpp" line="211"/>
         <source>&lt;b&gt;Playback&lt;/b&gt;</source>
         <translation>&lt;b&gt;Αναπαραγωγή&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../../animsettingdialog.cpp" line="208"/>
+        <location filename="../../animsettingdialog.cpp" line="216"/>
         <source>Duration:</source>
         <translation>Διάρκεια:</translation>
     </message>
     <message>
-        <location filename="../../animsettingdialog.cpp" line="220"/>
+        <location filename="../../animsettingdialog.cpp" line="229"/>
         <source>Start with mode</source>
         <translation>Εκκίνηση με το mode</translation>
     </message>
     <message>
-        <location filename="../../animsettingdialog.cpp" line="228"/>
+        <location filename="../../animsettingdialog.cpp" line="237"/>
         <source>Start with key press</source>
         <translation>Εκκίνηση με πάτημα πλήκτρου</translation>
     </message>
     <message>
-        <location filename="../../animsettingdialog.cpp" line="240"/>
+        <location filename="../../animsettingdialog.cpp" line="249"/>
         <source>on pressed key</source>
         <translation>στο πιεσμένο πλήκτρο</translation>
     </message>
     <message>
-        <location filename="../../animsettingdialog.cpp" line="241"/>
+        <location filename="../../animsettingdialog.cpp" line="250"/>
         <source>on whole keyboard</source>
         <translation>σε ολόκληρο το πληκτρολόγιο</translation>
     </message>
     <message>
-        <location filename="../../animsettingdialog.cpp" line="242"/>
+        <location filename="../../animsettingdialog.cpp" line="251"/>
         <source>on keyboard (once)</source>
         <translation>στο πληκτρολόγιο (μια φορά)</translation>
     </message>
     <message>
-        <location filename="../../animsettingdialog.cpp" line="246"/>
+        <location filename="../../animsettingdialog.cpp" line="255"/>
         <source>every time</source>
         <translation>κάθε φορά</translation>
     </message>
     <message>
-        <location filename="../../animsettingdialog.cpp" line="247"/>
+        <location filename="../../animsettingdialog.cpp" line="256"/>
         <source>only once</source>
         <translation>μόνο μια φορά</translation>
     </message>
     <message>
-        <location filename="../../animsettingdialog.cpp" line="285"/>
-        <location filename="../../animsettingdialog.cpp" line="297"/>
+        <location filename="../../animsettingdialog.cpp" line="294"/>
+        <location filename="../../animsettingdialog.cpp" line="306"/>
         <source>Repeat:</source>
         <translation>Επανάληψη:</translation>
     </message>
     <message>
-        <location filename="../../animsettingdialog.cpp" line="295"/>
-        <location filename="../../animsettingdialog.cpp" line="307"/>
+        <location filename="../../animsettingdialog.cpp" line="304"/>
+        <location filename="../../animsettingdialog.cpp" line="316"/>
         <source>times</source>
         <translation>φορές</translation>
     </message>
     <message>
-        <location filename="../../animsettingdialog.cpp" line="309"/>
-        <location filename="../../animsettingdialog.cpp" line="312"/>
+        <location filename="../../animsettingdialog.cpp" line="318"/>
+        <location filename="../../animsettingdialog.cpp" line="321"/>
         <source>Forever</source>
         <translation>Για πάντα</translation>
     </message>
     <message>
-        <location filename="../../animsettingdialog.cpp" line="360"/>
-        <location filename="../../animsettingdialog.cpp" line="364"/>
+        <location filename="../../animsettingdialog.cpp" line="371"/>
+        <location filename="../../animsettingdialog.cpp" line="375"/>
         <source>Stop after:</source>
         <translation>Διακοπή μετά από:</translation>
     </message>
@@ -921,7 +921,7 @@
         <translation>Ένταση ένδειξης:</translation>
     </message>
     <message>
-        <location filename="../../kperfwidget.cpp" line="237"/>
+        <location filename="../../kperfwidget.cpp" line="236"/>
         <source>Copy performance settings to:</source>
         <translation>Αντιγραφή ρυθμίσεων απόδοσης στο:</translation>
     </message>
@@ -933,40 +933,28 @@
         <translation type="vanished">Έξοδος</translation>
     </message>
     <message>
-        <location filename="../../kstatusnotifier/kstatusnotifieritem.cpp" line="521"/>
-        <location filename="../../kstatusnotifier/kstatusnotifieritem.cpp" line="1159"/>
+        <location filename="../../kstatusnotifier/kstatusnotifieritem.cpp" line="516"/>
+        <location filename="../../kstatusnotifier/kstatusnotifieritem.cpp" line="1171"/>
         <source>&amp;Minimize</source>
         <comment>@action:inmenu</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../kstatusnotifier/kstatusnotifieritem.cpp" line="876"/>
+        <location filename="../../kstatusnotifier/kstatusnotifieritem.cpp" line="892"/>
         <source>Quit</source>
         <comment>@action:inmenu</comment>
         <translation type="unfinished">Έξοδος</translation>
     </message>
     <message>
-        <location filename="../../kstatusnotifier/kstatusnotifieritem.cpp" line="1156"/>
+        <location filename="../../kstatusnotifier/kstatusnotifieritem.cpp" line="1168"/>
         <source>&amp;Restore</source>
         <comment>@action:inmenu</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../kstatusnotifier/kstatusnotifieritem.cpp" line="1172"/>
-        <source>Confirm Quit From System Tray</source>
-        <comment>@title:window</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../kstatusnotifier/kstatusnotifieritem.cpp" line="1173"/>
-        <source>&lt;qt&gt;Are you sure you want to quit &lt;b&gt;%1&lt;/b&gt;?&lt;/qt&gt;</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../kstatusnotifier/kstatusnotifieritem.cpp" line="1178"/>
         <source>Quit</source>
         <comment>@action:button</comment>
-        <translation type="unfinished">Έξοδος</translation>
+        <translation type="obsolete">Έξοδος</translation>
     </message>
 </context>
 <context>
@@ -1262,6 +1250,14 @@ The binding will not function until winlock has been disabled.</source>
         <location filename="../../kblightwidget.cpp" line="119"/>
         <source>%1 keys selected</source>
         <translation>%1 πλήκτρα επιλεγμένα</translation>
+    </message>
+</context>
+<context>
+    <name>KbManager</name>
+    <message>
+        <location filename="../../kbmanager.cpp" line="42"/>
+        <source>Please enable &quot;Turn lights off when idle&quot; before using --sleep</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -1588,7 +1584,7 @@ An attempt will be made to import as many as possible.</source>
     </message>
     <message>
         <location filename="../../kbwidget.ui" line="552"/>
-        <location filename="../../kbwidget.cpp" line="402"/>
+        <location filename="../../kbwidget.cpp" line="412"/>
         <source>Check for updates</source>
         <translation>Έλεγχος για ενημερώσεις</translation>
     </message>
@@ -1618,17 +1614,17 @@ An attempt will be made to import as many as possible.</source>
         <translation>Αποθήκευση στη συσκευή</translation>
     </message>
     <message>
-        <location filename="../../kbwidget.cpp" line="116"/>
+        <location filename="../../kbwidget.cpp" line="120"/>
         <source>Saving to hardware is not supported on this device.</source>
         <translation>Δεν υποστηρίζεται η αποθήκευση στη συγκεκριμένη συσκευή.</translation>
     </message>
     <message>
-        <location filename="../../kbwidget.cpp" line="178"/>
+        <location filename="../../kbwidget.cpp" line="182"/>
         <source>This device does not support setting the poll rate through software.</source>
         <translation>Αυτή η συσκευή δεν υποστηρίζει ρύθμιση του poll rate μέσω του λογισμικού.</translation>
     </message>
     <message>
-        <location filename="../../kbwidget.cpp" line="202"/>
+        <location filename="../../kbwidget.cpp" line="206"/>
         <source>Manage profiles...</source>
         <translation>Διαχείριση προφίλ...</translation>
     </message>
@@ -1637,64 +1633,64 @@ An attempt will be made to import as many as possible.</source>
         <translation type="vanished">Νέο mode...</translation>
     </message>
     <message>
-        <location filename="../../kbwidget.cpp" line="272"/>
+        <location filename="../../kbwidget.cpp" line="282"/>
         <source>Rename...</source>
         <translation>Μετονομασία...</translation>
     </message>
     <message>
-        <location filename="../../kbwidget.cpp" line="273"/>
+        <location filename="../../kbwidget.cpp" line="283"/>
         <source>Duplicate</source>
         <translation>Δημιουργία διπλότυπου</translation>
     </message>
     <message>
-        <location filename="../../kbwidget.cpp" line="274"/>
+        <location filename="../../kbwidget.cpp" line="284"/>
         <source>Delete</source>
         <translation>Διαγραφή</translation>
     </message>
     <message>
-        <location filename="../../kbwidget.cpp" line="279"/>
+        <location filename="../../kbwidget.cpp" line="289"/>
         <source>Move Up</source>
         <translation>Μετακίνηση Πάνω</translation>
     </message>
     <message>
-        <location filename="../../kbwidget.cpp" line="281"/>
+        <location filename="../../kbwidget.cpp" line="291"/>
         <source>Manage Events</source>
         <translation>Διαχείριση Συμβάντων</translation>
     </message>
     <message>
-        <location filename="../../kbwidget.cpp" line="285"/>
+        <location filename="../../kbwidget.cpp" line="295"/>
         <source>Move Down</source>
         <translation>Μετακίνηση Κάτω</translation>
     </message>
     <message>
-        <location filename="../../kbwidget.cpp" line="314"/>
+        <location filename="../../kbwidget.cpp" line="324"/>
         <source>Delete mode</source>
         <translation>Διαγραφή mode</translation>
     </message>
     <message>
-        <location filename="../../kbwidget.cpp" line="314"/>
+        <location filename="../../kbwidget.cpp" line="324"/>
         <source>Are you sure you want to delete this mode?</source>
         <translation>Είστε σίγουροι ότι θέλετε να διαγράψετε αυτό το mode;</translation>
     </message>
     <message>
-        <location filename="../../kbwidget.cpp" line="407"/>
+        <location filename="../../kbwidget.cpp" line="417"/>
         <source>Up to date</source>
         <translation>Ενημερωμένο</translation>
     </message>
     <message>
-        <location filename="../../kbwidget.cpp" line="409"/>
+        <location filename="../../kbwidget.cpp" line="419"/>
         <source>Upgrade to v%1</source>
         <translation>Αναβάθμιση στην έκδοση %1</translation>
     </message>
     <message>
-        <location filename="../../kbwidget.cpp" line="426"/>
+        <location filename="../../kbwidget.cpp" line="436"/>
         <source>Checking...</source>
         <translation>Γίνεται έλεγχος...</translation>
     </message>
     <message>
-        <location filename="../../kbwidget.cpp" line="434"/>
-        <location filename="../../kbwidget.cpp" line="438"/>
-        <location filename="../../kbwidget.cpp" line="441"/>
+        <location filename="../../kbwidget.cpp" line="444"/>
+        <location filename="../../kbwidget.cpp" line="448"/>
+        <location filename="../../kbwidget.cpp" line="451"/>
         <source>Firmware update</source>
         <translation>Ενημέρωση firmware</translation>
     </message>
@@ -1703,37 +1699,37 @@ An attempt will be made to import as many as possible.</source>
         <translation type="vanished">&lt;center&gt;Υπάρχει καινούργιο firmware διαθέσιμο για αυτή τη συσκευή.&lt;br /&gt;Ωστόσο, απαιτεί μια νεότερη έκδοση του ckb-next.&lt;br /&gt;Παρακαλώ ενημερώστε το ckb-next και δοκιμάστε ξανά.&lt;/center&gt;</translation>
     </message>
     <message>
-        <location filename="../../kbwidget.cpp" line="434"/>
+        <location filename="../../kbwidget.cpp" line="444"/>
         <source>&lt;center&gt;There was a problem getting the status for this device.&lt;br /&gt;Would you like to select a file manually?&lt;/center&gt;</source>
         <translation>&lt;center&gt;Υπήρξε πρόβλημα λήψης πληροφοριών για τη συσκευή.&lt;br /&gt;Θα θέλατε να επιλέξετε ένα αρχείο;&lt;/center&gt;</translation>
     </message>
     <message>
-        <location filename="../../kbwidget.cpp" line="438"/>
+        <location filename="../../kbwidget.cpp" line="448"/>
         <source>&lt;center&gt;There is a new firmware available for this device (v%1).&lt;br /&gt;However, it requires a newer version of ckb-next.&lt;br /&gt;Please upgrade ckb-next and try again.&lt;/center&gt;</source>
         <translation>&lt;center&gt;Υπάρχει καινούργιο firmware διαθέσιμο για αυτή τη συσκευή (v%1).&lt;br /&gt;Ωστόσο, απαιτεί μια νεότερη έκδοση του ckb-next.&lt;br /&gt;Παρακαλώ ενημερώστε το ckb-next και δοκιμάστε ξανά.&lt;/center&gt;</translation>
     </message>
     <message>
-        <location filename="../../kbwidget.cpp" line="441"/>
+        <location filename="../../kbwidget.cpp" line="451"/>
         <source>&lt;center&gt;Your firmware is already up to date.&lt;br /&gt;Would you like to select a file manually?&lt;/center&gt;</source>
         <translation>&lt;center&gt;Το firmware είναι ήδη ενημερωμένο.&lt;br /&gt;Θα θέλατε να επιλέξετε ένα αρχείο;&lt;/center&gt;</translation>
     </message>
     <message>
-        <location filename="../../kbwidget.cpp" line="453"/>
+        <location filename="../../kbwidget.cpp" line="463"/>
         <source>Select firmware file</source>
         <translation>Επιλογή αρχείου firmware</translation>
     </message>
     <message>
-        <location filename="../../kbwidget.cpp" line="453"/>
+        <location filename="../../kbwidget.cpp" line="463"/>
         <source>Firmware blobs (*.bin)</source>
         <translation>Αρχεία firmware (*.bin)</translation>
     </message>
     <message>
-        <location filename="../../kbwidget.cpp" line="458"/>
+        <location filename="../../kbwidget.cpp" line="468"/>
         <source>Error</source>
         <translation>Σφάλμα</translation>
     </message>
     <message>
-        <location filename="../../kbwidget.cpp" line="458"/>
+        <location filename="../../kbwidget.cpp" line="468"/>
         <source>&lt;center&gt;File could not be read.&lt;/center&gt;</source>
         <translation>&lt;center&gt;Δεν ήταν δυνατή η ανάγνωση του αρχείου.&lt;/center&gt;</translation>
     </message>
@@ -2124,7 +2120,7 @@ An attempt will be made to import as many as possible.</source>
         <translation>Αντιγραφή σε mode...</translation>
     </message>
     <message>
-        <location filename="../../mperfwidget.cpp" line="350"/>
+        <location filename="../../mperfwidget.cpp" line="357"/>
         <source>Copy performance settings to:</source>
         <translation>Αντιγραφή ρυθμίσεων απόδοσης στο:</translation>
     </message>
@@ -2227,12 +2223,12 @@ An attempt will be made to import as many as possible.</source>
         <translation>Σχετικά</translation>
     </message>
     <message>
-        <location filename="../../mainwindow.cpp" line="135"/>
+        <location filename="../../mainwindow.cpp" line="136"/>
         <source>Restore</source>
         <translation>Επαναφορά</translation>
     </message>
     <message>
-        <location filename="../../mainwindow.cpp" line="136"/>
+        <location filename="../../mainwindow.cpp" line="137"/>
         <source>Quit</source>
         <translation>Έξοδος</translation>
     </message>
@@ -2241,98 +2237,98 @@ An attempt will be made to import as many as possible.</source>
         <translation type="vanished">Μονόχρωμο Εικονίδιο</translation>
     </message>
     <message>
-        <location filename="../../mainwindow.cpp" line="162"/>
+        <location filename="../../mainwindow.cpp" line="163"/>
         <source>Settings</source>
         <translation>Ρυθμίσεις</translation>
     </message>
     <message>
-        <location filename="../../mainwindow.cpp" line="170"/>
+        <location filename="../../mainwindow.cpp" line="171"/>
         <source>The ckb-next daemon is not running. This program will &lt;b&gt;not&lt;/b&gt; work without it!</source>
         <translation>Το ckb-next-daemon δεν τρέχει. Αυτό το πρόγραμμα &lt;b&gt;δεν&lt;/b&gt; θα λειτουργήσει χωρίς αυτό!</translation>
     </message>
     <message>
-        <location filename="../../mainwindow.cpp" line="172"/>
+        <location filename="../../mainwindow.cpp" line="173"/>
         <source>Start it once with:</source>
         <translation>Εκκινήστε το μια φορά με:</translation>
     </message>
     <message>
-        <location filename="../../mainwindow.cpp" line="174"/>
+        <location filename="../../mainwindow.cpp" line="175"/>
         <source>Enable it for every boot:</source>
         <translation>Ενεργοποιήστε το για κάθε εκκίνηση:</translation>
     </message>
     <message>
-        <location filename="../../mainwindow.cpp" line="176"/>
+        <location filename="../../mainwindow.cpp" line="177"/>
         <source>If &quot;Unit ckb-next-daemon.service is masked.&quot;, unmask it first and try again:</source>
         <translation>Αν &quot;Unit ckb-next-daemon.service is masked.&quot;, τότε ξεμασκαρέψτε το και προσπαθήστε ξανά:</translation>
     </message>
     <message>
-        <location filename="../../mainwindow.cpp" line="179"/>
+        <location filename="../../mainwindow.cpp" line="180"/>
         <source>Start and enable it with:</source>
         <translation>Εκκινήστε και ενεργοποιήστε το με:</translation>
     </message>
     <message>
-        <location filename="../../mainwindow.cpp" line="205"/>
+        <location filename="../../mainwindow.cpp" line="206"/>
         <source>The ckb-next daemon is not running.</source>
         <translation>Το ckb-next-daemon δεν τρέχει.</translation>
     </message>
     <message>
-        <location filename="../../mainwindow.cpp" line="292"/>
+        <location filename="../../mainwindow.cpp" line="293"/>
         <source>Driver inactive</source>
         <translation>Ο driver είναι αδρανής</translation>
     </message>
     <message>
-        <location filename="../../mainwindow.cpp" line="299"/>
+        <location filename="../../mainwindow.cpp" line="300"/>
         <source>&lt;br /&gt;&lt;br /&gt;&lt;b&gt;Warning:&lt;/b&gt; Driver version mismatch (</source>
         <translation>&lt;br /&gt;&lt;br /&gt;&lt;b&gt;Προσοχή:&lt;/b&gt; Ασυμφωνία έκδοσης του driver (</translation>
     </message>
     <message>
-        <location filename="../../mainwindow.cpp" line="299"/>
+        <location filename="../../mainwindow.cpp" line="300"/>
         <source>). Please upgrade ckb-next</source>
         <translation>). Παρακαλώ ενημερώστε το ckb-next</translation>
     </message>
     <message>
-        <location filename="../../mainwindow.cpp" line="299"/>
+        <location filename="../../mainwindow.cpp" line="300"/>
         <source>. If the problem persists, try rebooting.</source>
         <translation>.&lt;br /&gt;Αν το πρόβλημα παραμένει, επανεκκινήστε το σύστημά σας.</translation>
     </message>
     <message>
-        <location filename="../../mainwindow.cpp" line="310"/>
+        <location filename="../../mainwindow.cpp" line="311"/>
         <source>&lt;br /&gt;&lt;b&gt;Warning:&lt;/b&gt; System Extension by &quot;Fumihiko Takayama&quot; is not allowed in Security &amp; Privacy. Please allow it and then unplug and replug your devices.</source>
         <translation>&lt;br /&gt;&lt;b&gt;Ποσοχή:&lt;/b&gt; Η επέκταση από &quot;Fumihiko Takayama&quot; δεν επιτρέπεται στο Ασφάλεια και απόρρητο. Επιτρέψτε το και επανασυνδέστε τις συσκευές.</translation>
     </message>
     <message>
-        <location filename="../../mainwindow.cpp" line="312"/>
+        <location filename="../../mainwindow.cpp" line="313"/>
         <source>&lt;br /&gt;&lt;b&gt;Warning:&lt;/b&gt; Make sure ckb-next-daemon is allowed in Security &amp; Privacy -&gt; Input monitoring.&lt;br /&gt;Please allow for up to 10 seconds for the daemon restart prompt to show up after allowing input monitoring.</source>
         <translation>&lt;br /&gt;&lt;b&gt;Προσοχή:&lt;/b&gt; Σιγουρευτείτε ότι το ckb-next-daemon επιτρέπεται στο Ασφάλεια και απόρρητο -&gt; Παρακολούθησή εισόδου.&lt;/br /&gt;Παρακαλώ επιτρέψτε μέχρι 10 δευτερόλεπτα μέχρι να εμφανιστεί η ειδοποίηση ενεργοποιήσης του daemon.</translation>
     </message>
     <message>
-        <location filename="../../mainwindow.cpp" line="322"/>
+        <location filename="../../mainwindow.cpp" line="323"/>
         <source>&lt;br /&gt;&lt;b&gt;Warning:&lt;/b&gt; The uinput module could not be loaded. If this issue persists after rebooting, compile a kernel with CONFIG_INPUT_UINPUT=y.</source>
         <translation>&lt;br /&gt;&lt;b&gt;Προσοχή:&lt;/b&gt; Δεν ήταν δυνατό να φορτωθεί το άρθρωμα πυρήνα uinput. Αν αυτο το πρόβλημα παραμένει μετά από επανεκκίνηση, μεταγλωττίστε πυρήνα με CONFIG_INPUT_UINPUT=y.</translation>
     </message>
     <message>
-        <location filename="../../mainwindow.cpp" line="325"/>
+        <location filename="../../mainwindow.cpp" line="326"/>
         <source>No devices connected</source>
         <translation>Δεν υπάρχουν συνδεδεμένες συσκευές</translation>
     </message>
     <message>
-        <location filename="../../mainwindow.cpp" line="328"/>
+        <location filename="../../mainwindow.cpp" line="329"/>
         <source>1 device connected</source>
         <translation>1 συσκευή συνδεδεμένη</translation>
     </message>
     <message>
-        <location filename="../../mainwindow.cpp" line="330"/>
+        <location filename="../../mainwindow.cpp" line="331"/>
         <source>%1 devices connected</source>
         <translation>%1 συσκευές συνδεδεμένες</translation>
     </message>
     <message>
-        <location filename="../../mainwindow.cpp" line="361"/>
+        <location filename="../../mainwindow.cpp" line="362"/>
         <source>A new firmware is available for your %1 (v%2)
 Would you like to install it now?</source>
         <translation>Υπάρχει νέο firmware για το %1 σας (v%2) Θα θέλατε να το εγκαταστήσετε τώρα;</translation>
     </message>
     <message>
-        <location filename="../../mainwindow.cpp" line="377"/>
+        <location filename="../../mainwindow.cpp" line="378"/>
         <source>ckb-next will still run in the background.
 To close it, choose Quit from the tray menu
 or click &quot;Quit&quot; on the Settings screen.</source>
@@ -2341,12 +2337,12 @@ or click &quot;Quit&quot; on the Settings screen.</source>
 ή κάντε κλικ στο &quot;Έξοδος&quot; στο παράθυρο ρυθμίσεων.</translation>
     </message>
     <message>
-        <location filename="../../mainwindow.cpp" line="536"/>
+        <location filename="../../mainwindow.cpp" line="539"/>
         <source>Update to v</source>
         <translation>Ενημέρωση στο v</translation>
     </message>
     <message>
-        <location filename="../../mainwindow.cpp" line="541"/>
+        <location filename="../../mainwindow.cpp" line="544"/>
         <source>Up to date</source>
         <translation>Ενημερωμένο</translation>
     </message>
@@ -2396,7 +2392,7 @@ or click &quot;Quit&quot; on the Settings screen.</source>
         <translation type="vanished">Εκκινήστε και ενεργοποιήστε το με:</translation>
     </message>
     <message>
-        <location filename="../../main.cpp" line="68"/>
+        <location filename="../../main.cpp" line="69"/>
         <source>Starts in background, without displaying the main window.</source>
         <translation>Εκκινείται στο παρασκήνιο, χωρίς να προβάλει το κυρίως παράθυρο.</translation>
     </message>
@@ -2405,42 +2401,47 @@ or click &quot;Quit&quot; on the Settings screen.</source>
         <translation type="vanished">Ομοίως με το background.</translation>
     </message>
     <message>
-        <location filename="../../main.cpp" line="73"/>
+        <location filename="../../main.cpp" line="74"/>
         <source>Causes already running instance (if any) to exit.</source>
         <translation>Αναγκάζει το λογισμικό (αν τρέχει) να κλείσει.</translation>
     </message>
     <message>
-        <location filename="../../main.cpp" line="76"/>
+        <location filename="../../main.cpp" line="77"/>
         <source>Switches to the profile with the specified name on all devices.</source>
         <translation>Αλλάζει στο προφίλ με το καθορισμένο όνομα σε όλες τις συσκευές.</translation>
     </message>
     <message>
-        <location filename="../../main.cpp" line="79"/>
+        <location filename="../../main.cpp" line="80"/>
         <source>Switches to the mode either in the current profile, or in the one specified by --profile</source>
         <translation>Αλλάζει στο mode είτε στο τρέχων προφίλ, ή σε προφιλ ορισμένο μέσω του --profile</translation>
     </message>
     <message>
-        <location filename="../../main.cpp" line="82"/>
+        <location filename="../../main.cpp" line="83"/>
+        <source>Turns the lights off as if the system was idling.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../main.cpp" line="86"/>
         <source>Delays application start for 5 seconds</source>
         <translation>Καθυστερεί την εκκίνηση του προγράμματος για 5 δευτερόλεπτα</translation>
     </message>
     <message>
-        <location filename="../../main.cpp" line="83"/>
+        <location filename="../../main.cpp" line="87"/>
         <source>Disables the daemon not running popup</source>
         <translation>Απενεργοποιεί το αναδυόμενο παράθυρο &quot;το ckb-next-daemon δεν εκτελείται&quot;</translation>
     </message>
     <message>
-        <location filename="../../main.cpp" line="97"/>
+        <location filename="../../main.cpp" line="101"/>
         <source>Enables the KeyWidget debug window</source>
         <translation>Ενεργοποιεί το παράθυρο αποσφαλμάτωσης KeyWidget</translation>
     </message>
     <message>
-        <location filename="../../main.cpp" line="299"/>
+        <location filename="../../main.cpp" line="320"/>
         <source>Downgrade Warning</source>
         <translation>Προειδοποίηση Υποβάθιμσης</translation>
     </message>
     <message>
-        <location filename="../../main.cpp" line="300"/>
+        <location filename="../../main.cpp" line="321"/>
         <source>Downgrading ckb-next will lead to profile data loss. It is recommended to click Cancel and update to the latest version.&lt;br&gt;&lt;br&gt;If you wish to continue, back up the settings file located at&lt;blockquote&gt;%1&lt;/blockquote&gt;and click OK.</source>
         <translation>Η υποβάθμιση του ckb-next θα οδηγήσει σε απώλεια δεδομένων στα προφίλ. Προτείνεται να επιλέξετε Ακύρωση και να ενημερώσετε το λογισμικό.&lt;br&gt;&lt;br&gt;Αν επιθυμείτε να συνεχίσετε, δημιουργήστε ένα αντίγραφο ασφαλείας του αρχείου&lt;blockquote&gt;%1&lt;/blockquote&gt;και επιλέξτε OK.</translation>
     </message>
@@ -2450,22 +2451,22 @@ or click &quot;Quit&quot; on the Settings screen.</source>
         <translation>Άγνωστο</translation>
     </message>
     <message>
-        <location filename="../../keymap.cpp" line="1974"/>
+        <location filename="../../keymap.cpp" line="2005"/>
         <source>Eject</source>
         <translation>Εξαγωγή</translation>
     </message>
     <message>
-        <location filename="../../keymap.cpp" line="1976"/>
+        <location filename="../../keymap.cpp" line="2007"/>
         <source>Power</source>
         <translation>Κουμπί Λειτουργίας</translation>
     </message>
     <message>
-        <location filename="../../keymap.cpp" line="1978"/>
+        <location filename="../../keymap.cpp" line="2009"/>
         <source>Wheel Left</source>
         <translation>Ροδέλα Αριστερά</translation>
     </message>
     <message>
-        <location filename="../../keymap.cpp" line="1980"/>
+        <location filename="../../keymap.cpp" line="2011"/>
         <source>Wheel Right</source>
         <translation>Ροδέλα Δεξιά</translation>
     </message>
@@ -2699,53 +2700,79 @@ or click &quot;Quit&quot; on the Settings screen.</source>
         <translation>Προεπισκόπηση</translation>
     </message>
     <message>
-        <location filename="../../rebindwidget.ui" line="1340"/>
+        <location filename="../../rebindwidget.ui" line="1320"/>
         <source>This device only</source>
         <translation>Αυτή τη συσκευή μόνο</translation>
     </message>
     <message>
-        <location filename="../../rebindwidget.ui" line="1345"/>
+        <location filename="../../rebindwidget.ui" line="1325"/>
         <source>All ckb-next devices</source>
         <translation>Όλες τις συσκευές του ckb-next</translation>
     </message>
     <message>
-        <location filename="../../rebindwidget.ui" line="1350"/>
+        <location filename="../../rebindwidget.ui" line="1330"/>
         <source>All keyboards</source>
         <translation>Όλα τα πληκτρολόγια</translation>
     </message>
     <message>
-        <location filename="../../rebindwidget.ui" line="1371"/>
+        <location filename="../../rebindwidget.ui" line="1355"/>
         <source>Record from:</source>
         <translation>Καταγραφή από:</translation>
     </message>
     <message>
-        <location filename="../../rebindwidget.ui" line="1378"/>
+        <location filename="../../rebindwidget.ui" line="1348"/>
         <source>Keystroke delay:</source>
         <translation>Καθυστέρηση πλήκτρων:</translation>
     </message>
     <message>
-        <location filename="../../rebindwidget.ui" line="1397"/>
+        <location filename="../../rebindwidget.ui" line="1338"/>
+        <source>Holding the key will repeat the macro indefinitely. With this value you can define the delay between individual executions of the registered macro.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../rebindwidget.ui" line="1341"/>
+        <source>Repetition delay:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../rebindwidget.ui" line="1395"/>
+        <source>Holding the key will repeat the macro indefinitely. With this value you can define the delay before the initial executions of the registered macro.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../rebindwidget.ui" line="1398"/>
+        <source>Initial delay:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../rebindwidget.ui" line="1408"/>
+        <location filename="../../rebindwidget.ui" line="1430"/>
+        <source>ms</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../rebindwidget.ui" line="1464"/>
         <source>Events</source>
         <translation>Συμβάντα</translation>
     </message>
     <message>
-        <location filename="../../rebindwidget.ui" line="1432"/>
+        <location filename="../../rebindwidget.ui" line="1499"/>
         <source>Edit as string</source>
         <translation>Χειροκίνητη επεξεργασία</translation>
     </message>
     <message>
-        <location filename="../../rebindwidget.ui" line="1522"/>
-        <location filename="../../rebindwidget.cpp" line="810"/>
+        <location filename="../../rebindwidget.ui" line="1589"/>
+        <location filename="../../rebindwidget.cpp" line="845"/>
         <source>Start Recording</source>
         <translation>Εκκίνηση Καταγραφής</translation>
     </message>
     <message>
-        <location filename="../../rebindwidget.ui" line="1547"/>
+        <location filename="../../rebindwidget.ui" line="1614"/>
         <source>Add</source>
         <translation>Προσθήκη</translation>
     </message>
     <message>
-        <location filename="../../rebindwidget.ui" line="1572"/>
+        <location filename="../../rebindwidget.ui" line="1639"/>
         <source>Remove</source>
         <translation>Αφαίρεση</translation>
     </message>
@@ -2758,12 +2785,12 @@ or click &quot;Quit&quot; on the Settings screen.</source>
         <translation type="vanished">Δεν θα υπάρχει καθυστέρηση</translation>
     </message>
     <message>
-        <location filename="../../rebindwidget.ui" line="1296"/>
+        <location filename="../../rebindwidget.ui" line="1364"/>
         <source>Set delay to default values: 20us up to 15 chars, 200us above</source>
         <translation>Θα υπάρχει καθυστέρηση 20μs μέχρι 15 χαρακτήρες και 200μs για παραπάνω</translation>
     </message>
     <message>
-        <location filename="../../rebindwidget.ui" line="1312"/>
+        <location filename="../../rebindwidget.ui" line="1380"/>
         <source>Delay will be the same as it was recorded</source>
         <translation>Η καθυστέρηση θα είναι ακριβώς όπως καταγράφηκε</translation>
     </message>
@@ -2777,7 +2804,7 @@ or click &quot;Quit&quot; on the Settings screen.</source>
         <translation type="vanished">Διακοπή</translation>
     </message>
     <message>
-        <location filename="../../rebindwidget.ui" line="1591"/>
+        <location filename="../../rebindwidget.ui" line="1658"/>
         <source>Clear</source>
         <translation>Εκκαθάριση</translation>
     </message>
@@ -2825,12 +2852,12 @@ or click &quot;Quit&quot; on the Settings screen.</source>
         <translation type="vanished">Χωρίς &amp;καθυστέρηση</translation>
     </message>
     <message>
-        <location filename="../../rebindwidget.ui" line="1299"/>
+        <location filename="../../rebindwidget.ui" line="1367"/>
         <source>de&amp;fault</source>
         <translation>&amp;Προεπιλογή</translation>
     </message>
     <message>
-        <location filename="../../rebindwidget.ui" line="1315"/>
+        <location filename="../../rebindwidget.ui" line="1383"/>
         <source>as t&amp;yped</source>
         <translation>Όπως Π&amp;ληκτρολογείται</translation>
     </message>
@@ -2847,22 +2874,22 @@ or click &quot;Quit&quot; on the Settings screen.</source>
         <translation type="obsolete">Καταγραφή μακροεντολής</translation>
     </message>
     <message>
-        <location filename="../../rebindwidget.ui" line="1621"/>
+        <location filename="../../rebindwidget.ui" line="1688"/>
         <source>Unbind</source>
         <translation>Κατάργηση Συσχέτισης</translation>
     </message>
     <message>
-        <location filename="../../rebindwidget.ui" line="1628"/>
+        <location filename="../../rebindwidget.ui" line="1695"/>
         <source>Reset to Default</source>
         <translation>Επαναφορά στα Αρχικά</translation>
     </message>
     <message>
-        <location filename="../../rebindwidget.ui" line="1635"/>
+        <location filename="../../rebindwidget.ui" line="1702"/>
         <source>Cancel</source>
         <translation>Ακύρωση</translation>
     </message>
     <message>
-        <location filename="../../rebindwidget.ui" line="1642"/>
+        <location filename="../../rebindwidget.ui" line="1709"/>
         <source>Apply</source>
         <translation>Εφαρμογή</translation>
     </message>
@@ -2883,14 +2910,14 @@ or click &quot;Quit&quot; on the Settings screen.</source>
         <translation type="vanished">Άγνωστη κατάσταση στο RebindWidget::helpStatus (%1)</translation>
     </message>
     <message>
-        <location filename="../../rebindwidget.cpp" line="84"/>
+        <location filename="../../rebindwidget.cpp" line="90"/>
         <source>Tip: use xdg-open to launch a file or directory. For instance, to open your home folder:
   xdg-open </source>
         <translation>Συμβουλή: χρησιμοποιήστε το xdg-open για να ανοίξετε ένα αρχείο ή έναν κατάλογο. Για παράδειγμα, για να ανοίξετε τον προσωπικό σας φάκελο:
   xdg-open </translation>
     </message>
     <message>
-        <location filename="../../rebindwidget.cpp" line="463"/>
+        <location filename="../../rebindwidget.cpp" line="496"/>
         <source>Key %1 (%2) is pressed but never released.
 This will result in the key being pressed by the macro until you manually press the key itself and release it.
 
@@ -2901,7 +2928,7 @@ Are you sure you want to continue?</source>
 Είστε σίγουροι οτι θέλετε να συνεχίσετε;</translation>
     </message>
     <message>
-        <location filename="../../rebindwidget.cpp" line="466"/>
+        <location filename="../../rebindwidget.cpp" line="499"/>
         <source>Key %1 (%2) is released but never pressed.
 This will have no observable effect unless the key is held down manually or by another macro.
 
@@ -2912,44 +2939,44 @@ Are you sure you want to continue?</source>
 Είστε σίγουροι οτι θέλετε να συνεχίσετε;</translation>
     </message>
     <message>
-        <location filename="../../rebindwidget.cpp" line="469"/>
+        <location filename="../../rebindwidget.cpp" line="502"/>
         <source>Macro warning</source>
         <translation>Προειδοποίηση μακροεντολής</translation>
     </message>
     <message>
-        <location filename="../../rebindwidget.cpp" line="811"/>
+        <location filename="../../rebindwidget.cpp" line="846"/>
         <source>Click Apply or manually edit the events.</source>
         <translation>Κάντε κλικ στο &quot;Εφαρμογή&quot; ή επεξεργαστείτε τα συμβάντα.</translation>
     </message>
     <message>
-        <location filename="../../rebindwidget.cpp" line="849"/>
+        <location filename="../../rebindwidget.cpp" line="884"/>
         <source>Unknown key combination pressed</source>
         <translation>Πιέστηκε άγνωστος συνδυασμός πλήκτρων</translation>
     </message>
     <message>
-        <location filename="../../rebindwidget.cpp" line="849"/>
+        <location filename="../../rebindwidget.cpp" line="884"/>
         <source>An unknown key combination (%1, %2) has been pressed.
 Make sure your keyboard layout is set to English - United States while recording macros.</source>
         <translation>Πιέστηκε άγνωστος συνδυασμός πλήκτρων (%1, %2).
 Παρακαλω σιγουρευτείτε οτι έχετε επιλέξει τη διάταξη Αγγλικά - Ηνωμένων Πολιτειών κατά την καταγραφή.</translation>
     </message>
     <message>
-        <location filename="../../rebindwidget.cpp" line="859"/>
+        <location filename="../../rebindwidget.cpp" line="894"/>
         <source>Stop Recording</source>
         <translation>Διακοπή Καταγραφής</translation>
     </message>
     <message>
-        <location filename="../../rebindwidget.cpp" line="860"/>
+        <location filename="../../rebindwidget.cpp" line="895"/>
         <source>Type your macro and press Stop Recording when finished.</source>
         <translation>Πληκτρολογήστε την μακροεντολή και κάντε κλικ στο &quot;Διακοπή Καταγραφής&quot; όταν ολοκληρώσετε.</translation>
     </message>
     <message>
-        <location filename="../../rebindwidget.cpp" line="867"/>
+        <location filename="../../rebindwidget.cpp" line="902"/>
         <source>Click Start Recording or manually edit the events.</source>
         <translation>Κάντε κλικ στο &quot;Εκκίνηση Καταγραφής&quot; ή επεξεργαστείτε τα συμβάντα χειροκίνητα.</translation>
     </message>
     <message>
-        <location filename="../../rebindwidget.cpp" line="935"/>
+        <location filename="../../rebindwidget.cpp" line="972"/>
         <source>&quot;Record from all keyboards&quot; is only recommended if you do not have a keyboard managed by ckb-next.
 It currently only functions with an English - United States keyboard layout.
 Make sure your keyboard is switched to it before recording.</source>
@@ -2958,7 +2985,7 @@ Make sure your keyboard is switched to it before recording.</source>
 Παρακαλω σιγουρευτείτε οτι έχετε επιλεγμένη την παραπάνω διάταξη πριν ξεκινήσετε την καταγραφή.</translation>
     </message>
     <message>
-        <location filename="../../rebindwidget.cpp" line="938"/>
+        <location filename="../../rebindwidget.cpp" line="975"/>
         <source>Record from all keyboards</source>
         <translation>Καταγραφή από όλα τα πληκτρολόγια</translation>
     </message>
@@ -2966,43 +2993,41 @@ Make sure your keyboard is switched to it before recording.</source>
 <context>
     <name>SettingsWidget</name>
     <message>
-        <location filename="../../settingswidget.ui" line="143"/>
+        <location filename="../../settingswidget.ui" line="141"/>
         <source>Modifier keys</source>
         <translation>Πλήκτρα τροποποίησης</translation>
     </message>
     <message>
-        <location filename="../../settingswidget.ui" line="375"/>
+        <location filename="../../settingswidget.ui" line="372"/>
         <source>Application</source>
         <translation>Εφαρμογή</translation>
     </message>
     <message>
-        <location filename="../../settingswidget.ui" line="61"/>
+        <location filename="../../settingswidget.ui" line="60"/>
         <source>No devices connected</source>
         <translation>Δεν υπάρχουν συνδεδεμένες συσκευές</translation>
     </message>
     <message>
-        <location filename="../../settingswidget.ui" line="389"/>
         <source>ckb-next will be started when you log in to your computer.</source>
-        <translation>Το ckb-next θα εκκινείται αυτόματα κατά την είσοδο στον υπολογιστή.</translation>
+        <translation type="vanished">Το ckb-next θα εκκινείται αυτόματα κατά την είσοδο στον υπολογιστή.</translation>
     </message>
     <message>
-        <location filename="../../settingswidget.ui" line="392"/>
         <source>Start ckb-next at login</source>
-        <translation>Εκκίνηση του ckb-next κατά την είσοδο</translation>
+        <translation type="vanished">Εκκίνηση του ckb-next κατά την είσοδο</translation>
     </message>
     <message>
-        <location filename="../../settingswidget.ui" line="399"/>
+        <location filename="../../settingswidget.ui" line="386"/>
         <source>You will be notified when new firmware versions are available. You&apos;ll have the option to install them immediately or wait until later.</source>
         <translation>Θα ειδοποιήστε όταν υπάρχει νέα έκδοση firmware. Θα έχετε τη δυνατότητα να το εγκαταστήσετε άμεσα, ή να το κάνετε αργότερα.</translation>
     </message>
     <message>
-        <location filename="../../settingswidget.ui" line="402"/>
+        <location filename="../../settingswidget.ui" line="389"/>
         <source>Check for new firmware automatically</source>
         <translatorcomment>Εκκίνηση του ckb-next κατα την είσοδο</translatorcomment>
         <translation>Αυτόματος έλεγχος για νέα έκδοση firmware</translation>
     </message>
     <message>
-        <location filename="../../settingswidget.ui" line="334"/>
+        <location filename="../../settingswidget.ui" line="332"/>
         <source>These will override the keyboard profile. See &quot;Binding&quot; tab for more settings.</source>
         <translation>Αυτά θα παρακάμψουν το προφίλ. Δείτε την καρτέλα &quot;Συσχέτιση Πλήκτρων&quot; για περισσότερες ρυθμίσεις.</translation>
     </message>
@@ -3011,39 +3036,39 @@ Make sure your keyboard is switched to it before recording.</source>
         <translation type="vanished">Περισσότερες ρυθμισεις</translation>
     </message>
     <message>
-        <location filename="../../settingswidget.ui" line="589"/>
+        <location filename="../../settingswidget.ui" line="576"/>
         <source>About Qt</source>
         <translation>Σχετικά με Qt</translation>
     </message>
     <message>
-        <location filename="../../settingswidget.ui" line="412"/>
+        <location filename="../../settingswidget.ui" line="399"/>
         <source>Check for ckb-next updates on startup</source>
         <translation>Έλεγχος για ενημερώσεις του ckb-next κατά την εκκίνηση</translation>
     </message>
     <message>
-        <location filename="../../settingswidget.ui" line="422"/>
+        <location filename="../../settingswidget.ui" line="409"/>
         <source>Enable this only if you have a high DPI monitor and the ckb-next window shows up too small.</source>
         <translation>Ενεργοποιήστε το αυτό μόνο αν έχετε οθόνη high DPI και το παράθυρο του ckb-next είναι πολύ μικρό.</translation>
     </message>
     <message>
-        <location filename="../../settingswidget.ui" line="425"/>
+        <location filename="../../settingswidget.ui" line="412"/>
         <source>Enable HiDPI Scaling</source>
         <translation>Ενεργοποίηση κλιμάκωσης HiDPI</translation>
     </message>
     <message>
-        <location filename="../../settingswidget.ui" line="439"/>
-        <location filename="../../settingswidget.cpp" line="197"/>
+        <location filename="../../settingswidget.ui" line="426"/>
+        <location filename="../../settingswidget.cpp" line="208"/>
         <source>Generate report</source>
         <translation>Δημιουργία αναφοράς</translation>
     </message>
     <message>
-        <location filename="../../settingswidget.ui" line="464"/>
+        <location filename="../../settingswidget.ui" line="451"/>
         <source>Check for updates</source>
         <translation>Έλεγχος για ενημερώσεις</translation>
     </message>
     <message>
-        <location filename="../../settingswidget.ui" line="471"/>
-        <location filename="../../settingswidget.cpp" line="286"/>
+        <location filename="../../settingswidget.ui" line="458"/>
+        <location filename="../../settingswidget.cpp" line="297"/>
         <source>Uninstall ckb-next</source>
         <translation>Απεγκατάσταση του ckb-next</translation>
     </message>
@@ -3052,22 +3077,22 @@ Make sure your keyboard is switched to it before recording.</source>
         <translation type="vanished">© 2014-2016 &lt;a href=&quot;https://github.com/ccMSC/&quot; style=&quot;text-decoration:none;&quot;&gt;ccMSC&lt;/a&gt;.&lt;br/&gt;© 2017-2019 &lt;a href=&quot;https://github.com/ckb-next/ckb-next/graphs/contributors&quot; style=&quot;text-decoration:none;&quot;&gt;Η ομάδα ανάπτυξης του ckb-next&lt;/a&gt;.</translation>
     </message>
     <message>
-        <location filename="../../settingswidget.ui" line="596"/>
+        <location filename="../../settingswidget.ui" line="583"/>
         <source>Quit</source>
         <translation>Έξοδος</translation>
     </message>
     <message>
-        <location filename="../../settingswidget.cpp" line="92"/>
+        <location filename="../../settingswidget.cpp" line="110"/>
         <source>The ckb-next development team</source>
         <translation>Η ομάδα ανάπτυξης του ckb-next</translation>
     </message>
     <message>
-        <location filename="../../settingswidget.cpp" line="96"/>
+        <location filename="../../settingswidget.cpp" line="114"/>
         <source>&lt;br/&gt;Special thanks to &lt;a href=&quot;https://github.com/tekezo&quot; style=&quot;text-decoration:none;&quot;&gt;tekezo&lt;/a&gt; for &lt;a href=&quot;https://github.com/tekezo/Karabiner-VirtualHIDDevice&quot; style=&quot;text-decoration:none;&quot;&gt;VirtualHIDDevice&lt;/a&gt;.</source>
         <translation>&lt;br/&gt;Ιδιαίτερες ευχαριστίες στον &lt;a href=&quot;https://github.com/tekezo&quot; style=&quot;text-decoration:none;&quot;&gt;tekezo&lt;/a&gt; για το &lt;a href=&quot;https://github.com/tekezo/Karabiner-VirtualHIDDevice&quot; style=&quot;text-decoration:none;&quot;&gt;VirtualHIDDevice&lt;/a&gt;.</translation>
     </message>
     <message>
-        <location filename="../../settingswidget.cpp" line="197"/>
+        <location filename="../../settingswidget.cpp" line="208"/>
         <source>This will collect software logs, as well as information about the Corsair devices in your system.
 
 Make sure they are plugged in and click OK.</source>
@@ -3076,25 +3101,25 @@ Make sure they are plugged in and click OK.</source>
 Σιγουρευτείτε ότι είναι συνδεδεμένες και κάντε κλικ στο OK.</translation>
     </message>
     <message>
-        <location filename="../../settingswidget.cpp" line="211"/>
-        <location filename="../../settingswidget.cpp" line="231"/>
+        <location filename="../../settingswidget.cpp" line="222"/>
+        <location filename="../../settingswidget.cpp" line="242"/>
         <source>Error executing ckb-next-dev-detect</source>
         <translation>Σφάλμα εκτέλεσης του ckb-next-dev-detect</translation>
     </message>
     <message>
-        <location filename="../../settingswidget.cpp" line="211"/>
+        <location filename="../../settingswidget.cpp" line="222"/>
         <source>An error occurred while trying to execute ckb-next-dev-detect.
 File not found or not executable.</source>
         <translation>Παρουσιάστηκε σφάλμα κατά την εκτέλεση του ckb-next-dev-detect.
 Το αρχείο δεν βρέθηκε ή δεν είναι εκτελέσιμο.</translation>
     </message>
     <message>
-        <location filename="../../settingswidget.cpp" line="216"/>
+        <location filename="../../settingswidget.cpp" line="227"/>
         <source>Generating Report</source>
         <translation>Γίνεται δημιουργία αναφοράς</translation>
     </message>
     <message>
-        <location filename="../../settingswidget.cpp" line="227"/>
+        <location filename="../../settingswidget.cpp" line="238"/>
         <source>An error occurred while trying to execute ckb-next-dev-detect.
 
 </source>
@@ -3103,44 +3128,44 @@ File not found or not executable.</source>
 </translation>
     </message>
     <message>
-        <location filename="../../settingswidget.cpp" line="230"/>
+        <location filename="../../settingswidget.cpp" line="241"/>
         <source>Return code %1</source>
         <translation>Κωδικός επιστροφής %1</translation>
     </message>
     <message>
-        <location filename="../../settingswidget.cpp" line="236"/>
+        <location filename="../../settingswidget.cpp" line="247"/>
         <source>Select output directory</source>
         <translation>Επιλέξτε φακέλου εξόδου</translation>
     </message>
     <message>
-        <location filename="../../settingswidget.cpp" line="239"/>
+        <location filename="../../settingswidget.cpp" line="250"/>
         <source>Report generated successfully</source>
         <translation>Επιτυχής δημιουργία αναφοράς</translation>
     </message>
     <message>
-        <location filename="../../settingswidget.cpp" line="239"/>
+        <location filename="../../settingswidget.cpp" line="250"/>
         <source>The report has been generated successfully.</source>
         <translation>Η αναφορά δημιουργήθηκε με επιτυχία.</translation>
     </message>
     <message>
-        <location filename="../../settingswidget.cpp" line="249"/>
+        <location filename="../../settingswidget.cpp" line="260"/>
         <source>Error writing report</source>
         <translation>Σφάλμα εγγραφής αναφοράς</translation>
     </message>
     <message>
-        <location filename="../../settingswidget.cpp" line="249"/>
+        <location filename="../../settingswidget.cpp" line="260"/>
         <source>Could not write report to the selected directory.
 Please pick a different one and try again.</source>
         <translation>Δεν ήταν δυνατή η δημιουργία αναφοράς στον επιλεγμένο φάκελο.
 Παρακαλώ διαλέξτε έναν άλλο φάκελο και δοκιμάστε ξανά.</translation>
     </message>
     <message>
-        <location filename="../../settingswidget.cpp" line="268"/>
+        <location filename="../../settingswidget.cpp" line="279"/>
         <source>Checking...</source>
         <translation>Γίνεται έλεγχος...</translation>
     </message>
     <message>
-        <location filename="../../settingswidget.cpp" line="286"/>
+        <location filename="../../settingswidget.cpp" line="297"/>
         <source>WARNING: Clicking OK will uninstall ckb-next and any older versions of the software from your system.
 
 Your settings and lighting profiles will be preserved.</source>
@@ -3149,12 +3174,12 @@ Your settings and lighting profiles will be preserved.</source>
 Οι ρυθμίσεις και τα προφίλ σας θα διατηρηθούν.</translation>
     </message>
     <message>
-        <location filename="../../settingswidget.cpp" line="298"/>
+        <location filename="../../settingswidget.cpp" line="309"/>
         <source>Please restart ckb-next</source>
         <translation>Παρακαλώ επανεκκινήστε το ckb-next</translation>
     </message>
     <message>
-        <location filename="../../settingswidget.cpp" line="298"/>
+        <location filename="../../settingswidget.cpp" line="309"/>
         <source>Please click the Quit button and restart ckb-next for the changes to take effect.</source>
         <translation>Κάντε κλικ στο κουμπί Έξοδος και επανεκκινήστε το ckb-next για να εφαρμοστούν οι αλλαγές.</translation>
     </message>

--- a/src/gui/resources/translations/el.ts
+++ b/src/gui/resources/translations/el.ts
@@ -2727,12 +2727,12 @@ or click &quot;Quit&quot; on the Settings screen.</source>
     <message>
         <location filename="../../rebindwidget.ui" line="1338"/>
         <source>Holding the key will repeat the macro indefinitely. With this value you can define the delay between individual executions of the registered macro.</source>
-        <translation type="unfinished"></translation>
+        <translation>Κρατόντας το πλήκτρο πατημένο, η μακροεντολή θα επαναλαμβάνεται επ&apos; αόριστον. Με αυτήν την τιμή μπορείτε να ορίσετε την καθυστέρηση μεταξύ των εκτελέσεων της καταχωρημένης μακροεντολής.</translation>
     </message>
     <message>
         <location filename="../../rebindwidget.ui" line="1341"/>
         <source>Repetition delay:</source>
-        <translation type="unfinished"></translation>
+        <translation>Καθυστέρηση επανάληψης:</translation>
     </message>
     <message>
         <location filename="../../rebindwidget.ui" line="1395"/>
@@ -2748,7 +2748,7 @@ or click &quot;Quit&quot; on the Settings screen.</source>
         <location filename="../../rebindwidget.ui" line="1408"/>
         <location filename="../../rebindwidget.ui" line="1430"/>
         <source>ms</source>
-        <translation type="unfinished"></translation>
+        <translation>ms</translation>
     </message>
     <message>
         <location filename="../../rebindwidget.ui" line="1464"/>

--- a/src/gui/resources/translations/en_GB.ts
+++ b/src/gui/resources/translations/en_GB.ts
@@ -95,9 +95,9 @@
         <location filename="../../animsettingdialog.ui" line="169"/>
         <location filename="../../animsettingdialog.ui" line="183"/>
         <location filename="../../animsettingdialog.ui" line="200"/>
-        <location filename="../../animsettingdialog.cpp" line="216"/>
-        <location filename="../../animsettingdialog.cpp" line="342"/>
-        <location filename="../../animsettingdialog.cpp" line="358"/>
+        <location filename="../../animsettingdialog.cpp" line="225"/>
+        <location filename="../../animsettingdialog.cpp" line="352"/>
+        <location filename="../../animsettingdialog.cpp" line="369"/>
         <source>seconds</source>
         <translation type="unfinished"></translation>
     </message>
@@ -193,81 +193,81 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../animsettingdialog.cpp" line="26"/>
+        <location filename="../../animsettingdialog.cpp" line="33"/>
         <source> Animation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../animsettingdialog.cpp" line="33"/>
+        <location filename="../../animsettingdialog.cpp" line="40"/>
         <source>&lt;b&gt;Animation&lt;/b&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../animsettingdialog.cpp" line="203"/>
+        <location filename="../../animsettingdialog.cpp" line="211"/>
         <source>&lt;b&gt;Playback&lt;/b&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../animsettingdialog.cpp" line="208"/>
+        <location filename="../../animsettingdialog.cpp" line="216"/>
         <source>Duration:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../animsettingdialog.cpp" line="220"/>
+        <location filename="../../animsettingdialog.cpp" line="229"/>
         <source>Start with mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../animsettingdialog.cpp" line="228"/>
+        <location filename="../../animsettingdialog.cpp" line="237"/>
         <source>Start with key press</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../animsettingdialog.cpp" line="240"/>
+        <location filename="../../animsettingdialog.cpp" line="249"/>
         <source>on pressed key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../animsettingdialog.cpp" line="241"/>
+        <location filename="../../animsettingdialog.cpp" line="250"/>
         <source>on whole keyboard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../animsettingdialog.cpp" line="242"/>
+        <location filename="../../animsettingdialog.cpp" line="251"/>
         <source>on keyboard (once)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../animsettingdialog.cpp" line="246"/>
+        <location filename="../../animsettingdialog.cpp" line="255"/>
         <source>every time</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../animsettingdialog.cpp" line="247"/>
+        <location filename="../../animsettingdialog.cpp" line="256"/>
         <source>only once</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../animsettingdialog.cpp" line="285"/>
-        <location filename="../../animsettingdialog.cpp" line="297"/>
+        <location filename="../../animsettingdialog.cpp" line="294"/>
+        <location filename="../../animsettingdialog.cpp" line="306"/>
         <source>Repeat:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../animsettingdialog.cpp" line="295"/>
-        <location filename="../../animsettingdialog.cpp" line="307"/>
+        <location filename="../../animsettingdialog.cpp" line="304"/>
+        <location filename="../../animsettingdialog.cpp" line="316"/>
         <source>times</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../animsettingdialog.cpp" line="309"/>
-        <location filename="../../animsettingdialog.cpp" line="312"/>
+        <location filename="../../animsettingdialog.cpp" line="318"/>
+        <location filename="../../animsettingdialog.cpp" line="321"/>
         <source>Forever</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../animsettingdialog.cpp" line="360"/>
-        <location filename="../../animsettingdialog.cpp" line="364"/>
+        <location filename="../../animsettingdialog.cpp" line="371"/>
+        <location filename="../../animsettingdialog.cpp" line="375"/>
         <source>Stop after:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -893,7 +893,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../kperfwidget.cpp" line="237"/>
+        <location filename="../../kperfwidget.cpp" line="236"/>
         <source>Copy performance settings to:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -901,39 +901,22 @@
 <context>
     <name>KStatusNotifierItem</name>
     <message>
-        <location filename="../../kstatusnotifier/kstatusnotifieritem.cpp" line="521"/>
-        <location filename="../../kstatusnotifier/kstatusnotifieritem.cpp" line="1159"/>
+        <location filename="../../kstatusnotifier/kstatusnotifieritem.cpp" line="516"/>
+        <location filename="../../kstatusnotifier/kstatusnotifieritem.cpp" line="1171"/>
         <source>&amp;Minimize</source>
         <comment>@action:inmenu</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../kstatusnotifier/kstatusnotifieritem.cpp" line="876"/>
+        <location filename="../../kstatusnotifier/kstatusnotifieritem.cpp" line="892"/>
         <source>Quit</source>
         <comment>@action:inmenu</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../kstatusnotifier/kstatusnotifieritem.cpp" line="1156"/>
+        <location filename="../../kstatusnotifier/kstatusnotifieritem.cpp" line="1168"/>
         <source>&amp;Restore</source>
         <comment>@action:inmenu</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../kstatusnotifier/kstatusnotifieritem.cpp" line="1172"/>
-        <source>Confirm Quit From System Tray</source>
-        <comment>@title:window</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../kstatusnotifier/kstatusnotifieritem.cpp" line="1173"/>
-        <source>&lt;qt&gt;Are you sure you want to quit &lt;b&gt;%1&lt;/b&gt;?&lt;/qt&gt;</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../kstatusnotifier/kstatusnotifieritem.cpp" line="1178"/>
-        <source>Quit</source>
-        <comment>@action:button</comment>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -1199,6 +1182,14 @@ The binding will not function until winlock has been disabled.</source>
     <message>
         <location filename="../../kblightwidget.cpp" line="119"/>
         <source>%1 keys selected</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>KbManager</name>
+    <message>
+        <location filename="../../kbmanager.cpp" line="42"/>
+        <source>Please enable &quot;Turn lights off when idle&quot; before using --sleep</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -1528,7 +1519,7 @@ An attempt will be made to import as many as possible.</source>
     </message>
     <message>
         <location filename="../../kbwidget.ui" line="552"/>
-        <location filename="../../kbwidget.cpp" line="402"/>
+        <location filename="../../kbwidget.cpp" line="412"/>
         <source>Check for updates</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1543,114 +1534,114 @@ An attempt will be made to import as many as possible.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../kbwidget.cpp" line="116"/>
+        <location filename="../../kbwidget.cpp" line="120"/>
         <source>Saving to hardware is not supported on this device.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../kbwidget.cpp" line="178"/>
+        <location filename="../../kbwidget.cpp" line="182"/>
         <source>This device does not support setting the poll rate through software.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../kbwidget.cpp" line="202"/>
+        <location filename="../../kbwidget.cpp" line="206"/>
         <source>Manage profiles...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../kbwidget.cpp" line="272"/>
+        <location filename="../../kbwidget.cpp" line="282"/>
         <source>Rename...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../kbwidget.cpp" line="273"/>
+        <location filename="../../kbwidget.cpp" line="283"/>
         <source>Duplicate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../kbwidget.cpp" line="274"/>
+        <location filename="../../kbwidget.cpp" line="284"/>
         <source>Delete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../kbwidget.cpp" line="279"/>
+        <location filename="../../kbwidget.cpp" line="289"/>
         <source>Move Up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../kbwidget.cpp" line="281"/>
+        <location filename="../../kbwidget.cpp" line="291"/>
         <source>Manage Events</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../kbwidget.cpp" line="285"/>
+        <location filename="../../kbwidget.cpp" line="295"/>
         <source>Move Down</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../kbwidget.cpp" line="314"/>
+        <location filename="../../kbwidget.cpp" line="324"/>
         <source>Delete mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../kbwidget.cpp" line="314"/>
+        <location filename="../../kbwidget.cpp" line="324"/>
         <source>Are you sure you want to delete this mode?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../kbwidget.cpp" line="407"/>
+        <location filename="../../kbwidget.cpp" line="417"/>
         <source>Up to date</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../kbwidget.cpp" line="409"/>
+        <location filename="../../kbwidget.cpp" line="419"/>
         <source>Upgrade to v%1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../kbwidget.cpp" line="426"/>
+        <location filename="../../kbwidget.cpp" line="436"/>
         <source>Checking...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../kbwidget.cpp" line="434"/>
-        <location filename="../../kbwidget.cpp" line="438"/>
-        <location filename="../../kbwidget.cpp" line="441"/>
+        <location filename="../../kbwidget.cpp" line="444"/>
+        <location filename="../../kbwidget.cpp" line="448"/>
+        <location filename="../../kbwidget.cpp" line="451"/>
         <source>Firmware update</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../kbwidget.cpp" line="434"/>
+        <location filename="../../kbwidget.cpp" line="444"/>
         <source>&lt;center&gt;There was a problem getting the status for this device.&lt;br /&gt;Would you like to select a file manually?&lt;/center&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../kbwidget.cpp" line="438"/>
+        <location filename="../../kbwidget.cpp" line="448"/>
         <source>&lt;center&gt;There is a new firmware available for this device (v%1).&lt;br /&gt;However, it requires a newer version of ckb-next.&lt;br /&gt;Please upgrade ckb-next and try again.&lt;/center&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../kbwidget.cpp" line="441"/>
+        <location filename="../../kbwidget.cpp" line="451"/>
         <source>&lt;center&gt;Your firmware is already up to date.&lt;br /&gt;Would you like to select a file manually?&lt;/center&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../kbwidget.cpp" line="453"/>
+        <location filename="../../kbwidget.cpp" line="463"/>
         <source>Select firmware file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../kbwidget.cpp" line="453"/>
+        <location filename="../../kbwidget.cpp" line="463"/>
         <source>Firmware blobs (*.bin)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../kbwidget.cpp" line="458"/>
+        <location filename="../../kbwidget.cpp" line="468"/>
         <source>Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../kbwidget.cpp" line="458"/>
+        <location filename="../../kbwidget.cpp" line="468"/>
         <source>&lt;center&gt;File could not be read.&lt;/center&gt;</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2041,7 +2032,7 @@ An attempt will be made to import as many as possible.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../mperfwidget.cpp" line="350"/>
+        <location filename="../../mperfwidget.cpp" line="357"/>
         <source>Copy performance settings to:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2140,120 +2131,120 @@ An attempt will be made to import as many as possible.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../mainwindow.cpp" line="135"/>
+        <location filename="../../mainwindow.cpp" line="136"/>
         <source>Restore</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../mainwindow.cpp" line="136"/>
+        <location filename="../../mainwindow.cpp" line="137"/>
         <source>Quit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../mainwindow.cpp" line="162"/>
+        <location filename="../../mainwindow.cpp" line="163"/>
         <source>Settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../mainwindow.cpp" line="170"/>
+        <location filename="../../mainwindow.cpp" line="171"/>
         <source>The ckb-next daemon is not running. This program will &lt;b&gt;not&lt;/b&gt; work without it!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../mainwindow.cpp" line="172"/>
+        <location filename="../../mainwindow.cpp" line="173"/>
         <source>Start it once with:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../mainwindow.cpp" line="174"/>
+        <location filename="../../mainwindow.cpp" line="175"/>
         <source>Enable it for every boot:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../mainwindow.cpp" line="176"/>
+        <location filename="../../mainwindow.cpp" line="177"/>
         <source>If &quot;Unit ckb-next-daemon.service is masked.&quot;, unmask it first and try again:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../mainwindow.cpp" line="179"/>
+        <location filename="../../mainwindow.cpp" line="180"/>
         <source>Start and enable it with:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../mainwindow.cpp" line="205"/>
+        <location filename="../../mainwindow.cpp" line="206"/>
         <source>The ckb-next daemon is not running.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../mainwindow.cpp" line="292"/>
+        <location filename="../../mainwindow.cpp" line="293"/>
         <source>Driver inactive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../mainwindow.cpp" line="299"/>
+        <location filename="../../mainwindow.cpp" line="300"/>
         <source>&lt;br /&gt;&lt;br /&gt;&lt;b&gt;Warning:&lt;/b&gt; Driver version mismatch (</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../mainwindow.cpp" line="299"/>
+        <location filename="../../mainwindow.cpp" line="300"/>
         <source>). Please upgrade ckb-next</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../mainwindow.cpp" line="299"/>
+        <location filename="../../mainwindow.cpp" line="300"/>
         <source>. If the problem persists, try rebooting.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../mainwindow.cpp" line="310"/>
+        <location filename="../../mainwindow.cpp" line="311"/>
         <source>&lt;br /&gt;&lt;b&gt;Warning:&lt;/b&gt; System Extension by &quot;Fumihiko Takayama&quot; is not allowed in Security &amp; Privacy. Please allow it and then unplug and replug your devices.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../mainwindow.cpp" line="312"/>
+        <location filename="../../mainwindow.cpp" line="313"/>
         <source>&lt;br /&gt;&lt;b&gt;Warning:&lt;/b&gt; Make sure ckb-next-daemon is allowed in Security &amp; Privacy -&gt; Input monitoring.&lt;br /&gt;Please allow for up to 10 seconds for the daemon restart prompt to show up after allowing input monitoring.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../mainwindow.cpp" line="322"/>
+        <location filename="../../mainwindow.cpp" line="323"/>
         <source>&lt;br /&gt;&lt;b&gt;Warning:&lt;/b&gt; The uinput module could not be loaded. If this issue persists after rebooting, compile a kernel with CONFIG_INPUT_UINPUT=y.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../mainwindow.cpp" line="325"/>
+        <location filename="../../mainwindow.cpp" line="326"/>
         <source>No devices connected</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../mainwindow.cpp" line="328"/>
+        <location filename="../../mainwindow.cpp" line="329"/>
         <source>1 device connected</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../mainwindow.cpp" line="330"/>
+        <location filename="../../mainwindow.cpp" line="331"/>
         <source>%1 devices connected</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../mainwindow.cpp" line="361"/>
+        <location filename="../../mainwindow.cpp" line="362"/>
         <source>A new firmware is available for your %1 (v%2)
 Would you like to install it now?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../mainwindow.cpp" line="377"/>
+        <location filename="../../mainwindow.cpp" line="378"/>
         <source>ckb-next will still run in the background.
 To close it, choose Quit from the tray menu
 or click &quot;Quit&quot; on the Settings screen.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../mainwindow.cpp" line="536"/>
+        <location filename="../../mainwindow.cpp" line="539"/>
         <source>Update to v</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../mainwindow.cpp" line="541"/>
+        <location filename="../../mainwindow.cpp" line="544"/>
         <source>Up to date</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2287,47 +2278,52 @@ or click &quot;Quit&quot; on the Settings screen.</source>
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../../main.cpp" line="68"/>
+        <location filename="../../main.cpp" line="69"/>
         <source>Starts in background, without displaying the main window.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../main.cpp" line="73"/>
+        <location filename="../../main.cpp" line="74"/>
         <source>Causes already running instance (if any) to exit.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../main.cpp" line="76"/>
+        <location filename="../../main.cpp" line="77"/>
         <source>Switches to the profile with the specified name on all devices.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../main.cpp" line="79"/>
+        <location filename="../../main.cpp" line="80"/>
         <source>Switches to the mode either in the current profile, or in the one specified by --profile</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../main.cpp" line="82"/>
+        <location filename="../../main.cpp" line="83"/>
+        <source>Turns the lights off as if the system was idling.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../main.cpp" line="86"/>
         <source>Delays application start for 5 seconds</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../main.cpp" line="83"/>
+        <location filename="../../main.cpp" line="87"/>
         <source>Disables the daemon not running popup</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../main.cpp" line="97"/>
+        <location filename="../../main.cpp" line="101"/>
         <source>Enables the KeyWidget debug window</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../main.cpp" line="299"/>
+        <location filename="../../main.cpp" line="320"/>
         <source>Downgrade Warning</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../main.cpp" line="300"/>
+        <location filename="../../main.cpp" line="321"/>
         <source>Downgrading ckb-next will lead to profile data loss. It is recommended to click Cancel and update to the latest version.&lt;br&gt;&lt;br&gt;If you wish to continue, back up the settings file located at&lt;blockquote&gt;%1&lt;/blockquote&gt;and click OK.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2337,22 +2333,22 @@ or click &quot;Quit&quot; on the Settings screen.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../keymap.cpp" line="1974"/>
+        <location filename="../../keymap.cpp" line="2005"/>
         <source>Eject</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../keymap.cpp" line="1976"/>
+        <location filename="../../keymap.cpp" line="2007"/>
         <source>Power</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../keymap.cpp" line="1978"/>
+        <location filename="../../keymap.cpp" line="2009"/>
         <source>Wheel Left</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../keymap.cpp" line="1980"/>
+        <location filename="../../keymap.cpp" line="2011"/>
         <source>Wheel Right</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2613,109 +2609,135 @@ or click &quot;Quit&quot; on the Settings screen.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../rebindwidget.ui" line="1340"/>
+        <location filename="../../rebindwidget.ui" line="1320"/>
         <source>This device only</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../rebindwidget.ui" line="1345"/>
+        <location filename="../../rebindwidget.ui" line="1325"/>
         <source>All ckb-next devices</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../rebindwidget.ui" line="1350"/>
+        <location filename="../../rebindwidget.ui" line="1330"/>
         <source>All keyboards</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../rebindwidget.ui" line="1371"/>
+        <location filename="../../rebindwidget.ui" line="1355"/>
         <source>Record from:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../rebindwidget.ui" line="1378"/>
+        <location filename="../../rebindwidget.ui" line="1348"/>
         <source>Keystroke delay:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../rebindwidget.ui" line="1397"/>
+        <location filename="../../rebindwidget.ui" line="1338"/>
+        <source>Holding the key will repeat the macro indefinitely. With this value you can define the delay between individual executions of the registered macro.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../rebindwidget.ui" line="1341"/>
+        <source>Repetition delay:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../rebindwidget.ui" line="1395"/>
+        <source>Holding the key will repeat the macro indefinitely. With this value you can define the delay before the initial executions of the registered macro.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../rebindwidget.ui" line="1398"/>
+        <source>Initial delay:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../rebindwidget.ui" line="1408"/>
+        <location filename="../../rebindwidget.ui" line="1430"/>
+        <source>ms</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../rebindwidget.ui" line="1464"/>
         <source>Events</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../rebindwidget.ui" line="1432"/>
+        <location filename="../../rebindwidget.ui" line="1499"/>
         <source>Edit as string</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../rebindwidget.ui" line="1522"/>
-        <location filename="../../rebindwidget.cpp" line="810"/>
+        <location filename="../../rebindwidget.ui" line="1589"/>
+        <location filename="../../rebindwidget.cpp" line="845"/>
         <source>Start Recording</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../rebindwidget.ui" line="1547"/>
+        <location filename="../../rebindwidget.ui" line="1614"/>
         <source>Add</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../rebindwidget.ui" line="1572"/>
+        <location filename="../../rebindwidget.ui" line="1639"/>
         <source>Remove</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../rebindwidget.ui" line="1296"/>
+        <location filename="../../rebindwidget.ui" line="1364"/>
         <source>Set delay to default values: 20us up to 15 chars, 200us above</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../rebindwidget.ui" line="1312"/>
+        <location filename="../../rebindwidget.ui" line="1380"/>
         <source>Delay will be the same as it was recorded</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../rebindwidget.ui" line="1299"/>
+        <location filename="../../rebindwidget.ui" line="1367"/>
         <source>de&amp;fault</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../rebindwidget.ui" line="1315"/>
+        <location filename="../../rebindwidget.ui" line="1383"/>
         <source>as t&amp;yped</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../rebindwidget.ui" line="1591"/>
+        <location filename="../../rebindwidget.ui" line="1658"/>
         <source>Clear</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../rebindwidget.ui" line="1621"/>
+        <location filename="../../rebindwidget.ui" line="1688"/>
         <source>Unbind</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../rebindwidget.ui" line="1628"/>
+        <location filename="../../rebindwidget.ui" line="1695"/>
         <source>Reset to Default</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../rebindwidget.ui" line="1635"/>
+        <location filename="../../rebindwidget.ui" line="1702"/>
         <source>Cancel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../rebindwidget.ui" line="1642"/>
+        <location filename="../../rebindwidget.ui" line="1709"/>
         <source>Apply</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../rebindwidget.cpp" line="84"/>
+        <location filename="../../rebindwidget.cpp" line="90"/>
         <source>Tip: use xdg-open to launch a file or directory. For instance, to open your home folder:
   xdg-open </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../rebindwidget.cpp" line="463"/>
+        <location filename="../../rebindwidget.cpp" line="496"/>
         <source>Key %1 (%2) is pressed but never released.
 This will result in the key being pressed by the macro until you manually press the key itself and release it.
 
@@ -2723,7 +2745,7 @@ Are you sure you want to continue?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../rebindwidget.cpp" line="466"/>
+        <location filename="../../rebindwidget.cpp" line="499"/>
         <source>Key %1 (%2) is released but never pressed.
 This will have no observable effect unless the key is held down manually or by another macro.
 
@@ -2731,50 +2753,50 @@ Are you sure you want to continue?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../rebindwidget.cpp" line="469"/>
+        <location filename="../../rebindwidget.cpp" line="502"/>
         <source>Macro warning</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../rebindwidget.cpp" line="811"/>
+        <location filename="../../rebindwidget.cpp" line="846"/>
         <source>Click Apply or manually edit the events.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../rebindwidget.cpp" line="849"/>
+        <location filename="../../rebindwidget.cpp" line="884"/>
         <source>Unknown key combination pressed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../rebindwidget.cpp" line="849"/>
+        <location filename="../../rebindwidget.cpp" line="884"/>
         <source>An unknown key combination (%1, %2) has been pressed.
 Make sure your keyboard layout is set to English - United States while recording macros.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../rebindwidget.cpp" line="859"/>
+        <location filename="../../rebindwidget.cpp" line="894"/>
         <source>Stop Recording</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../rebindwidget.cpp" line="860"/>
+        <location filename="../../rebindwidget.cpp" line="895"/>
         <source>Type your macro and press Stop Recording when finished.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../rebindwidget.cpp" line="867"/>
+        <location filename="../../rebindwidget.cpp" line="902"/>
         <source>Click Start Recording or manually edit the events.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../rebindwidget.cpp" line="935"/>
+        <location filename="../../rebindwidget.cpp" line="972"/>
         <source>&quot;Record from all keyboards&quot; is only recommended if you do not have a keyboard managed by ckb-next.
 It currently only functions with an English - United States keyboard layout.
 Make sure your keyboard is switched to it before recording.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../rebindwidget.cpp" line="938"/>
+        <location filename="../../rebindwidget.cpp" line="975"/>
         <source>Record from all keyboards</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2782,178 +2804,168 @@ Make sure your keyboard is switched to it before recording.</source>
 <context>
     <name>SettingsWidget</name>
     <message>
-        <location filename="../../settingswidget.ui" line="61"/>
+        <location filename="../../settingswidget.ui" line="60"/>
         <source>No devices connected</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../settingswidget.ui" line="143"/>
+        <location filename="../../settingswidget.ui" line="141"/>
         <source>Modifier keys</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../settingswidget.ui" line="334"/>
+        <location filename="../../settingswidget.ui" line="332"/>
         <source>These will override the keyboard profile. See &quot;Binding&quot; tab for more settings.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../settingswidget.ui" line="375"/>
+        <location filename="../../settingswidget.ui" line="372"/>
         <source>Application</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../settingswidget.ui" line="389"/>
-        <source>ckb-next will be started when you log in to your computer.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../settingswidget.ui" line="392"/>
-        <source>Start ckb-next at login</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../settingswidget.ui" line="399"/>
+        <location filename="../../settingswidget.ui" line="386"/>
         <source>You will be notified when new firmware versions are available. You&apos;ll have the option to install them immediately or wait until later.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../settingswidget.ui" line="402"/>
+        <location filename="../../settingswidget.ui" line="389"/>
         <source>Check for new firmware automatically</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../settingswidget.ui" line="412"/>
+        <location filename="../../settingswidget.ui" line="399"/>
         <source>Check for ckb-next updates on startup</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../settingswidget.ui" line="422"/>
+        <location filename="../../settingswidget.ui" line="409"/>
         <source>Enable this only if you have a high DPI monitor and the ckb-next window shows up too small.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../settingswidget.ui" line="425"/>
+        <location filename="../../settingswidget.ui" line="412"/>
         <source>Enable HiDPI Scaling</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../settingswidget.ui" line="439"/>
-        <location filename="../../settingswidget.cpp" line="197"/>
+        <location filename="../../settingswidget.ui" line="426"/>
+        <location filename="../../settingswidget.cpp" line="208"/>
         <source>Generate report</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../settingswidget.ui" line="464"/>
+        <location filename="../../settingswidget.ui" line="451"/>
         <source>Check for updates</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../settingswidget.ui" line="471"/>
-        <location filename="../../settingswidget.cpp" line="286"/>
+        <location filename="../../settingswidget.ui" line="458"/>
+        <location filename="../../settingswidget.cpp" line="297"/>
         <source>Uninstall ckb-next</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../settingswidget.ui" line="589"/>
+        <location filename="../../settingswidget.ui" line="576"/>
         <source>About Qt</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../settingswidget.ui" line="596"/>
+        <location filename="../../settingswidget.ui" line="583"/>
         <source>Quit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../settingswidget.cpp" line="92"/>
+        <location filename="../../settingswidget.cpp" line="110"/>
         <source>The ckb-next development team</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../settingswidget.cpp" line="96"/>
+        <location filename="../../settingswidget.cpp" line="114"/>
         <source>&lt;br/&gt;Special thanks to &lt;a href=&quot;https://github.com/tekezo&quot; style=&quot;text-decoration:none;&quot;&gt;tekezo&lt;/a&gt; for &lt;a href=&quot;https://github.com/tekezo/Karabiner-VirtualHIDDevice&quot; style=&quot;text-decoration:none;&quot;&gt;VirtualHIDDevice&lt;/a&gt;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../settingswidget.cpp" line="197"/>
+        <location filename="../../settingswidget.cpp" line="208"/>
         <source>This will collect software logs, as well as information about the Corsair devices in your system.
 
 Make sure they are plugged in and click OK.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../settingswidget.cpp" line="211"/>
-        <location filename="../../settingswidget.cpp" line="231"/>
+        <location filename="../../settingswidget.cpp" line="222"/>
+        <location filename="../../settingswidget.cpp" line="242"/>
         <source>Error executing ckb-next-dev-detect</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../settingswidget.cpp" line="211"/>
+        <location filename="../../settingswidget.cpp" line="222"/>
         <source>An error occurred while trying to execute ckb-next-dev-detect.
 File not found or not executable.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../settingswidget.cpp" line="216"/>
+        <location filename="../../settingswidget.cpp" line="227"/>
         <source>Generating Report</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../settingswidget.cpp" line="227"/>
+        <location filename="../../settingswidget.cpp" line="238"/>
         <source>An error occurred while trying to execute ckb-next-dev-detect.
 
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../settingswidget.cpp" line="230"/>
+        <location filename="../../settingswidget.cpp" line="241"/>
         <source>Return code %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../settingswidget.cpp" line="236"/>
+        <location filename="../../settingswidget.cpp" line="247"/>
         <source>Select output directory</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../settingswidget.cpp" line="239"/>
+        <location filename="../../settingswidget.cpp" line="250"/>
         <source>Report generated successfully</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../settingswidget.cpp" line="239"/>
+        <location filename="../../settingswidget.cpp" line="250"/>
         <source>The report has been generated successfully.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../settingswidget.cpp" line="249"/>
+        <location filename="../../settingswidget.cpp" line="260"/>
         <source>Error writing report</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../settingswidget.cpp" line="249"/>
+        <location filename="../../settingswidget.cpp" line="260"/>
         <source>Could not write report to the selected directory.
 Please pick a different one and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../settingswidget.cpp" line="268"/>
+        <location filename="../../settingswidget.cpp" line="279"/>
         <source>Checking...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../settingswidget.cpp" line="286"/>
+        <location filename="../../settingswidget.cpp" line="297"/>
         <source>WARNING: Clicking OK will uninstall ckb-next and any older versions of the software from your system.
 
 Your settings and lighting profiles will be preserved.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../settingswidget.cpp" line="298"/>
+        <location filename="../../settingswidget.cpp" line="309"/>
         <source>Please restart ckb-next</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../settingswidget.cpp" line="298"/>
+        <location filename="../../settingswidget.cpp" line="309"/>
         <source>Please click the Quit button and restart ckb-next for the changes to take effect.</source>
         <translation type="unfinished"></translation>
     </message>


### PR DESCRIPTION
Replace the fix repetition delay between macros with a configurable one.

This PR:
- Adds the UI to set (and display) the macro repetition delay,
- amends the GUI and daemon to encode, send, receive, parse, etc. this new data as part of the `$macro:` message,
- does some (potentially unnecessary) cleanup commits in-between to simplify development, and
- update the translation file where necessary and possible.

Screenshot for convenient UI demo:

<img width="746" height="274" alt="screenshot_2026-02-13_13-58-15" src="https://github.com/user-attachments/assets/716fe8de-bec2-497f-9b36-2fd49ccc5c25" />

If merged:
Closes #1253 
Closes #1256