### PR TITLE
Add copy button to "ckb-next-daemon not running" prompt

### DIFF
--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -138,6 +138,7 @@ if (MACOS OR LINUX)
               clickeventpushbutton.cpp
               colorbutton.cpp
               colormap.cpp
+              daemonwarndialog.cpp
               extrasettingswidget.cpp
               fwupgradedialog.cpp
               gradientbutton.cpp
@@ -195,6 +196,7 @@ if (MACOS OR LINUX)
               clickeventpushbutton.h
               colorbutton.h
               colormap.h
+              daemonwarndialog.h
               extrasettingswidget.h
               fwupgradedialog.h
               gradientbutton.h
@@ -249,6 +251,7 @@ if (MACOS OR LINUX)
               animdetailsdialog.ui
               animsettingdialog.ui
               ckbupdaterwidget.ui
+              daemonwarndialog.ui
               extrasettingswidget.ui
               fwupgradedialog.ui
               gradientdialog.ui

--- a/src/gui/daemonwarndialog.cpp
+++ b/src/gui/daemonwarndialog.cpp
@@ -1,0 +1,82 @@
+#include <QClipboard>
+#include <QLabel>
+#include <QScreen>
+#include <QStyle>
+#include <QTextDocument>
+
+#include "daemonwarndialog.h"
+#include "ui_daemonwarndialog.h"
+
+DaemonWarnDialog::DaemonWarnDialog(QWidget *parent) :
+    QDialog(parent),
+    ui(new Ui::DaemonWarnDialog)
+{
+    ui->setupUi(this);
+
+    // Release resources on exit.
+    this->setAttribute(Qt::WA_DeleteOnClose);
+
+    // Display Critical Message Box icon.
+    QStyle *style = this->style();
+    int imageSize = style->pixelMetric(QStyle::PM_MessageBoxIconSize, nullptr, this);
+    QIcon icon = style->standardIcon(QStyle::SP_MessageBoxCritical, nullptr, this);
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+    ui->iconLabel->setPixmap(icon.pixmap(QSize(imageSize, imageSize), this->devicePixelRatio()));
+#else // QT_VERSION < 6.0.0
+    ui->iconLabel->setPixmap(icon.pixmap(QSize(imageSize, imageSize)));
+#endif
+
+    // Display icon instead of name on copy buttons.
+    QIcon fallbackIcon = style->standardIcon(QStyle::SP_FileIcon, nullptr, this);
+#if QT_VERSION >= QT_VERSION_CHECK(6, 7, 0)
+    icon = QIcon::fromTheme(QIcon::ThemeIcon::EditCopy, fallbackIcon);
+#else // QT_VERSION < 6.7.0
+    icon = QIcon::fromTheme("edit-copy", fallbackIcon);
+#endif
+    ui->pushButton->setIcon(icon);
+    ui->pushButton_2->setIcon(icon);
+    ui->pushButton_3->setIcon(icon);
+
+#ifdef Q_OS_MACOS
+    // On Mac only one command is displayed. Hide the remaining elements.
+    ui->label_4->hide();
+    ui->label_5->hide();
+    ui->label_6->hide();
+    ui->label_7->hide();
+    ui->pushButton_2->hide();
+    ui->pushButton_3->hide();
+
+    ui->label_2->setText(tr("Start and enable it with:"));
+    ui->label_3->setText("<code>sudo launchctl load -w /Library/LaunchDaemons/org.ckb-next.daemon.plist</code>");
+#endif // Q_OS_MACOS
+
+    // Call copyText() with the appropriate label, when the copy buttons are
+    // pressed.
+    QObject::connect(ui->pushButton, &QPushButton::clicked, this, [=] () {
+        this->copyText(ui->label_3);
+    });
+    QObject::connect(ui->pushButton_2, &QPushButton::clicked, this, [=] () {
+        this->copyText(ui->label_5);
+    });
+    QObject::connect(ui->pushButton_3, &QPushButton::clicked, this, [=] () {
+        this->copyText(ui->label_7);
+    });
+
+    ui->gridLayout->activate();
+    this->setFixedSize(ui->gridLayoutWidget->geometry().size());
+}
+
+DaemonWarnDialog::~DaemonWarnDialog() {
+    delete ui;
+}
+
+void
+DaemonWarnDialog::copyText(QLabel *label)
+{
+    QClipboard *clipboard = QApplication::clipboard();
+
+    // Strip HTML tags when setting the clipboard content.
+    QTextDocument doc;
+    doc.setHtml(label->text());
+    clipboard->setText(doc.toPlainText());
+}

--- a/src/gui/daemonwarndialog.h
+++ b/src/gui/daemonwarndialog.h
@@ -1,0 +1,26 @@
+#ifndef DAEMONWARNDIALOG_H
+#define DAEMONWARNDIALOG_H
+
+#include <QDialog>
+#include <QLabel>
+
+namespace Ui {
+class DaemonWarnDialog;
+}
+
+class DaemonWarnDialog : public QDialog
+{
+    Q_OBJECT
+
+public:
+    explicit DaemonWarnDialog(QWidget *parent);
+    ~DaemonWarnDialog();
+
+private slots:
+    void copyText(QLabel *label);
+
+private:
+    Ui::DaemonWarnDialog *ui;
+};
+
+#endif // DAEMONWARNDIALOG_H

