### PR TITLE
Allow control wheel rotation to be bound

### DIFF
--- a/src/daemon/keymap.c
+++ b/src/daemon/keymap.c
@@ -455,8 +455,8 @@ const key keymap_bragi[N_KEYS_BRAGI_PATCH] = {
     { "prev",          126, KEY_PREVIOUSSONG },
     { "mr",            -1,  KEY_CORSAIR },
     { "profswitch",    128, KEY_CORSAIR },
-    { 0,               -1,  KEY_NONE },
-    { 0,               -1,  KEY_NONE },
+    { "ctrlwheelcw",    -1, KEY_CORSAIR },
+    { "ctrlwheelccw",   -1, KEY_CORSAIR },
     { "g1",            131, KEY_CORSAIR },
     { "g2",            132, KEY_CORSAIR },
     { "g3",            133, KEY_CORSAIR },
@@ -911,11 +911,11 @@ void process_input_urb(void* context, unsigned char* buffer, int urblen, ushort 
                                 int32_t wheel;
                                 memcpy(&wheel, buffer + 4, sizeof(int32_t));
                                 if(wheel > 0) {
-                                    // Apply fresh key data
-                                    SET_KEYBIT(targetkb->input.keys, 103); // volup
+                                    // Apply fresh key data: clockwise rotation
+                                    SET_KEYBIT(targetkb->input.keys, 129);
                                 } else {
-                                    // Apply fresh key data
-                                    SET_KEYBIT(targetkb->input.keys, 104); // voldn
+                                    // Apply fresh key data: counter-clockwise rotation
+                                    SET_KEYBIT(targetkb->input.keys, 130);
                                 }
                             }
                         } else {

--- a/src/gui/keyaction.cpp
+++ b/src/gui/keyaction.cpp
@@ -86,6 +86,12 @@ QString KeyAction::defaultAction(const QString& key, KeyMap::Model model){
     if(key == "profdn")
         return "$mode:-4";
 
+    // In lieu of better use: Control dial maps to Volume control by default.
+    if(key == "ctrlwheelcw")
+        return "volup";
+    if(key == "ctrlwheelccw")
+        return "voldn";
+
 #ifdef Q_OS_MACOS
     // macOS has no forwards and backwards, so we bind them to macros that simulate that action
     if(key == "mouse4")

--- a/src/gui/keymap.cpp
+++ b/src/gui/keymap.cpp
@@ -809,7 +809,9 @@ static QHash<QString, Key> getMap(KeyMap::Model model, KeyMap::Layout layout){
         map["rightbar11"] = {nullptr, "Right Light Bar 11", "rightbar11", 292, 88, 6, 9, true, false};
 
         map["profswitch"] = {nullptr,  "Profile Switch", "profswitch", 20, 10, 11, 9, true, true};
+        map["ctrlwheelccw"] = {nullptr, "Control Wheel Counterclockwise", "ctrlwheelccw", 28, 10, 6, 16, false, true };
         map["ctrlwheelb"] = {nullptr, "Control Wheel Button", "ctrlwheelb", 35, 10, 11, 11, true, true };
+        map["ctrlwheelcw"] = {nullptr, "Control Wheel Clockwise", "ctrlwheelcw", 42, 10, 6, 16, false, true };
         map["lock"] = {nullptr, "Lock", "lock", 50, 10, 11, 9, true, true};
 
         map["mute"].height = map["profswitch"].height;

--- a/src/gui/keymap.cpp
+++ b/src/gui/keymap.cpp
@@ -808,28 +808,23 @@ static QHash<QString, Key> getMap(KeyMap::Model model, KeyMap::Layout layout){
         map["rightbar10"] = {nullptr, "Right Light Bar 10", "rightbar10", 292, 79, 6, 9, true, false};
         map["rightbar11"] = {nullptr, "Right Light Bar 11", "rightbar11", 292, 88, 6, 9, true, false};
 
-        map["ctrlwheelb"] = map["light"];
-        map["ctrlwheelb"].name = "ctrlwheelb";
-        map["ctrlwheelb"]._friendlyName = "Control Wheel Button";
-        map["ctrlwheelb"].height = map["ctrlwheelb"].width;
-        map["ctrlwheelb"].y -= 3;
+        map["profswitch"] = {nullptr,  "Profile Switch", "profswitch", 20, 10, 11, 9, true, true};
+        map["ctrlwheelb"] = {nullptr, "Control Wheel Button", "ctrlwheelb", 35, 10, 11, 11, true, true };
+        map["lock"] = {nullptr, "Lock", "lock", 50, 10, 11, 9, true, true};
 
-        map["profswitch"].height += 1;
-        map["lock"].height = map["mute"].height = map["profswitch"].height;
+        map["mute"].height = map["profswitch"].height;
         map["mute"].y = map["profswitch"].y = map["lock"].y = map["ctrlwheelb"].y;
         map["volup"].y = map["ctrlwheelb"].y - 2;
         map["voldn"].y = map["ctrlwheelb"].y + 2;
-        map["profswitch"].x -= 1;
-        map["lock"].x += 1;
 
-        map["ctrlwheel1"] = {nullptr, "Control Wheel 22.5°",  "ctrlwheel1", 60+2, 10, 8, 6, true, false};
-        map["ctrlwheel2"] = {nullptr, "Control Wheel 67.5°",  "ctrlwheel2", 60+3, 10+1, 5, 8, true, false};
-        map["ctrlwheel3"] = {nullptr, "Control Wheel 112.5°", "ctrlwheel3", 60+3, 10+2, 5, 8, true, false};
-        map["ctrlwheel4"] = {nullptr, "Control Wheel 157.5°", "ctrlwheel4", 60+2, 10+3, 8, 6, true, false};
-        map["ctrlwheel5"] = {nullptr, "Control Wheel 202.5°", "ctrlwheel5", 60+1, 10+3, 8, 6, true, false};
-        map["ctrlwheel6"] = {nullptr, "Control Wheel 247.5°", "ctrlwheel6", 60, 10+2, 5, 8, true, false};
-        map["ctrlwheel7"] = {nullptr, "Control Wheel 292.5°", "ctrlwheel7", 60, 10+1, 5, 8, true, false};
-        map["ctrlwheel8"] = {nullptr, "Control Wheel 337.5°", "ctrlwheel8", 60+1, 10, 8, 6, true, false};
+        map["ctrlwheel1"] = {nullptr, "Control Wheel 22.5°",  "ctrlwheel1", 35+2, 10, 8, 6, true, false};
+        map["ctrlwheel2"] = {nullptr, "Control Wheel 67.5°",  "ctrlwheel2", 35+3, 10+1, 5, 8, true, false};
+        map["ctrlwheel3"] = {nullptr, "Control Wheel 112.5°", "ctrlwheel3", 35+3, 10+2, 5, 8, true, false};
+        map["ctrlwheel4"] = {nullptr, "Control Wheel 157.5°", "ctrlwheel4", 35+2, 10+3, 8, 6, true, false};
+        map["ctrlwheel5"] = {nullptr, "Control Wheel 202.5°", "ctrlwheel5", 35+1, 10+3, 8, 6, true, false};
+        map["ctrlwheel6"] = {nullptr, "Control Wheel 247.5°", "ctrlwheel6", 35, 10+2, 5, 8, true, false};
+        map["ctrlwheel7"] = {nullptr, "Control Wheel 292.5°", "ctrlwheel7", 35, 10+1, 5, 8, true, false};
+        map["ctrlwheel8"] = {nullptr, "Control Wheel 337.5°", "ctrlwheel8", 35+1, 10, 8, 6, true, false};
 
         map["logoleft"] = {nullptr, "Logo Left", "logoleft", 134, 10, 10, 10, true, false};
         map["logo"] = {nullptr, "Logo", "logo", 144, 10, 10, 10, true, false};


### PR DESCRIPTION
This PR is separated into two commits:

## Refactor K100 control wheel setup:

- Move whole cluster more left to be more in line with physical design,
- separate control wheel and media clusters in code, and
- replace individual assignments to `Key`'s attributes by full `Key` assignment to improve readability.

## Add scan codes for clockwise/counter-clockwise rotation of the wheel

- Add keys to `daemon/keymap.c`,
- add `Key`s to `gui/keymap.c`, and
- emit new scancodes for clockwise/counterclockwise rotation instead of hard-coded volup/voldown ones.

(I hope this format is still acceptable, I disclaim, that no LLMs were utilized in making this PR.)