### PR TITLE
#505 Implement K57 RGB Wireless

### DIFF
--- a/src/daemon/usb_bragi.c
+++ b/src/daemon/usb_bragi.c
@@ -26,8 +26,8 @@ void bragi_fill_input_eps(usbdevice* kb)
     if(kb->vendor == V_CORSAIR){
         switch(kb->product){
             case P_K57_D:
-                kb->bragi_out_ep = 0x2;
-                kb->bragi_in_ep = 0x82;
+                kb->input_endpoints[0] = 0x81; // Endpoint 1 (Keystrokes / Media)
+                kb->input_endpoints[1] = 0x84; // Endpoint 4 (Bragi Status Checks)
                 break;
             case P_K57_U:
             case P_K55_PRO:


### PR DESCRIPTION
This sets the correct endpoints for K57 RGB Wireless when using in dongle mode. AI tools were used.

Tested on Nobara OS 44. Media controls and G1-G6 buttons work as expected.

Very rarely (maybe once per week) wrong key codes are sent to the system. I don't have a fix for that. Could be something in the endpoint traffic that gets parsed wrong. As a workaround, turning the keyboard on and off fixes that. I feel like this is not a big problem since K57 is still in experimental mode. I will continue investigating this on my leisure.