--- a/src/gui/daemonwarndialog.ui
+++ b/src/gui/daemonwarndialog.ui
@@ -1,0 +1,222 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>DaemonWarnDialog</class>
+ <widget class="QDialog" name="DaemonWarnDialog">
+  <property name="windowModality">
+   <enum>Qt::WindowModality::ApplicationModal</enum>
+  </property>
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>580</width>
+    <height>400</height>
+   </rect>
+  </property>
+  <property name="sizePolicy">
+   <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+    <horstretch>0</horstretch>
+    <verstretch>0</verstretch>
+   </sizepolicy>
+  </property>
+  <property name="windowTitle">
+   <string>ckb-next-daemon not running</string>
+  </property>
+  <property name="modal">
+   <bool>false</bool>
+  </property>
+  <widget class="QWidget" name="gridLayoutWidget">
+   <property name="geometry">
+    <rect>
+     <x>0</x>
+     <y>0</y>
+     <width>581</width>
+     <height>400</height>
+    </rect>
+   </property>
+   <layout class="QGridLayout" name="gridLayout" columnstretch="2,1,10,1">
+    <property name="leftMargin">
+     <number>16</number>
+    </property>
+    <property name="topMargin">
+     <number>16</number>
+    </property>
+    <property name="rightMargin">
+     <number>16</number>
+    </property>
+    <property name="bottomMargin">
+     <number>16</number>
+    </property>
+    <property name="spacing">
+     <number>8</number>
+    </property>
+    <item row="0" column="0" rowspan="8">
+     <widget class="QLabel" name="iconLabel">
+      <property name="text">
+       <string notr="true"/>
+      </property>
+      <property name="alignment">
+       <set>Qt::AlignmentFlag::AlignLeading|Qt::AlignmentFlag::AlignLeft|Qt::AlignmentFlag::AlignTop</set>
+      </property>
+      <property name="textInteractionFlags">
+       <set>Qt::TextInteractionFlag::NoTextInteraction</set>
+      </property>
+     </widget>
+    </item>
+    <item row="6" column="3">
+     <widget class="QPushButton" name="pushButton_3">
+      <property name="toolTip">
+       <string>Copy to clipboard</string>
+      </property>
+      <property name="text">
+       <string/>
+      </property>
+      <property name="flat">
+       <bool>false</bool>
+      </property>
+     </widget>
+    </item>
+    <item row="2" column="3">
+     <widget class="QPushButton" name="pushButton">
+      <property name="toolTip">
+       <string>Copy to clipboard</string>
+      </property>
+      <property name="text">
+       <string/>
+      </property>
+      <property name="default">
+       <bool>false</bool>
+      </property>
+      <property name="flat">
+       <bool>false</bool>
+      </property>
+     </widget>
+    </item>
+    <item row="4" column="3">
+     <widget class="QPushButton" name="pushButton_2">
+      <property name="toolTip">
+       <string>Copy to clipboard</string>
+      </property>
+      <property name="text">
+       <string/>
+      </property>
+      <property name="flat">
+       <bool>false</bool>
+      </property>
+     </widget>
+    </item>
+    <item row="6" column="2">
+     <widget class="QLabel" name="label_7">
+      <property name="text">
+       <string notr="true">&lt;code&gt;sudo systemctl unmask ckb-next-daemon&lt;/code&gt;</string>
+      </property>
+      <property name="textFormat">
+       <enum>Qt::TextFormat::RichText</enum>
+      </property>
+      <property name="wordWrap">
+       <bool>true</bool>
+      </property>
+      <property name="textInteractionFlags">
+       <set>Qt::TextInteractionFlag::LinksAccessibleByKeyboard|Qt::TextInteractionFlag::LinksAccessibleByMouse|Qt::TextInteractionFlag::TextBrowserInteraction|Qt::TextInteractionFlag::TextSelectableByKeyboard|Qt::TextInteractionFlag::TextSelectableByMouse</set>
+      </property>
+     </widget>
+    </item>
+    <item row="5" column="1" colspan="3">
+     <widget class="QLabel" name="label_6">
+      <property name="text">
+       <string>If &quot;Unit ckb-next-daemon.service is masked&quot;, unmask it first and try again:</string>
+      </property>
+     </widget>
+    </item>
+    <item row="7" column="1" colspan="3">
+     <widget class="QDialogButtonBox" name="buttonBox">
+      <property name="sizePolicy">
+       <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
+        <horstretch>0</horstretch>
+        <verstretch>0</verstretch>
+       </sizepolicy>
+      </property>
+      <property name="standardButtons">
+       <set>QDialogButtonBox::StandardButton::Ok</set>
+      </property>
+     </widget>
+    </item>
+    <item row="1" column="1" colspan="3">
+     <widget class="QLabel" name="label_2">
+      <property name="text">
+       <string>Start it once with:</string>
+      </property>
+     </widget>
+    </item>
+    <item row="0" column="1" colspan="3">
+     <widget class="QLabel" name="label">
+      <property name="text">
+       <string>The ckb-next daemon is not running. This program will &lt;b&gt;not&lt;/b&gt; work without it!</string>
+      </property>
+     </widget>
+    </item>
+    <item row="2" column="2">
+     <widget class="QLabel" name="label_3">
+      <property name="text">
+       <string notr="true">&lt;code&gt;sudo systemctl start ckb-next-daemon&lt;/code&gt;</string>
+      </property>
+      <property name="textFormat">
+       <enum>Qt::TextFormat::RichText</enum>
+      </property>
+      <property name="wordWrap">
+       <bool>true</bool>
+      </property>
+      <property name="textInteractionFlags">
+       <set>Qt::TextInteractionFlag::LinksAccessibleByKeyboard|Qt::TextInteractionFlag::LinksAccessibleByMouse|Qt::TextInteractionFlag::TextBrowserInteraction|Qt::TextInteractionFlag::TextSelectableByKeyboard|Qt::TextInteractionFlag::TextSelectableByMouse</set>
+      </property>
+     </widget>
+    </item>
+    <item row="3" column="1" colspan="3">
+     <widget class="QLabel" name="label_4">
+      <property name="text">
+       <string>Enable it for every boot:</string>
+      </property>
+     </widget>
+    </item>
+    <item row="4" column="2">
+     <widget class="QLabel" name="label_5">
+      <property name="text">
+       <string notr="true">&lt;code&gt;sudo systemctl enable ckb-next-daemon&lt;/code&gt;</string>
+      </property>
+      <property name="textFormat">
+       <enum>Qt::TextFormat::RichText</enum>
+      </property>
+      <property name="wordWrap">
+       <bool>true</bool>
+      </property>
+      <property name="textInteractionFlags">
+       <set>Qt::TextInteractionFlag::LinksAccessibleByKeyboard|Qt::TextInteractionFlag::LinksAccessibleByMouse|Qt::TextInteractionFlag::TextBrowserInteraction|Qt::TextInteractionFlag::TextSelectableByKeyboard|Qt::TextInteractionFlag::TextSelectableByMouse</set>
+      </property>
+     </widget>
+    </item>
+   </layout>
+  </widget>
+ </widget>
+ <resources/>
+ <connections>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>accepted()</signal>
+   <receiver>DaemonWarnDialog</receiver>
+   <slot>accept()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>286</x>
+     <y>279</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>445</x>
+     <y>293</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
+ <slots>
+  <slot>accept()</slot>
+ </slots>
+</ui>

