### PR TITLE
CKB-1322: Fix UI crash on macro delay content being unavailable

### DIFF
--- a/src/gui/kbbind.cpp
+++ b/src/gui/kbbind.cpp
@@ -245,11 +245,11 @@ void KbBind::update(QFile& cmd, int notify, bool force){
 #else // QT_VERSION < 6.0.0
                 QVector<QStringRef> macroContent = act->value().splitRef(':');
 #endif
-                if (macroContent[1].length() > 0)
-                    // Fields used: 1 - daemon string, 5 - repetition delay
-                    macros.append("macro " + keyLatin1
-                            + ":" + macroContent[1].toLatin1()
-                            + ":" + macroContent[5].toLatin1());
+                // Fields used: 1 - daemon string, 5 - repetition delay
+                if (macroContent.at(1).length() > 0)
+                    macros.append("macro " + keyLatin1 + ":" + macroContent.at(1).toLatin1());
+                if (macroContent.length() > 5 && macroContent.at(5).length() > 0)
+                    macros.append(":" + macroContent.at(5).toLatin1());
             }
         } else {
             // Otherwise, write the binding

--- a/src/gui/rebindwidget.ui
+++ b/src/gui/rebindwidget.ui
@@ -1407,6 +1407,9 @@
              <property name="suffix">
               <string>ms</string>
              </property>
+             <property name="minimum">
+              <number>1</number>
+             </property>
              <property name="maximum">
               <number>2000</number>
              </property>


### PR DESCRIPTION
The situation:
- The macro repetition delay PR added a commit, that passes the macro's 5th field to the string it sends to the daemon,
- macros defined prior to that commit only had 4 fields,
- the `QList<QStringView>::operator[]` would run into an assertion, where the given index was smaller than the available list size.

This PR:
- Fixes this by checking the length of the macro data first, and only appends the data if it's available.
- Adds a field validator to the UI, to have a minimum of 1ms delay between macro invocations. A value of 0ms will be disregarded by the daemon and reset to the default (currently 500ms).

Should fix #1322