### PR TITLE
daemon: provide modifiable repeat delay (i.e. rapid fire)

### DIFF
--- a/src/daemon/input.c
+++ b/src/daemon/input.c
@@ -82,10 +82,6 @@ static pthread_t macro_pt_first() {
 
 // Default macro keystroke delay
 const struct timespec macrodelay = { .tv_nsec = 1000000 };
-// Initial repeat delay
-#define DELAY_REPEAT_INITIAL 500000000
-// Delay for every subsequent repeat
-#define DELAY_REPEAT_CATCHUP 500000000
 
 static inline void clock_microsleep(uint32_t s) {
     const struct timespec ts = {
@@ -172,7 +168,7 @@ static void* play_macro(void* param) {
 
         queued_mutex_unlock(mmutex(kb));
 
-        int delay_ns = first_keydownloop ? DELAY_REPEAT_INITIAL : DELAY_REPEAT_CATCHUP;
+        int delay_us = first_keydownloop ? macro->delay_repeat_initial : macro->delay_repeat;
 
         queued_mutex_lock(imutex(kb));
         // detect if the macro playback has been aborted
@@ -184,19 +180,19 @@ static void* play_macro(void* param) {
 
         if (macro->triggered > 1) {
             macro->triggered -= 2;
-            delay_ns = 0;
+            delay_us = 0;
             first_keydownloop = 1;
         }
 
         if (macro->triggered == 0)
             break;
 
-        if (!delay_ns) {
+        if (!delay_us) {
             queued_mutex_unlock(imutex(kb));
             continue;
         }
 
-        queued_cond_nanosleep(mintvar(kb), imutex(kb), delay_ns);
+        queued_cond_nanosleep(mintvar(kb), imutex(kb), delay_us*1000);
 
         if (macro->triggered == 2) {
             // the key was released, but not pressed again, during the sleep
@@ -204,7 +200,7 @@ static void* play_macro(void* param) {
             break;
         }
 
-        // if the key released and pressed during the sleep, reset to use DELAY_REPEAT_INITIAL
+        // if the key released and pressed during the sleep, reset to use delay_repeat_initial
         if (macro->triggered == 1)
             first_keydownloop = 0;
 
@@ -665,9 +661,24 @@ static void _cmd_macro(usbmode* mode, const char* keys, const char* assignment, 
     // Allocate a buffer for them
     macro.actions = calloc(count, sizeof(macroaction));
     macro.actioncount = 0;
-    // Scan the actions
+    // set repeat delay
     position = 0;
     field = 0;
+    if (assignment[position] == '=') {
+        position++;
+        sscanf(assignment + position, "%u%n", &(macro.delay_repeat_initial), &field);
+        if ((field == 0) || (assignment[position += field] != ';'))
+            return;
+        position++;
+        sscanf(assignment + position, "%u%n", &(macro.delay_repeat), &field);
+        if ((field == 0) || (assignment[position += field] != ';'))
+            return;
+        position++;
+    } else {
+        macro.delay_repeat_initial = 500000;
+        macro.delay_repeat = 500000;
+    }
+    // Scan the actions
     // max action = old 11 chars plus 12 chars which is the max 32-bit unsigned int 4294967295 size * 2 + 1 for range underscore
     while(position < right && sscanf(assignment + position, "%36[^,]%n", keyname, &field) == 1){
         if(!strcmp(keyname, "clear"))

--- a/src/daemon/structures.h
+++ b/src/daemon/structures.h
@@ -56,6 +56,10 @@ typedef struct {
      * thread shuts itself down immediately.
      */
     char triggered;
+
+    uint32_t delay_repeat_initial;  // us dey before the first repeaet
+    uint32_t delay_repeat;          // us delay before subsequent repeat
+
     struct _macro_param* param;
 } keymacro;
 


### PR DESCRIPTION
src/daemon/input.c has DELAY_REPEAT_* which capture the rate at which a macro will repeat if its triggering key is pressed.  That code allows for a different initial, and followup rate, but has hardcoded both for 0.5 seconds.

Separately, some games benefit from "rapid fire" macro actions.  Make this repeat rate adjustable by:

1. Remove the hardcoded 0.5 (expressed in ns) as a variable holding a us delay (microsecond).
2. In _cmd_macro, extend the "macro" command to look for a leading `"=%u;%u;"` in the assignment.  Process the first unsigned integer as the initial repeat delay, and the second as the subsequent repeat delay.

I'm VERY new to any kind of c string parsing, so I apologize if this is bad.  In particular, after writing this, I'm thinking that maybe I should have just done

```c
sscanf(assignment + position, "=%u;%u;%n", &(macro.delay_repeat_initial), &(macro.delay_repeat), &field);
```

However, the patch (as posted, rebased on 0.6.2 in Debian) builds and superficially does what I was hoping for.

I did not try to extend the GUI (I don't use it).  First thing would be to make sure the daemon feature is acceptable/works.  Maybe follow-on work can expose it in the GUI?

P.S. I'm actually somewhat surprised no one added this already, given the path was basically charted out (and I myself worked on it, too!).