--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -24,6 +24,7 @@ XWindowDetector* windowDetector = nullptr;
 #endif
 
 #include "ckbsystemtrayicon.h"
+#include "daemonwarndialog.h"
 
 
 extern QSharedMemory appShare;
@@ -163,25 +164,7 @@ MainWindow::MainWindow(const bool silent, QWidget *parent) :
     ui->tabWidget->addTab(settingsWidget = new SettingsWidget(this), QString(tr("Settings")));
     settingsWidget->setVersion(KbManager::ckbGuiVersion());
 
-    // create daemon dialog as a QMessageBox
-    // this will create a focussed dialog, that has to be interacted with,
-    // if the daemon is not running
-    // set the main and informative text to tell the user about the issue
-    QMessageBox dialog;
-    dialog.setText(tr("The ckb-next daemon is not running. This program will <b>not</b> work without it!"));
-#ifndef Q_OS_MACOS
-    QString daemonDialogText = tr("Start it once with:") +
-    "<blockquote><code>sudo systemctl start ckb-next-daemon</code></blockquote>" +
-    tr("Enable it for every boot:") +
-    "<blockquote><code>sudo systemctl enable ckb-next-daemon</code></blockquote><br>" +
-    tr("If \"Unit ckb-next-daemon.service is masked.\", unmask it first and try again:") +
-    "<blockquote><code>sudo systemctl unmask ckb-next-daemon</code></blockquote>";
-#else
-    QString daemonDialogText = QString(tr("Start and enable it with:")) +
-    "<blockquote><code>sudo launchctl load -w /Library/LaunchDaemons/org.ckb-next.daemon.plist</code></blockquote>";
-#endif
-    dialog.setInformativeText(daemonDialogText);
-    dialog.setIcon(QMessageBox::Critical);
+    DaemonWarnDialog *warnDialog = new DaemonWarnDialog(mainWindow);
 
     // Set up signal handler
     socketpair(AF_UNIX, SOCK_STREAM, 0, MainWindow::signalHandlerFd);
@@ -205,7 +188,7 @@ MainWindow::MainWindow(const bool silent, QWidget *parent) :
         // finally show the dialog
         settingsWidget->setStatus(tr("The ckb-next daemon is not running."));
         showWindow();
-        dialog.exec();
+        warnDialog->open();
     }
 #ifndef DISABLE_UPDATER
     if(!CkbSettings::get("Program/DisableAutoUpdCheck", false).toBool())

--- a/src/gui/resources/translations/de.ts
+++ b/src/gui/resources/translations/de.ts
@@ -425,32 +425,32 @@
         <location filename="../../daemonwarndialog.ui" line="82"/>
         <location filename="../../daemonwarndialog.ui" line="98"/>
         <source>Copy to clipboard</source>
-        <translation type="unfinished"></translation>
+        <translation>In die Zwischenablage kopieren</translation>
     </message>
     <message>
         <location filename="../../daemonwarndialog.ui" line="127"/>
         <source>If &quot;Unit ckb-next-daemon.service is masked&quot;, unmask it first and try again:</source>
-        <translation type="unfinished"></translation>
+        <translation>Falls Sie die Nachricht &quot;Dienst ckb-next-daemon.service ist maskiert&quot; erhalten, entsperren Sie ihn und versuchen Sie es erneut:</translation>
     </message>
     <message>
         <location filename="../../daemonwarndialog.ui" line="147"/>
         <source>Start it once with:</source>
-        <translation type="unfinished">Einmalig starten mit:</translation>
+        <translation>Einmalig starten mit:</translation>
     </message>
     <message>
         <location filename="../../daemonwarndialog.ui" line="154"/>
         <source>The ckb-next daemon is not running. This program will &lt;b&gt;not&lt;/b&gt; work without it!</source>
-        <translation type="unfinished">Der ckb-next-Daemon läuft nicht. Das Programm wird ohne &lt;b&gt;nicht&lt;/b&gt; nicht funktionieren!</translation>
+        <translation>Der ckb-next-Daemon läuft nicht. Das Programm wird ohne &lt;b&gt;nicht&lt;/b&gt; nicht funktionieren!</translation>
     </message>
     <message>
         <location filename="../../daemonwarndialog.ui" line="177"/>
         <source>Enable it for every boot:</source>
-        <translation type="unfinished">Für jeden Systemstart aktivieren:</translation>
+        <translation>Für jeden Systemstart aktivieren:</translation>
     </message>
     <message>
         <location filename="../../daemonwarndialog.cpp" line="49"/>
         <source>Start and enable it with:</source>
-        <translation type="unfinished">Starten und aktivieren mit:</translation>
+        <translation>Starten und aktivieren mit:</translation>
     </message>
 </context>
 <context>

--- a/src/gui/resources/translations/de.ts
+++ b/src/gui/resources/translations/de.ts
@@ -414,6 +414,46 @@
     </message>
 </context>
 <context>
