### PR TITLE
Add support for CORSAIR K70 RGB PRO Mechanical Gaming Keyboard (1bc4)

### DIFF
--- a/src/daemon/device_bragi.c
+++ b/src/daemon/device_bragi.c
@@ -83,9 +83,14 @@ static int setactive_bragi(usbdevice* kb, int active){
     uchar res = BRAGI_RES_LIGHTING;
     if(IS_MONOCHROME_DEV(kb))
         res = BRAGI_RES_LIGHTING_MONOCHROME;
+    else if(kb->product == P_K70_PRO_MECH)
+        res = BRAGI_RES_ALT_LIGHTING;
     int light = bragi_open_handle(kb, BRAGI_LIGHTING_HANDLE, res);
     if(light < 0)
         return light;
+
+    if(kb->product == P_K70_PRO_MECH && !light)
+        kb->vtable.updatergb = updatergb_keyboard_bragi_alt;
 
     // Check if the device returned an error
     // Non fatal for now. Should first figure out what the error codes mean.

--- a/src/daemon/keymap_patch.c
+++ b/src/daemon/keymap_patch.c
@@ -158,6 +158,7 @@ static const keypatches mappatches[] = {
     ADD_PATCH(V_CORSAIR, P_K70_TKL_CHAMP_OPTIC, k70tklpatch),
     ADD_PATCH(V_CORSAIR, P_K70_PRO,       k70propatch),
     ADD_PATCH(V_CORSAIR, P_K70_PRO_OPTIC, k70propatch),
+    ADD_PATCH(V_CORSAIR, P_K70_PRO_MECH, k70propatch),
     ADD_PATCH(V_CORSAIR, P_K70_CORE_RGB, k70corergbpatch),
     ADD_PATCH(V_CORSAIR, P_K70_CORE_RGB_2, k70corergbpatch),
     ADD_PATCH(V_CORSAIR, P_K70_CORE_RGB_3, k70corergbpatch),

--- a/src/daemon/led_bragi.c
+++ b/src/daemon/led_bragi.c
@@ -50,6 +50,7 @@ static inline size_t bragi_led_count(usbdevice* kb){
     LED_CASE_K(P_MM700, 3);
     LED_CASE_K(P_K70_PRO, 193);
     LED_CASE_K(P_K70_PRO_OPTIC, 193);
+    LED_CASE_K(P_K70_PRO_MECH, 142);
     LED_CASE_K(P_K70_CORE_RGB, 123);
     LED_CASE_K(P_K70_CORE_RGB_2, 123);
     LED_CASE_K(P_K70_CORE_RGB_3, 123);

--- a/src/daemon/usb.c
+++ b/src/daemon/usb.c
@@ -79,6 +79,7 @@ const device_desc models[] = {
     { V_CORSAIR, P_K70_TKL_CHAMP_OPTIC, },
     { V_CORSAIR, P_K70_PRO, },
     { V_CORSAIR, P_K70_PRO_OPTIC, },
+    { V_CORSAIR, P_K70_PRO_MECH, },
     { V_CORSAIR, P_K70_CORE_RGB, },
     { V_CORSAIR, P_K70_CORE_RGB_2, },
     { V_CORSAIR, P_K70_CORE_RGB_3, },
@@ -214,7 +215,7 @@ const char* product_str(ushort product){
         return "k70mk2";
     if(product == P_K70_TKL || product == P_K70_TKL_CHAMP_OPTIC)
         return "k70tkl";
-    if(product == P_K70_PRO || product == P_K70_PRO_OPTIC)
+    if(product == P_K70_PRO || product == P_K70_PRO_OPTIC || product == P_K70_PRO_MECH)
         return "k70pro";
     if(product == P_K70_CORE_RGB || product == P_K70_CORE_RGB_2 || product == P_K70_CORE_RGB_3)
         return "k70_core_rgb";

--- a/src/daemon/usb.h
+++ b/src/daemon/usb.h
@@ -93,10 +93,11 @@
 #define P_K70_TKL_CHAMP_OPTIC 0x1bb9
 #define P_K70_PRO            0x1bb3
 #define P_K70_PRO_OPTIC      0x1bd4
+#define P_K70_PRO_MECH       0x1bc4
 #define P_K70_CORE_RGB       0x2b0a
 #define P_K70_CORE_RGB_2     0x1bff
 #define P_K70_CORE_RGB_3     0x1bfd
-#define IS_K70(kb)           ((kb)->vendor == V_CORSAIR && ((kb)->product == P_K70 || (kb)->product == P_K70_LEGACY || (kb)->product == P_K70_RFIRE || (kb)->product == P_K70_RFIRE_NRGB || (kb)->product == P_K70_LUX || (kb)->product == P_K70_LUX_NRGB || (kb)->product == P_K70_MK2 || (kb)->product == P_K70_MK2SE || (kb)->product == P_K70_MK2LP || (kb)->product == P_K70_TKL || (kb)->product == P_K70_PRO || (kb)->product == P_K70_PRO_OPTIC || (kb)->product == P_K70_TKL_CHAMP_OPTIC) || IS_K70CORERGB(kb))
+#define IS_K70(kb)           ((kb)->vendor == V_CORSAIR && ((kb)->product == P_K70 || (kb)->product == P_K70_LEGACY || (kb)->product == P_K70_RFIRE || (kb)->product == P_K70_RFIRE_NRGB || (kb)->product == P_K70_LUX || (kb)->product == P_K70_LUX_NRGB || (kb)->product == P_K70_MK2 || (kb)->product == P_K70_MK2SE || (kb)->product == P_K70_MK2LP || (kb)->product == P_K70_TKL || (kb)->product == P_K70_PRO || (kb)->product == P_K70_PRO_OPTIC || (kb)->product == P_K70_PRO_MECH || (kb)->product == P_K70_TKL_CHAMP_OPTIC) || IS_K70CORERGB(kb))
 #define IS_K70CORERGB(kb)    ((kb)->vendor == V_CORSAIR && ((kb)->product == P_K70_CORE_RGB || (kb)->product == P_K70_CORE_RGB_2 || (kb)->product == P_K70_CORE_RGB_3))
 
 // The Legacy K90 behaves like a Legacy K95.
@@ -307,13 +308,13 @@ const char* product_str(ushort product);
         clock_nanosleep(CLOCK_MONOTONIC, 0, &(struct timespec) {.tv_nsec = 30000000}, NULL)
 
 // This should be removed in the future when we implement autodetection
-#define USES_BRAGI(vendor, product)                  (((vendor) == (V_CORSAIR)) && ((product) == (P_M55_RGB_PRO) || (product) == (P_IRONCLAW_W_U) || (product) == (P_IRONCLAW_W_D) || (product) == (P_K95_PLATINUM_XT) || (product) == (P_DARK_CORE_RGB_PRO_SE) || (product) == (P_DARK_CORE_RGB_PRO_SE_WL) || (product) == P_HARPOON_WL_U || (product) == P_HARPOON_WL_D || (product) == P_K57_U || (product) == P_K57_D || (product) == P_KATAR_PRO_XT || (product) == P_KATAR_PRO || (product) == P_K60_PRO_RGB || (product) == P_K60_PRO_RGB_LP || (product) == P_K60_PRO_RGB_SE || (product) == P_K60_PRO_MONO || (product) == P_K60_PRO_TKL || (product) == P_K55_PRO || (product) == P_K55_PRO_XT || (product) == (P_DARK_CORE_RGB_PRO) || (product) == (P_DARK_CORE_RGB_PRO_WL) || (product) == P_GENERIC_BRAGI_DONGLE || (product) == P_K100_OPTICAL || (product) == P_K100_MECHANICAL || (product) == P_K100_OPTICAL_VARIANT || (product) == P_K65_MINI || (product) == P_K70_TKL || (product) == P_K70_TKL_CHAMP_OPTIC || (product) == P_MM700 || (product) == P_K70_PRO || (product) == P_K70_PRO_OPTIC || (product) == P_K70_CORE_RGB || (product) == P_K70_CORE_RGB_2 || (product) == P_K70_CORE_RGB_3 || (product) == P_SCIMITAR_ELITE_BRAGI))
+#define USES_BRAGI(vendor, product)                  (((vendor) == (V_CORSAIR)) && ((product) == (P_M55_RGB_PRO) || (product) == (P_IRONCLAW_W_U) || (product) == (P_IRONCLAW_W_D) || (product) == (P_K95_PLATINUM_XT) || (product) == (P_DARK_CORE_RGB_PRO_SE) || (product) == (P_DARK_CORE_RGB_PRO_SE_WL) || (product) == P_HARPOON_WL_U || (product) == P_HARPOON_WL_D || (product) == P_K57_U || (product) == P_K57_D || (product) == P_KATAR_PRO_XT || (product) == P_KATAR_PRO || (product) == P_K60_PRO_RGB || (product) == P_K60_PRO_RGB_LP || (product) == P_K60_PRO_RGB_SE || (product) == P_K60_PRO_MONO || (product) == P_K60_PRO_TKL || (product) == P_K55_PRO || (product) == P_K55_PRO_XT || (product) == (P_DARK_CORE_RGB_PRO) || (product) == (P_DARK_CORE_RGB_PRO_WL) || (product) == P_GENERIC_BRAGI_DONGLE || (product) == P_K100_OPTICAL || (product) == P_K100_MECHANICAL || (product) == P_K100_OPTICAL_VARIANT || (product) == P_K65_MINI || (product) == P_K70_TKL || (product) == P_K70_TKL_CHAMP_OPTIC || (product) == P_MM700 || (product) == P_K70_PRO || (product) == P_K70_PRO_OPTIC || (product) == P_K70_PRO_MECH || (product) == P_K70_CORE_RGB || (product) == P_K70_CORE_RGB_2 || (product) == P_K70_CORE_RGB_3 || (product) == P_SCIMITAR_ELITE_BRAGI))
 
 // Devices that use bragi jumbo packets (1024 bytes)
 #define USES_BRAGI_JUMBO(vendor, product)           ((vendor) == (V_CORSAIR) && ((product) == P_K100_OPTICAL || (product) == P_K100_MECHANICAL || (product) == P_K100_OPTICAL_VARIANT || (product) == P_K65_MINI || (product) == P_K70_TKL || (product) == P_K70_TKL_CHAMP_OPTIC || (product) == P_K70_PRO || (product) == P_K70_PRO_OPTIC))
 
 // Devices that use large bragi packets (128 bytes)
-#define USES_BRAGI_LARGE(vendor, product)           ((vendor) == (V_CORSAIR) && ((product) == P_SCIMITAR_ELITE_BRAGI))
+#define USES_BRAGI_LARGE(vendor, product)           ((vendor) == (V_CORSAIR) && ((product) == P_SCIMITAR_ELITE_BRAGI || (product) == P_K70_PRO_MECH))
 
 // Used for devices that have the scroll wheel packet in the hardware hid packet only
 #define SW_PKT_HAS_NO_WHEEL(kb)                     ((kb)->vendor == V_CORSAIR && ((kb)->product == P_M55_RGB_PRO || (kb)->product == P_KATAR_PRO_XT || (kb)->product == P_KATAR_PRO || (kb)->product == P_SCIMITAR_ELITE_BRAGI))


### PR DESCRIPTION
Resolves #1062.

Unlike the K70 PRO (0x1bb3) which uses jumbo packets and 193 LED zones, this variant uses 128-byte large packets and 142 LED zones.

The changes in `device_bragi.c` are not strictly necessary: The existing fallback path (try 0x01, fail, retry with 0x22) would handle it.  I explicitly set the resource and updatergb function to avoid a needless error and retry cycle on every connect.

Tested with full RGB control and per-key mapping.