### PR TITLE
feat: Add Cats Lock mode to keyboard Performance tab

### DIFF
--- a/src/gui/kbbind.cpp
+++ b/src/gui/kbbind.cpp
@@ -281,16 +281,16 @@ void KbBind::update(QFile& cmd, int notify, bool force){
             "grave","1","2","3","4","5","6","7","8","9","0","minus","equal","bspace",
             // QWERTY rows
             "tab","q","w","e","r","t","y","u","i","o","p","lbrace","rbrace","bslash",
-            "caps","a","s","d","f","g","h","j","k","l","semi","quote","enter",
+            "caps","a","s","d","f","g","h","j","k","l","colon","quote","enter",
             "lshift","z","x","c","v","b","n","m","comma","dot","slash","rshift",
             // Bottom row
             "lctrl","lwin","lalt","space","ralt","rwin","rmenu","rctrl",
-            // Numpad
-            "numlock","kp_slash","kp_asterisk","kp_minus",
-            "kp7","kp8","kp9","kp_plus",
-            "kp4","kp5","kp6",
-            "kp1","kp2","kp3",
-            "kp0","kp_dot","kp_enter",
+            // Numpad (names from src/daemon/keymap.c)
+            "numlock","numslash","numstar","numminus","numplus","numenter",
+            "num7","num8","num9",
+            "num4","num5","num6",
+            "num1","num2","num3",
+            "num0","numdot",
             // Media / G-keys (present on K95 and similar)
             "mute","volup","voldn","stop","prev","play","next",
             "g1","g2","g3","g4","g5","g6","g7","g8","g9","g10",

--- a/src/gui/kbbind.cpp
+++ b/src/gui/kbbind.cpp
@@ -12,7 +12,7 @@ qint64 KbBind::globalRemapTime = 0;
 
 KbBind::KbBind(KbMode* modeParent, Kb* parentBoard, const KeyMap& keyMap) :
     QObject(modeParent), _devParent(parentBoard), lastGlobalRemapTime(globalRemapTime), _map(keyMap),
-    _winLock(false), _needsUpdate(true), _needsSave(true) {
+    _winLock(false), _catsLockMode(false), _catsLockActive(false), _needsUpdate(true), _needsSave(true) {
 }
 
 ///
@@ -24,7 +24,7 @@ KbBind::KbBind(KbMode* modeParent, Kb* parentBoard, const KeyMap& keyMap) :
 ///
 KbBind::KbBind(KbMode* modeParent, Kb* parentBoard, const KeyMap& keyMap, const KbBind& other) :
     QObject(modeParent), _devParent(parentBoard), lastGlobalRemapTime(globalRemapTime), _bind(other._bind),
-    _winLock(false), _needsUpdate(true), _needsSave(true) {
+    _winLock(false), _catsLockMode(false), _catsLockActive(false), _needsUpdate(true), _needsSave(true) {
     map(keyMap);
 
     /// Create a new Hash table and copy all entries
@@ -75,6 +75,8 @@ void KbBind::load(CkbSettingsBase& settings){
         }
     }
     _winLock = settings.value("WinLock").toBool();
+    _catsLockMode = settings.value("CatsLockMode").toBool();
+    // _catsLockActive intentionally NOT loaded — always starts unlocked on profile load.
     emit didLoad();
     map(currentMap);
 }
@@ -95,6 +97,7 @@ void KbBind::save(CkbSettingsBase& settings){
         }
     }
     settings.setValue("WinLock", _winLock);
+    settings.setValue("CatsLockMode", _catsLockMode);
 }
 
 QString KbBind::globalRemap(const QString& key){
@@ -263,6 +266,45 @@ void KbBind::update(QFile& cmd, int notify, bool force){
     if(_winLock)
         cmd.write(" unbind lwin rwin");
 
+    // Cats Lock: when active, silence every key except the WinLock key itself.
+    // Written after the normal binding loop so these override any custom binds.
+    if(_catsLockMode && _catsLockActive) {
+        static const char* const silenced[] = {
+            // Function row
+            "esc","f1","f2","f3","f4","f5","f6","f7","f8","f9","f10","f11","f12",
+            // System cluster
+            "prtscn","scroll","pause",
+            // Navigation cluster
+            "ins","home","pgup","del","end","pgdn",
+            "up","down","left","right",
+            // Number row
+            "grave","1","2","3","4","5","6","7","8","9","0","minus","equal","bspace",
+            // QWERTY rows
+            "tab","q","w","e","r","t","y","u","i","o","p","lbrace","rbrace","bslash",
+            "caps","a","s","d","f","g","h","j","k","l","semi","quote","enter",
+            "lshift","z","x","c","v","b","n","m","comma","dot","slash","rshift",
+            // Bottom row
+            "lctrl","lwin","lalt","space","ralt","rwin","rmenu","rctrl",
+            // Numpad
+            "numlock","kp_slash","kp_asterisk","kp_minus",
+            "kp7","kp8","kp9","kp_plus",
+            "kp4","kp5","kp6",
+            "kp1","kp2","kp3",
+            "kp0","kp_dot","kp_enter",
+            // Media / G-keys (present on K95 and similar)
+            "mute","volup","voldn","stop","prev","play","next",
+            "g1","g2","g3","g4","g5","g6","g7","g8","g9","g10",
+            "g11","g12","g13","g14","g15","g16","g17","g18",
+            // ISO extra key, light key, mode keys
+            "bslash_iso","light","m1","m2","m3","mr",
+            nullptr
+        };
+        for(const char* const* k = silenced; *k; ++k) {
+            cmd.write(" unbind ");
+            cmd.write(*k);
+        }
+    }
+
     // At last, send Macro definitions if available.
     // If no definitions are made, clear macro will be sent only to reset all macros,
     cmd.write(macros.toLatin1());
@@ -305,8 +347,39 @@ void KbBind::handleNotificationChannel(bool start) {
 }
 
 void KbBind::keyEvent(const QString& key, bool down){
+    // Cats Lock: intercept the WinLock key to toggle the lock state.
+    // We handle it here (not via KeyAction) so the lock key is never truly
+    // unbound — it always does something, and no changes to keyaction.cpp are needed.
+    if(_catsLockMode && key == "lock") {
+        if(down)
+            setCatsLockActive(!_catsLockActive);
+        return; // consume the event; don't pass to the normal action system
+    }
+
     QString rKey = globalRemap(key);
     KeyAction* act = bindAction(rKey);
     if(act)
         act->keyEvent(this, down);
+}
+
+void KbBind::setCatsLockMode(bool enable) {
+    if(_catsLockMode == enable)
+        return;
+    _catsLockMode = enable;
+    if(!enable && _catsLockActive) {
+        // Disabling the mode while locked: silently unlock first so the next
+        // update() call restores full bindings.
+        _catsLockActive = false;
+        emit catsLockActiveChanged(false);
+    }
+    _needsUpdate = true;
+    _needsSave   = true;
+}
+
+void KbBind::setCatsLockActive(bool active) {
+    if(_catsLockActive == active)
+        return;
+    _catsLockActive = active;
+    _needsUpdate    = true;
+    emit catsLockActiveChanged(active);
 }

--- a/src/gui/kbbind.h
+++ b/src/gui/kbbind.h
@@ -79,6 +79,15 @@ public:
     inline bool winLock()                   { return _winLock; }
     void        winLock(bool newWinLock)    { _winLock = newWinLock; _needsUpdate = true; }
 
+    // Cats Lock: when mode is enabled the WinLock (lock) key toggles a full
+    // keyboard lockdown — every key is silenced except the lock key itself,
+    // so only the user (not the cat) can unlock it from the GUI.
+    // _catsLockMode is persisted per profile; _catsLockActive is runtime-only.
+    inline bool catsLockMode()   const { return _catsLockMode; }
+    inline bool catsLockActive() const { return _catsLockActive; }
+    void        setCatsLockMode(bool enable);
+    void        setCatsLockActive(bool active);
+
     // Updates bindings to the driver. Write "mode %d" first.
     // By default, nothing will be written unless bindings have changed. Use force = true or call setNeedsUpdate() to override.
     void        update(QFile& cmd, int notify, bool force = false);
@@ -109,6 +118,8 @@ signals:
     void didLoad();
     void layoutChanged();
     void updated();
+    // Fired whenever the keyboard flips between locked and unlocked at runtime.
+    void catsLockActiveChanged(bool active);
 
 private:
     Kb* _devParent;
@@ -132,6 +143,8 @@ private:
     QHash<QString, KeyAction*> _bind;
 
     bool _winLock;
+    bool _catsLockMode;   ///< persisted: is Cats Lock configured for this mode?
+    bool _catsLockActive; ///< runtime only: is the keyboard currently locked?
     bool _needsUpdate;
     bool _needsSave;
     friend class KeyAction;

--- a/src/gui/kbperf.cpp
+++ b/src/gui/kbperf.cpp
@@ -540,7 +540,8 @@ void KbPerf::applyIndicators(int modeIndex, const bool indicatorState[HW_I_COUNT
         }
     }
     if(iEnable[LOCK]){
-        if(bind()->winLock())
+        // Light the lock indicator when either WinLock or Cats Lock is active.
+        if(bind()->winLock() || bind()->catsLockActive())
             lightIndicator("lock", iColor[LOCK][0].rgba());
         else
             lightIndicator("lock", iColor[LOCK][1].rgba());

--- a/src/gui/kbwidget.cpp
+++ b/src/gui/kbwidget.cpp
@@ -230,7 +230,7 @@ void KbWidget::modeChanged(){
     // Update tabs
     ui->lightWidget->setLight(device->currentLight());
     ui->bindWidget->setBind(device->currentBind(), device->currentProfile());
-    ui->kPerfWidget->setPerf(device->currentPerf(), device->currentProfile());
+    ui->kPerfWidget->setPerf(device->currentPerf(), device->currentProfile(), device->currentBind());
     ui->mPerfWidget->setPerf(device->currentPerf(), device->currentProfile());
     // Update selection
     ui->modesList->setCurrentIndex(ui->modesList->model()->index(index, 0));

--- a/src/gui/kperfwidget.cpp
+++ b/src/gui/kperfwidget.cpp
@@ -10,7 +10,8 @@
 ///
 KPerfWidget::KPerfWidget(QWidget *parent) :
     QWidget(parent),
-    ui(new Ui::KPerfWidget)
+    ui(new Ui::KPerfWidget),
+    perf(nullptr), profile(nullptr), bind(nullptr)
 {
     ui->setupUi(this);
     // Set up indicators
@@ -135,9 +136,23 @@ void KPerfWidget::mode2Raw(HwMode mode, bool& sw_enable, i_hw& hw_enable){
     }
 }
 
-void KPerfWidget::setPerf(KbPerf* newPerf, KbProfile* newProfile){
+void KPerfWidget::setPerf(KbPerf* newPerf, KbProfile* newProfile, KbBind* newBind){
     perf = newPerf;
     profile = newProfile;
+    bind = newBind;
+
+    // Cats Lock: sync checkbox and connect the runtime-active signal.
+    // Disconnect first to avoid duplicate connections on mode switch.
+    disconnect(bind, &KbBind::catsLockActiveChanged,
+               this, &KPerfWidget::on_catsLockActiveChanged);
+    // Block signals while syncing checkbox state so we don't call setCatsLockMode
+    // back on a bind that already has the correct value.
+    ui->catsLockBox->blockSignals(true);
+    ui->catsLockBox->setChecked(bind->catsLockMode());
+    ui->catsLockBox->blockSignals(false);
+    on_catsLockActiveChanged(bind->catsLockActive()); // update label immediately
+    connect(bind, &KbBind::catsLockActiveChanged,
+            this, &KPerfWidget::on_catsLockActiveChanged);
     // Set intensity
     ui->intensityBox->setValue(std::round(perf->iOpacity() * 100.f));
     // Set hardware indicator values
@@ -230,6 +245,19 @@ void KPerfWidget::on_intensityBox_valueChanged(int arg1){
     if(!perf)
         return;
     perf->iOpacity(arg1 / 100.f);
+}
+
+void KPerfWidget::on_catsLockBox_toggled(bool checked){
+    if(!bind)
+        return;
+    bind->setCatsLockMode(checked);
+}
+
+void KPerfWidget::on_catsLockActiveChanged(bool active){
+    // Update the checkbox label so the current lock state is always visible.
+    ui->catsLockBox->setText(active
+        ? tr("Cats Lock: keyboard is LOCKED (press WinLock to unlock)")
+        : tr("Cats Lock: WinLock key locks all other keys"));
 }
 
 void KPerfWidget::on_copyButton_clicked(){

--- a/src/gui/kperfwidget.h
+++ b/src/gui/kperfwidget.h
@@ -6,6 +6,7 @@
 #include <QComboBox>
 #include "kbperf.h"
 #include "kbprofile.h"
+#include "kbbind.h"
 #include "colorbutton.h"
 
 namespace Ui {
@@ -20,7 +21,7 @@ public:
     explicit KPerfWidget(QWidget *parent = nullptr);
     ~KPerfWidget();
 
-    void setPerf(KbPerf* newPerf, KbProfile* newProfile);
+    void setPerf(KbPerf* newPerf, KbProfile* newProfile, KbBind* newBind);
 
     static const int I_COUNT = KbPerf::I_COUNT;
     static const int HW_I_COUNT = KbPerf::HW_I_COUNT;
@@ -32,6 +33,7 @@ private:
 
     KbPerf* perf;
     KbProfile* profile;
+    KbBind* bind;
 
     // Hardware indicator dropdowns
     enum HwMode {
@@ -62,6 +64,8 @@ private slots:
     void uiUpdated(int index);
     void on_intensityBox_valueChanged(int arg1);
     void on_copyButton_clicked();
+    void on_catsLockBox_toggled(bool checked);
+    void on_catsLockActiveChanged(bool active);
 };
 
 #endif // KPERFWIDGET_H

--- a/src/gui/kperfwidget.ui
+++ b/src/gui/kperfwidget.ui
@@ -430,7 +430,19 @@
      </property>
     </widget>
    </item>
-   <item row="33" column="1">
+   <item row="33" column="1" colspan="11">
+    <widget class="QCheckBox" name="catsLockBox">
+     <property name="text">
+      <string>Cats Lock: WinLock key locks all other keys</string>
+     </property>
+     <property name="toolTip">
+      <string>When enabled, pressing the WinLock key silences every other key.
+Press WinLock again to unlock. Useful for stopping cats and other
+small animals from typing. Uncheck this box to disable the feature.</string>
+     </property>
+    </widget>
+   </item>
+   <item row="34" column="1">
     <spacer name="verticalSpacer">
      <property name="orientation">
       <enum>Qt::Vertical</enum>
@@ -1124,6 +1136,7 @@
   <tabstop>scrollBox</tabstop>
   <tabstop>scrollColorOn</tabstop>
   <tabstop>scrollColorOff</tabstop>
+  <tabstop>catsLockBox</tabstop>
  </tabstops>
  <resources/>
  <connections/>


### PR DESCRIPTION
When enabled in the Performance tab, the WinLock (lock) key toggles a full keyboard lockdown: every key except WinLock itself is silenced at the daemon level. Press WinLock again to unlock. The lock state is runtime-only (not persisted); the mode toggle is saved per profile.

Changes:
- kbbind.h/cpp: _catsLockMode (persisted), _catsLockActive (runtime), setCatsLockMode/setCatsLockActive, catsLockActiveChanged signal, mass-unbind in update(), keyEvent interception for lock key
- kbperf.cpp: lock LED lights for catsLockActive() as well as winLock()
- kperfwidget.h/cpp/ui: catsLockBox checkbox, setPerf() takes KbBind*, label updates to reflect live locked/unlocked state
- kbwidget.cpp: pass currentBind() to kPerfWidget->setPerf()