+    <name>DaemonWarnDialog</name>
+    <message>
+        <location filename="../../daemonwarndialog.ui" line="23"/>
+        <source>ckb-next-daemon not running</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../daemonwarndialog.ui" line="69"/>
+        <location filename="../../daemonwarndialog.ui" line="82"/>
+        <location filename="../../daemonwarndialog.ui" line="98"/>
+        <source>Copy to clipboard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../daemonwarndialog.ui" line="127"/>
+        <source>If &quot;Unit ckb-next-daemon.service is masked&quot;, unmask it first and try again:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../daemonwarndialog.ui" line="147"/>
+        <source>Start it once with:</source>
+        <translation type="unfinished">Einmalig starten mit:</translation>
+    </message>
+    <message>
+        <location filename="../../daemonwarndialog.ui" line="154"/>
+        <source>The ckb-next daemon is not running. This program will &lt;b&gt;not&lt;/b&gt; work without it!</source>
+        <translation type="unfinished">Der ckb-next-Daemon läuft nicht. Das Programm wird ohne &lt;b&gt;nicht&lt;/b&gt; nicht funktionieren!</translation>
+    </message>
+    <message>
+        <location filename="../../daemonwarndialog.ui" line="177"/>
+        <source>Enable it for every boot:</source>
+        <translation type="unfinished">Für jeden Systemstart aktivieren:</translation>
+    </message>
+    <message>
+        <location filename="../../daemonwarndialog.cpp" line="49"/>
+        <source>Start and enable it with:</source>
+        <translation type="unfinished">Starten und aktivieren mit:</translation>
+    </message>
+</context>
+<context>
     <name>ExtraSettingsWidget</name>
     <message>
         <location filename="../../extrasettingswidget.ui" line="309"/>
@@ -2215,109 +2255,104 @@ Es wird versucht, so viele wie möglich zu importieren.</translation>
         <translation>Über</translation>
     </message>
     <message>
-        <location filename="../../mainwindow.cpp" line="136"/>
+        <location filename="../../mainwindow.cpp" line="137"/>
         <source>Restore</source>
         <translation>Wiederherstellen</translation>
     </message>
     <message>
-        <location filename="../../mainwindow.cpp" line="137"/>
+        <location filename="../../mainwindow.cpp" line="138"/>
         <source>Quit</source>
         <translation>Beenden</translation>
     </message>
     <message>
-        <location filename="../../mainwindow.cpp" line="163"/>
+        <location filename="../../mainwindow.cpp" line="164"/>
         <source>Settings</source>
         <translation>Einstellungen</translation>
     </message>
     <message>
-        <location filename="../../mainwindow.cpp" line="171"/>
         <source>The ckb-next daemon is not running. This program will &lt;b&gt;not&lt;/b&gt; work without it!</source>
-        <translation>Der ckb-next-Daemon läuft nicht. Das Programm wird ohne &lt;b&gt;nicht&lt;/b&gt; nicht funktionieren!</translation>
+        <translation type="vanished">Der ckb-next-Daemon läuft nicht. Das Programm wird ohne &lt;b&gt;nicht&lt;/b&gt; nicht funktionieren!</translation>
     </message>
     <message>
-        <location filename="../../mainwindow.cpp" line="173"/>
         <source>Start it once with:</source>
-        <translation>Einmalig starten mit:</translation>
+        <translation type="vanished">Einmalig starten mit:</translation>
     </message>
     <message>
-        <location filename="../../mainwindow.cpp" line="175"/>
         <source>Enable it for every boot:</source>
-        <translation>Für jeden Systemstart aktivieren:</translation>
+        <translation type="vanished">Für jeden Systemstart aktivieren:</translation>
     </message>
     <message>
-        <location filename="../../mainwindow.cpp" line="177"/>
         <source>If &quot;Unit ckb-next-daemon.service is masked.&quot;, unmask it first and try again:</source>
-        <translation>Falls Sie die Nachricht &quot;Dienst ckb-next-daemon.service ist maskiert&quot; erhalten, entsperren Sie ihn und versuchen Sie es erneut:</translation>
+        <translation type="vanished">Falls Sie die Nachricht &quot;Dienst ckb-next-daemon.service ist maskiert&quot; erhalten, entsperren Sie ihn und versuchen Sie es erneut:</translation>
     </message>
     <message>
-        <location filename="../../mainwindow.cpp" line="180"/>
         <source>Start and enable it with:</source>
-        <translation>Starten und aktivieren mit:</translation>
+        <translation type="vanished">Starten und aktivieren mit:</translation>
     </message>
     <message>
-        <location filename="../../mainwindow.cpp" line="206"/>
+        <location filename="../../mainwindow.cpp" line="189"/>
         <source>The ckb-next daemon is not running.</source>
         <translation>Der ckb-next-Daemon läuft nicht.</translation>
     </message>
     <message>
-        <location filename="../../mainwindow.cpp" line="293"/>
+        <location filename="../../mainwindow.cpp" line="276"/>
         <source>Driver inactive</source>
         <translation>Treiber inaktiv</translation>
     </message>
     <message>
-        <location filename="../../mainwindow.cpp" line="300"/>
+        <location filename="../../mainwindow.cpp" line="283"/>
         <source>&lt;br /&gt;&lt;br /&gt;&lt;b&gt;Warning:&lt;/b&gt; Driver version mismatch (</source>
         <translation>&lt;br /&gt;&lt;br /&gt;&lt;b&gt;Warnung:&lt;/b&gt; Treiber-Version stimmt nicht überein(</translation>
     </message>
     <message>
-        <location filename="../../mainwindow.cpp" line="300"/>
+        <location filename="../../mainwindow.cpp" line="283"/>
         <source>). Please upgrade ckb-next</source>
         <translation>). Bitte aktualisieren Sie ckb-next</translation>
     </message>
     <message>
-        <location filename="../../mainwindow.cpp" line="300"/>
+        <location filename="../../mainwindow.cpp" line="283"/>
         <source>. If the problem persists, try rebooting.</source>
         <translation>. Wenn das Problem weiterhin besteht, versuchen Sie es mit einem Rechner-Neustart.</translation>
     </message>
     <message>
-        <location filename="../../mainwindow.cpp" line="311"/>
+        <location filename="../../mainwindow.cpp" line="294"/>
         <source>&lt;br /&gt;&lt;b&gt;Warning:&lt;/b&gt; System Extension by &quot;Fumihiko Takayama&quot; is not allowed in Security &amp; Privacy. Please allow it and then unplug and replug your devices.</source>
         <translation>&lt;br /&gt;&lt;b&gt;Warnung:&lt;/b&gt; Die Systemerweiterung von &quot;Fumihiko Takayama&quot; ist unter Sicherheit &amp; Datenschutz nicht erlaubt. Bitte lassen Sie sie zu und stecken Sie dann Ihre Geräte ab und wieder an.</translation>
     </message>
     <message>
