### PR TITLE
Fix Ironclaw RGB Wireless bindings

### DIFF
--- a/src/daemon/keymap_patch.c
+++ b/src/daemon/keymap_patch.c
@@ -28,6 +28,9 @@ static const keypatch m95patch[] = {
 };
 
 static const keypatch icwpatch[] = {
+    { 232, "optbtn",              -1, KEY_CORSAIR },
+    { 233, "profup",              -1, KEY_CORSAIR },
+    { 234, "profdn",              -1, KEY_CORSAIR },
     { 237+20, "back",  LED_MOUSE,     KEY_NONE },
     { 238+20, "wheel", LED_MOUSE + 1, KEY_NONE },
     { 239+20, "front", LED_MOUSE + 2, KEY_NONE },

--- a/src/gui/keyaction.cpp
+++ b/src/gui/keyaction.cpp
@@ -73,7 +73,7 @@ QString KeyAction::defaultAction(const QString& key, KeyMap::Model model){
         return "$lock:0";
     // DPI buttons
     if(key == "dpiup"){
-        if(model == KeyMap::M55 || model == KeyMap::HARPOON || model == KeyMap::GLAIVE || model == KeyMap::IRONCLAW)
+        if(model == KeyMap::M55 || model == KeyMap::HARPOON || model == KeyMap::GLAIVE || model == KeyMap::IRONCLAW || model == KeyMap::IRONCLAW_W)
             return "$dpi:-4";
         return "$dpi:-2";
     }
@@ -81,7 +81,11 @@ QString KeyAction::defaultAction(const QString& key, KeyMap::Model model){
         return "$dpi:-1";
     if(key == "sniper")
         return "$dpi:0";
+    if(key == "optbtn")
+        return "$dpi:0";
     if(key == "profswitch")
+        return "$mode:-3";
+    if(key == "profup")
         return "$mode:-3";
     if(key == "profdn")
         return "$mode:-4";


### PR DESCRIPTION
This should fix non-working button bindings (Profile up, Profile down and Opt/Sniper) on Ironclaw RGB Wireless.

This was fixed using AI tools. Tested to work wirelessly (slipstream dongle) and with USB cable attached on Nobara OS 44.

Note: The device appears in the GUI as different device depending whether USB cable is attached or not, so you have to bind the buttons twice! This is probably true for lighting and other settings as well and is outside the scope of this PR.