### PR TITLE
Remove references to matrix chats in issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,8 +1,5 @@
 blank_issues_enabled: false
 contact_links:
-  - name: Matrix
-    url: https://matrix.to/#/#ckb-next:matrix.org
-    about: "Ask for support in the #ckb-next room."
   - name: IRC
     url: https://web.libera.chat/?channels=#ckb-next
     about: "Ask for support in #ckb-next at web.libera.chat."

--- a/.github/ISSUE_TEMPLATE/help-request.yml
+++ b/.github/ISSUE_TEMPLATE/help-request.yml
@@ -7,7 +7,6 @@ body:
       value: |
         ## Please try these Resources first!
         * IRC chat: #ckb-next channel at [irc.libera.chat](https://web.libera.chat/?channels=#ckb-next)
-        * [Matrix](https://matrix.to/#/#ckb-next:matrix.org): #ckb-next:matrix.org
   - type: textarea
     id: question-body
     attributes:


### PR DESCRIPTION
Forgotten in 2ed8dd12

Currently there is no Matrix chat available for ckb-next. Once we decide to put in the effort to get it working again, we can revert this change.

Tagging @Ravenslofty as requested.