-        <location filename="../../mainwindow.cpp" line="313"/>
+        <location filename="../../mainwindow.cpp" line="296"/>
         <source>&lt;br /&gt;&lt;b&gt;Warning:&lt;/b&gt; Make sure ckb-next-daemon is allowed in Security &amp; Privacy -&gt; Input monitoring.&lt;br /&gt;Please allow for up to 10 seconds for the daemon restart prompt to show up after allowing input monitoring.</source>
         <translation>&lt;br /&gt;&lt;b&gt;Warnung:&lt;/b&gt; Stellen Sie sicher, dass ckb-next-daemon unter Sicherheit &amp; Datenschutz-&gt; Eingabeüberwachung zugelassen ist. &lt;br /&gt;Bitte warten Sie bis zu 10 Sekunden, bis die Aufforderung zum Neustart des Daemons erscheint, nachdem Sie die Eingabeüberwachung zugelassen haben.</translation>
     </message>
     <message>
-        <location filename="../../mainwindow.cpp" line="323"/>
+        <location filename="../../mainwindow.cpp" line="306"/>
         <source>&lt;br /&gt;&lt;b&gt;Warning:&lt;/b&gt; The uinput module could not be loaded. If this issue persists after rebooting, compile a kernel with CONFIG_INPUT_UINPUT=y.</source>
         <translation>&lt;br /&gt;&lt;b&gt;Warnung:&lt;/b&gt; Das uinput-Modul konnte nicht geladen werden. Wenn dieses Problem nach einem Neustart weiterhin besteht, kompilieren Sie einen Kernel mit CONFIG_INPUT_UINPUT=y.</translation>
     </message>
     <message>
-        <location filename="../../mainwindow.cpp" line="326"/>
+        <location filename="../../mainwindow.cpp" line="309"/>
         <source>No devices connected</source>
         <translation>Keine Geräte verbunden</translation>
     </message>
     <message>
-        <location filename="../../mainwindow.cpp" line="329"/>
+        <location filename="../../mainwindow.cpp" line="312"/>
         <source>1 device connected</source>
         <translation>1 Gerät verbunden</translation>
     </message>
     <message>
-        <location filename="../../mainwindow.cpp" line="331"/>
+        <location filename="../../mainwindow.cpp" line="314"/>
         <source>%1 devices connected</source>
         <translation>%1 Geräte verbunden</translation>
     </message>
     <message>
-        <location filename="../../mainwindow.cpp" line="362"/>
+        <location filename="../../mainwindow.cpp" line="345"/>
         <source>A new firmware is available for your %1 (v%2)
 Would you like to install it now?</source>
         <translation>Eine neue Firmware ist für Ihr(e) %1 (v%2) verfübar
 Möchten Sie sie installieren?</translation>
     </message>
     <message>
-        <location filename="../../mainwindow.cpp" line="378"/>
+        <location filename="../../mainwindow.cpp" line="361"/>
         <source>ckb-next will still run in the background.
 To close it, choose Quit from the tray menu
 or click &quot;Quit&quot; on the Settings screen.</source>
@@ -2326,12 +2361,12 @@ Um es zu beenden, wählen Sie Beenden aus dem Tray-Menü
 oder klicken Sie auf &quot;Beenden&quot; in den Einstellungen.</translation>
     </message>
     <message>
-        <location filename="../../mainwindow.cpp" line="539"/>
+        <location filename="../../mainwindow.cpp" line="522"/>
         <source>Update to v</source>
         <translation>Aktualisieren auf v</translation>
     </message>
     <message>
-        <location filename="../../mainwindow.cpp" line="544"/>
+        <location filename="../../mainwindow.cpp" line="527"/>
         <source>Up to date</source>
         <translation>Aktuell</translation>
     </message>

--- a/src/gui/resources/translations/el.ts
+++ b/src/gui/resources/translations/el.ts
@@ -400,6 +400,46 @@
     </message>
 </context>
 <context>
+    <name>DaemonWarnDialog</name>
+    <message>
+        <location filename="../../daemonwarndialog.ui" line="23"/>
+        <source>ckb-next-daemon not running</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../daemonwarndialog.ui" line="69"/>
+        <location filename="../../daemonwarndialog.ui" line="82"/>
+        <location filename="../../daemonwarndialog.ui" line="98"/>
+        <source>Copy to clipboard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../daemonwarndialog.ui" line="127"/>
+        <source>If &quot;Unit ckb-next-daemon.service is masked&quot;, unmask it first and try again:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../daemonwarndialog.ui" line="147"/>
+        <source>Start it once with:</source>
+        <translation type="unfinished">Εκκινήστε το μια φορά με:</translation>
+    </message>
+    <message>
+        <location filename="../../daemonwarndialog.ui" line="154"/>
+        <source>The ckb-next daemon is not running. This program will &lt;b&gt;not&lt;/b&gt; work without it!</source>
+        <translation type="unfinished">Το ckb-next-daemon δεν τρέχει. Αυτό το πρόγραμμα &lt;b&gt;δεν&lt;/b&gt; θα λειτουργήσει χωρίς αυτό!</translation>
+    </message>
+    <message>
+        <location filename="../../daemonwarndialog.ui" line="177"/>
+        <source>Enable it for every boot:</source>
+        <translation type="unfinished">Ενεργοποιήστε το για κάθε εκκίνηση:</translation>
+    </message>
+    <message>
+        <location filename="../../daemonwarndialog.cpp" line="49"/>
+        <source>Start and enable it with:</source>
+        <translation type="unfinished">Εκκινήστε και ενεργοποιήστε το με:</translation>
+    </message>
+</context>
+<context>
     <name>ExtraSettingsWidget</name>
     <message>
         <location filename="../../extrasettingswidget.ui" line="20"/>
@@ -2224,12 +2264,12 @@ An attempt will be made to import as many as possible.</source>
         <translation>Σχετικά</translation>
     </message>
     <message>
-        <location filename="../../mainwindow.cpp" line="136"/>
+        <location filename="../../mainwindow.cpp" line="137"/>
         <source>Restore</source>
         <translation>Επαναφορά</translation>
     </message>
     <message>
-        <location filename="../../mainwindow.cpp" line="137"/>
+        <location filename="../../mainwindow.cpp" line="138"/>
         <source>Quit</source>
         <translation>Έξοδος</translation>
     </message>
@@ -2238,98 +2278,93 @@ An attempt will be made to import as many as possible.</source>
         <translation type="vanished">Μονόχρωμο Εικονίδιο</translation>
     </message>
     <message>
-        <location filename="../../mainwindow.cpp" line="163"/>
+        <location filename="../../mainwindow.cpp" line="164"/>
         <source>Settings</source>
         <translation>Ρυθμίσεις</translation>
     </message>
     <message>
-        <location filename="../../mainwindow.cpp" line="171"/>
         <source>The ckb-next daemon is not running. This program will &lt;b&gt;not&lt;/b&gt; work without it!</source>
-        <translation>Το ckb-next-daemon δεν τρέχει. Αυτό το πρόγραμμα &lt;b&gt;δεν&lt;/b&gt; θα λειτουργήσει χωρίς αυτό!</translation>
+        <translation type="vanished">Το ckb-next-daemon δεν τρέχει. Αυτό το πρόγραμμα &lt;b&gt;δεν&lt;/b&gt; θα λειτουργήσει χωρίς αυτό!</translation>
     </message>
     <message>
-        <location filename="../../mainwindow.cpp" line="173"/>
         <source>Start it once with:</source>
-        <translation>Εκκινήστε το μια φορά με:</translation>
+        <translation type="vanished">Εκκινήστε το μια φορά με:</translation>
     </message>
     <message>
-        <location filename="../../mainwindow.cpp" line="175"/>
         <source>Enable it for every boot:</source>
-        <translation>Ενεργοποιήστε το για κάθε εκκίνηση:</translation>
+        <translation type="vanished">Ενεργοποιήστε το για κάθε εκκίνηση:</translation>
     </message>
     <message>
-        <location filename="../../mainwindow.cpp" line="177"/>
         <source>If &quot;Unit ckb-next-daemon.service is masked.&quot;, unmask it first and try again:</source>
-        <translation>Αν &quot;Unit ckb-next-daemon.service is masked.&quot;, τότε ξεμασκαρέψτε το και προσπαθήστε ξανά:</translation>
+        <translation type="vanished">Αν &quot;Unit ckb-next-daemon.service is masked.&quot;, τότε ξεμασκαρέψτε το και προσπαθήστε ξανά:</translation>
     </message>
     <message>
-        <location filename="../../mainwindow.cpp" line="180"/>
         <source>Start and enable it with:</source>
-        <translation>Εκκινήστε και ενεργοποιήστε το με:</translation>
+        <translation type="vanished">Εκκινήστε και ενεργοποιήστε το με:</translation>
     </message>
     <message>
-        <location filename="../../mainwindow.cpp" line="206"/>
+        <location filename="../../mainwindow.cpp" line="189"/>
         <source>The ckb-next daemon is not running.</source>
         <translation>Το ckb-next-daemon δεν τρέχει.</translation>
     </message>
     <message>
-        <location filename="../../mainwindow.cpp" line="293"/>
+        <location filename="../../mainwindow.cpp" line="276"/>
         <source>Driver inactive</source>
         <translation>Ο driver είναι αδρανής</translation>
     </message>
     <message>
-        <location filename="../../mainwindow.cpp" line="300"/>
+        <location filename="../../mainwindow.cpp" line="283"/>
         <source>&lt;br /&gt;&lt;br /&gt;&lt;b&gt;Warning:&lt;/b&gt; Driver version mismatch (</source>
         <translation>&lt;br /&gt;&lt;br /&gt;&lt;b&gt;Προσοχή:&lt;/b&gt; Ασυμφωνία έκδοσης του driver (</translation>
     </message>
     <message>
-        <location filename="../../mainwindow.cpp" line="300"/>
+        <location filename="../../mainwindow.cpp" line="283"/>
         <source>). Please upgrade ckb-next</source>
         <translation>). Παρακαλώ ενημερώστε το ckb-next</translation>
     </message>
     <message>
-        <location filename="../../mainwindow.cpp" line="300"/>
+        <location filename="../../mainwindow.cpp" line="283"/>
         <source>. If the problem persists, try rebooting.</source>
         <translation>.&lt;br /&gt;Αν το πρόβλημα παραμένει, επανεκκινήστε το σύστημά σας.</translation>
     </message>
     <message>
-        <location filename="../../mainwindow.cpp" line="311"/>
+        <location filename="../../mainwindow.cpp" line="294"/>
         <source>&lt;br /&gt;&lt;b&gt;Warning:&lt;/b&gt; System Extension by &quot;Fumihiko Takayama&quot; is not allowed in Security &amp; Privacy. Please allow it and then unplug and replug your devices.</source>
         <translation>&lt;br /&gt;&lt;b&gt;Ποσοχή:&lt;/b&gt; Η επέκταση από &quot;Fumihiko Takayama&quot; δεν επιτρέπεται στο Ασφάλεια και απόρρητο. Επιτρέψτε το και επανασυνδέστε τις συσκευές.</translation>
     </message>
     <message>
-        <location filename="../../mainwindow.cpp" line="313"/>
+        <location filename="../../mainwindow.cpp" line="296"/>
         <source>&lt;br /&gt;&lt;b&gt;Warning:&lt;/b&gt; Make sure ckb-next-daemon is allowed in Security &amp; Privacy -&gt; Input monitoring.&lt;br /&gt;Please allow for up to 10 seconds for the daemon restart prompt to show up after allowing input monitoring.</source>
         <translation>&lt;br /&gt;&lt;b&gt;Προσοχή:&lt;/b&gt; Σιγουρευτείτε ότι το ckb-next-daemon επιτρέπεται στο Ασφάλεια και απόρρητο -&gt; Παρακολούθησή εισόδου.&lt;/br /&gt;Παρακαλώ επιτρέψτε μέχρι 10 δευτερόλεπτα μέχρι να εμφανιστεί η ειδοποίηση ενεργοποιήσης του daemon.</translation>
     </message>
     <message>
-        <location filename="../../mainwindow.cpp" line="323"/>
+        <location filename="../../mainwindow.cpp" line="306"/>
         <source>&lt;br /&gt;&lt;b&gt;Warning:&lt;/b&gt; The uinput module could not be loaded. If this issue persists after rebooting, compile a kernel with CONFIG_INPUT_UINPUT=y.</source>
         <translation>&lt;br /&gt;&lt;b&gt;Προσοχή:&lt;/b&gt; Δεν ήταν δυνατό να φορτωθεί το άρθρωμα πυρήνα uinput. Αν αυτο το πρόβλημα παραμένει μετά από επανεκκίνηση, μεταγλωττίστε πυρήνα με CONFIG_INPUT_UINPUT=y.</translation>
     </message>
     <message>
-        <location filename="../../mainwindow.cpp" line="326"/>
+        <location filename="../../mainwindow.cpp" line="309"/>
         <source>No devices connected</source>
         <translation>Δεν υπάρχουν συνδεδεμένες συσκευές</translation>
     </message>
     <message>
-        <location filename="../../mainwindow.cpp" line="329"/>
+        <location filename="../../mainwindow.cpp" line="312"/>
         <source>1 device connected</source>
         <translation>1 συσκευή συνδεδεμένη</translation>
     </message>
     <message>
-        <location filename="../../mainwindow.cpp" line="331"/>
+        <location filename="../../mainwindow.cpp" line="314"/>
         <source>%1 devices connected</source>
         <translation>%1 συσκευές συνδεδεμένες</translation>
     </message>
     <message>
-        <location filename="../../mainwindow.cpp" line="362"/>
+        <location filename="../../mainwindow.cpp" line="345"/>
         <source>A new firmware is available for your %1 (v%2)
 Would you like to install it now?</source>
         <translation>Υπάρχει νέο firmware για το %1 σας (v%2) Θα θέλατε να το εγκαταστήσετε τώρα;</translation>
     </message>
     <message>
-        <location filename="../../mainwindow.cpp" line="378"/>
+        <location filename="../../mainwindow.cpp" line="361"/>
         <source>ckb-next will still run in the background.
 To close it, choose Quit from the tray menu
 or click &quot;Quit&quot; on the Settings screen.</source>
@@ -2338,12 +2373,12 @@ or click &quot;Quit&quot; on the Settings screen.</source>
 ή κάντε κλικ στο &quot;Έξοδος&quot; στο παράθυρο ρυθμίσεων.</translation>
     </message>
     <message>
-        <location filename="../../mainwindow.cpp" line="539"/>
+        <location filename="../../mainwindow.cpp" line="522"/>
         <source>Update to v</source>
         <translation>Ενημέρωση στο v</translation>
     </message>
     <message>
-        <location filename="../../mainwindow.cpp" line="544"/>
+        <location filename="../../mainwindow.cpp" line="527"/>
         <source>Up to date</source>
         <translation>Ενημερωμένο</translation>
     </message>

--- a/src/gui/resources/translations/el.ts
+++ b/src/gui/resources/translations/el.ts
@@ -404,39 +404,39 @@
     <message>
         <location filename="../../daemonwarndialog.ui" line="23"/>
         <source>ckb-next-daemon not running</source>
-        <translation type="unfinished"></translation>
+        <translation>Το ckb-next-daemon δεν τρέχει</translation>
     </message>
     <message>
         <location filename="../../daemonwarndialog.ui" line="69"/>
         <location filename="../../daemonwarndialog.ui" line="82"/>
         <location filename="../../daemonwarndialog.ui" line="98"/>
         <source>Copy to clipboard</source>
-        <translation type="unfinished"></translation>
+        <translation>Αντιγραφή στο πρόχειρο</translation>
     </message>
     <message>
         <location filename="../../daemonwarndialog.ui" line="127"/>
         <source>If &quot;Unit ckb-next-daemon.service is masked&quot;, unmask it first and try again:</source>
-        <translation type="unfinished"></translation>
+        <translation>Αν &quot;Unit ckb-next-daemon.service is masked.&quot;, τότε ξεμασκαρέψτε το και προσπαθήστε ξανά:</translation>
     </message>
     <message>
         <location filename="../../daemonwarndialog.ui" line="147"/>
         <source>Start it once with:</source>
-        <translation type="unfinished">Εκκινήστε το μια φορά με:</translation>
+        <translation>Εκκινήστε το μια φορά με:</translation>
     </message>
     <message>
         <location filename="../../daemonwarndialog.ui" line="154"/>
         <source>The ckb-next daemon is not running. This program will &lt;b&gt;not&lt;/b&gt; work without it!</source>
-        <translation type="unfinished">Το ckb-next-daemon δεν τρέχει. Αυτό το πρόγραμμα &lt;b&gt;δεν&lt;/b&gt; θα λειτουργήσει χωρίς αυτό!</translation>
+        <translation>Το ckb-next-daemon δεν τρέχει. Αυτό το πρόγραμμα &lt;b&gt;δεν&lt;/b&gt; θα λειτουργήσει χωρίς αυτό!</translation>
     </message>
     <message>
         <location filename="../../daemonwarndialog.ui" line="177"/>
         <source>Enable it for every boot:</source>
-        <translation type="unfinished">Ενεργοποιήστε το για κάθε εκκίνηση:</translation>
+        <translation>Ενεργοποιήστε το για κάθε εκκίνηση:</translation>
     </message>
     <message>
         <location filename="../../daemonwarndialog.cpp" line="49"/>
         <source>Start and enable it with:</source>
-        <translation type="unfinished">Εκκινήστε και ενεργοποιήστε το με:</translation>
+        <translation>Εκκινήστε και ενεργοποιήστε το με:</translation>
     </message>
 </context>
 <context>

--- a/src/gui/resources/translations/en_GB.ts
+++ b/src/gui/resources/translations/en_GB.ts
@@ -400,6 +400,46 @@
     </message>
 </context>
 <context>
+    <name>DaemonWarnDialog</name>
+    <message>
+        <location filename="../../daemonwarndialog.ui" line="23"/>
+        <source>ckb-next-daemon not running</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../daemonwarndialog.ui" line="69"/>
+        <location filename="../../daemonwarndialog.ui" line="82"/>
+        <location filename="../../daemonwarndialog.ui" line="98"/>
+        <source>Copy to clipboard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../daemonwarndialog.ui" line="127"/>
+        <source>If &quot;Unit ckb-next-daemon.service is masked&quot;, unmask it first and try again:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../daemonwarndialog.ui" line="147"/>
+        <source>Start it once with:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../daemonwarndialog.ui" line="154"/>
+        <source>The ckb-next daemon is not running. This program will &lt;b&gt;not&lt;/b&gt; work without it!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../daemonwarndialog.ui" line="177"/>
+        <source>Enable it for every boot:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../daemonwarndialog.cpp" line="49"/>
+        <source>Start and enable it with:</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>ExtraSettingsWidget</name>
     <message>
         <location filename="../../extrasettingswidget.ui" line="309"/>
@@ -2136,120 +2176,95 @@ An attempt will be made to import as many as possible.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../mainwindow.cpp" line="136"/>
+        <location filename="../../mainwindow.cpp" line="137"/>
         <source>Restore</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../mainwindow.cpp" line="137"/>
+        <location filename="../../mainwindow.cpp" line="138"/>
         <source>Quit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../mainwindow.cpp" line="163"/>
+        <location filename="../../mainwindow.cpp" line="164"/>
         <source>Settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../mainwindow.cpp" line="171"/>
-        <source>The ckb-next daemon is not running. This program will &lt;b&gt;not&lt;/b&gt; work without it!</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../mainwindow.cpp" line="173"/>
-        <source>Start it once with:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../mainwindow.cpp" line="175"/>
-        <source>Enable it for every boot:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../mainwindow.cpp" line="177"/>
-        <source>If &quot;Unit ckb-next-daemon.service is masked.&quot;, unmask it first and try again:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../mainwindow.cpp" line="180"/>
-        <source>Start and enable it with:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../../mainwindow.cpp" line="206"/>
+        <location filename="../../mainwindow.cpp" line="189"/>
         <source>The ckb-next daemon is not running.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../mainwindow.cpp" line="293"/>
+        <location filename="../../mainwindow.cpp" line="276"/>
         <source>Driver inactive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../mainwindow.cpp" line="300"/>
+        <location filename="../../mainwindow.cpp" line="283"/>
         <source>&lt;br /&gt;&lt;br /&gt;&lt;b&gt;Warning:&lt;/b&gt; Driver version mismatch (</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../mainwindow.cpp" line="300"/>
+        <location filename="../../mainwindow.cpp" line="283"/>
         <source>). Please upgrade ckb-next</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../mainwindow.cpp" line="300"/>
+        <location filename="../../mainwindow.cpp" line="283"/>
         <source>. If the problem persists, try rebooting.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../mainwindow.cpp" line="311"/>
+        <location filename="../../mainwindow.cpp" line="294"/>
         <source>&lt;br /&gt;&lt;b&gt;Warning:&lt;/b&gt; System Extension by &quot;Fumihiko Takayama&quot; is not allowed in Security &amp; Privacy. Please allow it and then unplug and replug your devices.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../mainwindow.cpp" line="313"/>
+        <location filename="../../mainwindow.cpp" line="296"/>
         <source>&lt;br /&gt;&lt;b&gt;Warning:&lt;/b&gt; Make sure ckb-next-daemon is allowed in Security &amp; Privacy -&gt; Input monitoring.&lt;br /&gt;Please allow for up to 10 seconds for the daemon restart prompt to show up after allowing input monitoring.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../mainwindow.cpp" line="323"/>
+        <location filename="../../mainwindow.cpp" line="306"/>
         <source>&lt;br /&gt;&lt;b&gt;Warning:&lt;/b&gt; The uinput module could not be loaded. If this issue persists after rebooting, compile a kernel with CONFIG_INPUT_UINPUT=y.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../mainwindow.cpp" line="326"/>
+        <location filename="../../mainwindow.cpp" line="309"/>
         <source>No devices connected</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../mainwindow.cpp" line="329"/>
+        <location filename="../../mainwindow.cpp" line="312"/>
         <source>1 device connected</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../mainwindow.cpp" line="331"/>
+        <location filename="../../mainwindow.cpp" line="314"/>
         <source>%1 devices connected</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../mainwindow.cpp" line="362"/>
+        <location filename="../../mainwindow.cpp" line="345"/>
         <source>A new firmware is available for your %1 (v%2)
 Would you like to install it now?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../mainwindow.cpp" line="378"/>
+        <location filename="../../mainwindow.cpp" line="361"/>
         <source>ckb-next will still run in the background.
 To close it, choose Quit from the tray menu
 or click &quot;Quit&quot; on the Settings screen.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../mainwindow.cpp" line="539"/>
+        <location filename="../../mainwindow.cpp" line="522"/>
         <source>Update to v</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../mainwindow.cpp" line="544"/>
+        <location filename="../../mainwindow.cpp" line="527"/>
         <source>Up to date</source>
         <translation type="unfinished"></translation>
     </message>


### PR DESCRIPTION
Re-Implement ad-hoc `QMessageBox` as a custom `QDialog`, that adds functionality of copying the service-commands into the clipboard. The commands additionally are keyboard- and mouse-interactable.

Also added DE translations as well (only the dialog title and "Copy to clipboard" are new items, the rest were used in the ad-hoc dialog before).

Coded on a sick day.

Closes #1277 